### PR TITLE
funds-manager: Use dummy key for arbitrum client

### DIFF
--- a/funds-manager/Dockerfile
+++ b/funds-manager/Dockerfile
@@ -51,4 +51,4 @@ RUN apt-get update && \
 COPY --from=builder /build/target/release/funds-manager /bin/funds-manager
 
 ENTRYPOINT ["/bin/funds-manager"]
-CMD ["--help"]
+CMD ["--datadog-logging"]

--- a/funds-manager/src/db/schema.rs
+++ b/funds-manager/src/db/schema.rs
@@ -27,4 +27,8 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(fees, indexing_metadata, wallets,);
+diesel::allow_tables_to_appear_in_same_query!(
+    fees,
+    indexing_metadata,
+    wallets,
+);


### PR DESCRIPTION
### Purpose
This PR updates the CLI in two ways:
1. Allows each config entry to be set by an environment variable. This will make it easier to deploy the `funds-manager` via terraform.
2. Removes the Arbitrum private key argument. We don't need a private key for any arbitrum client operations, so instead we use a dummy key -- the master key used in nitro dev nodes.

### Testing
- Ran the funds manager with the dummy key and environment variables