### PR TITLE
compliance: compliance-server: Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*.log
+.env
+**/Dockerfile

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ debug = true
 opt-level = 3 # Full optimizations
 lto = true
 
+[http]
+check-revoke = false
+
 [workspace.dependencies]
 # === Renegade Dependencies === #
 arbitrum-client = { git = "https://github.com/renegade-fi/renegade.git", features = [

--- a/compliance/compliance-server/Cargo.toml
+++ b/compliance/compliance-server/Cargo.toml
@@ -16,7 +16,7 @@ diesel = { version = "2.2", features = ["postgres", "r2d2"] }
 renegade-util = { workspace = true }
 
 # === Misc === #
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "env"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/compliance/compliance-server/Dockerfile
+++ b/compliance/compliance-server/Dockerfile
@@ -1,0 +1,46 @@
+FROM --platform=arm64 rust:latest AS chef
+
+# Create a build dir and add local dependencies
+WORKDIR /build
+
+COPY ./rust-toolchain ./rust-toolchain
+RUN cat rust-toolchain | xargs rustup toolchain install
+
+# Install cargo-chef
+RUN cargo install cargo-chef
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json --bin compliance-server
+
+FROM chef AS builder
+COPY --from=planner /build/recipe.json recipe.json
+
+# Install protoc, openssl, and pkg-config
+RUN apt-get update && \
+    apt-get install -y pkg-config && \
+    apt-get install -y libssl-dev && \
+    apt-get install -y libclang-dev
+
+# Disable compiler warnings and enable backtraces for panic debugging
+ENV RUSTFLAGS=-Awarnings
+ENV RUST_BACKTRACE=1
+
+# Build only the dependencies to cache them in this layer
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Build the compliance server
+COPY . .
+RUN cargo build --release -p compliance-server
+
+# Release stage
+FROM --platform=arm64 debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y libssl-dev && \
+    apt-get install -y ca-certificates && \
+    apt-get install -y libpq-dev
+
+# Copy the binary from the build stage
+COPY --from=builder /build/target/release/compliance-server /bin/compliance-server
+CMD ["compliance-server"]

--- a/compliance/compliance-server/src/main.rs
+++ b/compliance/compliance-server/src/main.rs
@@ -37,13 +37,13 @@ type ConnectionPool = Arc<Pool<ConnectionManager<PgConnection>>>;
 #[command(about = "The CLI for the compliance server")]
 struct Cli {
     /// The port to listen on
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "3000")]
     port: u16,
     /// The Chainalysis API key
-    #[arg(long)]
+    #[arg(long, env = "CHAINALYSIS_API_KEY")]
     chainalysis_api_key: String,
     /// The url of the compliance database
-    #[arg(long)]
+    #[arg(long, env = "DATABASE_URL")]
     db_url: String,
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a `Dockerfile` for the compliance server to deploy it on an ECS cluster. As well, I added env variable fallbacks for the secrets used to configure the compliance server. We will configure these via secrets manager.

### Testing
- Built and ran the dockerfile and tested the compliance server