### PR TITLE
funds-manager: Use `diesel-async` and add `warp` endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,9 @@ renegade-circuit-types = { package = "circuit-types", git = "https://github.com/
 renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
 renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git" }
 
+# === Database Dependencies === #
+diesel = { version = "2.1" }
+diesel-async = { version = "0.4" }
+
 # === Misc Dependencies === #
 tracing = "0.1"

--- a/compliance/compliance-server/Cargo.toml
+++ b/compliance/compliance-server/Cargo.toml
@@ -10,7 +10,7 @@ warp = "0.3"
 compliance-api = { path = "../compliance-api" }
 
 # === Database === #
-diesel = { version = "2.2", features = ["postgres", "r2d2"] }
+diesel = { workspace = true, features = ["postgres", "r2d2"] }
 
 # === Renegade Dependencies === #
 renegade-util = { workspace = true }

--- a/funds-manager/Cargo.toml
+++ b/funds-manager/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fee-sweeper"
+name = "funds-manager"
 description = "Manages custody of funds for protocol operator"
 version = "0.1.0"
 edition = "2021"
@@ -11,10 +11,15 @@ http-body-util = "0.1.0"
 tokio = { version = "1.10", features = ["full"] }
 warp = "0.3"
 
+
 # === Infra === #
 aws-sdk-secretsmanager = "1.37"
 aws-config = "1.5"
-diesel = { version = "2.2", features = ["postgres", "numeric", "uuid"] }
+diesel = { workspace = true, features = ["postgres", "numeric", "uuid"] }
+diesel-async = { workspace = true, features = ["postgres"] }
+native-tls = "0.2"
+postgres-native-tls = "0.5"
+tokio-postgres = "0.7.7"
 
 # === Blockchain Interaction === #
 alloy-sol-types = "0.3.1"

--- a/funds-manager/src/db/mod.rs
+++ b/funds-manager/src/db/mod.rs
@@ -1,5 +1,37 @@
 //! Database code
 
+use diesel_async::AsyncPgConnection;
+use native_tls::TlsConnector;
+use postgres_native_tls::MakeTlsConnector;
+use renegade_util::err_str;
+use tracing::error;
+
+use crate::error::FundsManagerError;
+
 pub mod models;
 #[allow(missing_docs)]
 pub mod schema;
+
+/// Establish a connection to the database
+pub async fn establish_connection(db_url: &str) -> Result<AsyncPgConnection, FundsManagerError> {
+    // Build a TLS connector, we don't validate certificates for simplicity.
+    // Practically this is unnecessary because we will be limiting our traffic to
+    // within a siloed environment when deployed
+    let connector = TlsConnector::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .map_err(err_str!(FundsManagerError::Db))?;
+    let connector = MakeTlsConnector::new(connector);
+    let (client, conn) = tokio_postgres::connect(db_url, connector)
+        .await
+        .map_err(err_str!(FundsManagerError::Db))?;
+
+    // Spawn the connection handle in a separate task
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            error!("Connection error: {}", e);
+        }
+    });
+
+    AsyncPgConnection::try_from(client).await.map_err(err_str!(FundsManagerError::Db))
+}

--- a/funds-manager/src/error.rs
+++ b/funds-manager/src/error.rs
@@ -21,6 +21,7 @@ pub enum FundsManagerError {
     Custom(String),
 }
 
+#[allow(clippy::needless_pass_by_value)]
 impl FundsManagerError {
     /// Create an arbitrum error
     pub fn arbitrum<T: ToString>(msg: T) -> FundsManagerError {
@@ -67,3 +68,28 @@ impl Display for FundsManagerError {
 }
 impl Error for FundsManagerError {}
 impl Reject for FundsManagerError {}
+
+/// API-specific error type
+#[derive(Debug)]
+pub enum ApiError {
+    /// Error during fee indexing
+    IndexingError(String),
+    /// Error during fee redemption
+    RedemptionError(String),
+    /// Internal server error
+    InternalError(String),
+}
+
+impl Reject for ApiError {}
+
+impl Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiError::IndexingError(e) => write!(f, "Indexing error: {}", e),
+            ApiError::RedemptionError(e) => write!(f, "Redemption error: {}", e),
+            ApiError::InternalError(e) => write!(f, "Internal error: {}", e),
+        }
+    }
+}
+
+impl Error for ApiError {}

--- a/funds-manager/src/indexer/index_fees.rs
+++ b/funds-manager/src/indexer/index_fees.rs
@@ -26,7 +26,7 @@ use crate::Indexer;
 impl Indexer {
     /// Index all fees since the given block
     pub async fn index_fees(&mut self) -> Result<(), FundsManagerError> {
-        let block_number = self.get_latest_block()?;
+        let block_number = self.get_latest_block().await?;
         info!("indexing fees from block {block_number}");
 
         let filter = self
@@ -48,7 +48,7 @@ impl Indexer {
 
             if block > most_recent_block {
                 most_recent_block = block;
-                self.update_latest_block(most_recent_block)?;
+                self.update_latest_block(most_recent_block).await?;
             }
         }
 
@@ -86,7 +86,7 @@ impl Indexer {
 
         // Otherwise, index the note
         let fee = NewFee::new_from_note(&note, tx);
-        self.insert_fee(fee)
+        self.insert_fee(fee).await
     }
 
     /// Get a note from a transaction body


### PR DESCRIPTION
### Purpose
This PR refactors the `funds-manager` to use `diesel-async` which allows us to fit the funds manager endpoints into the `warp` interface. I expose two endpoints `index-fees` and `redeem-fees`.

### Todo
- Move the endpoints and request types into an API crate as in other extensions

### Testing
- Tested both endpoints