### PR TITLE
funds-manager: custody-client: Add withdrawal handler

### DIFF
--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -38,4 +38,6 @@ pub struct WithdrawFundsRequest {
     pub mint: String,
     /// The amount of funds to withdraw
     pub amount: u128,
+    /// The address to withdraw to
+    pub address: String,
 }

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -17,7 +17,7 @@ aws-sdk-secretsmanager = "1.37"
 aws-config = "1.5"
 diesel = { workspace = true, features = ["postgres", "numeric", "uuid"] }
 diesel-async = { workspace = true, features = ["postgres"] }
-fireblocks-sdk = "0.4"
+fireblocks-sdk = { git = "https://github.com/renegade-fi/fireblocks-sdk-rs" }
 native-tls = "0.2"
 postgres-native-tls = "0.5"
 tokio-postgres = "0.7.7"

--- a/funds-manager/funds-manager-server/src/custody_client/deposit.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/deposit.rs
@@ -1,81 +1,40 @@
 //! Deposit funds into the custody backend
 
-use fireblocks_sdk::{
-    types::{Account as FireblocksAccount, AccountAsset},
-    PagingVaultRequestBuilder,
-};
-use renegade_util::err_str;
-
 use crate::error::FundsManagerError;
 
-use super::{CustodyClient, DepositSource};
+use super::{CustodyClient, DepositWithdrawSource};
 
 impl CustodyClient {
     /// Get the deposit address for the given mint
     pub(crate) async fn get_deposit_address(
         &self,
         mint: &str,
-        source: DepositSource,
+        source: DepositWithdrawSource,
     ) -> Result<String, FundsManagerError> {
         // Find a vault account for the asset
         let symbol = self.get_erc20_token_symbol(mint).await?;
-        let deposit_vault =
-            self.get_vault_account(&source).await?.ok_or(FundsManagerError::fireblocks(
-                format!("no vault for deposit source: {}", source.get_vault_name()),
-            ))?;
+        let deposit_vault = self.get_vault_account(&source).await?.ok_or_else(|| {
+            FundsManagerError::fireblocks(format!(
+                "no vault for deposit source: {}",
+                source.get_vault_name()
+            ))
+        })?;
 
         // TODO: Create an account asset if one doesn't exist
-        let asset = self.get_wallet_for_ticker(&deposit_vault, &symbol).ok_or(
+        let asset = self.get_wallet_for_ticker(&deposit_vault, &symbol).ok_or_else(|| {
             FundsManagerError::fireblocks(format!(
                 "no wallet for deposit source: {}",
                 source.get_vault_name()
-            )),
-        )?;
+            ))
+        })?;
 
         // Fetch the wallet addresses for the asset
         let client = self.get_fireblocks_client()?;
         let (addresses, _rid) = client.addresses(deposit_vault.id, &asset.id).await?;
-        let addr = addresses.first().ok_or(FundsManagerError::fireblocks(format!(
-            "no addresses for asset: {}",
-            asset.id
-        )))?;
+        let addr = addresses.first().ok_or_else(|| {
+            FundsManagerError::fireblocks(format!("no addresses for asset: {}", asset.id))
+        })?;
 
         Ok(addr.address.clone())
-    }
-
-    /// Get the vault account for a given asset and source
-    async fn get_vault_account(
-        &self,
-        source: &DepositSource,
-    ) -> Result<Option<FireblocksAccount>, FundsManagerError> {
-        let client = self.get_fireblocks_client()?;
-        let req = PagingVaultRequestBuilder::new()
-            .limit(100)
-            .build()
-            .map_err(err_str!(FundsManagerError::Fireblocks))?;
-
-        let (vaults, _rid) = client.vaults(req).await?;
-        for vault in vaults.accounts.into_iter() {
-            if vault.name == source.get_vault_name() {
-                return Ok(Some(vault));
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Find the wallet in a vault account for a given symbol
-    fn get_wallet_for_ticker(
-        &self,
-        vault: &FireblocksAccount,
-        symbol: &str,
-    ) -> Option<AccountAsset> {
-        for acct in vault.assets.iter() {
-            if acct.id.starts_with(symbol) {
-                return Some(acct.clone());
-            }
-        }
-
-        None
     }
 }

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -1,0 +1,60 @@
+use crate::error::FundsManagerError;
+use bigdecimal::{BigDecimal, FromPrimitive};
+use fireblocks_sdk::types::TransactionStatus;
+
+use super::{CustodyClient, DepositWithdrawSource};
+
+impl CustodyClient {
+    /// Withdraw funds from custody
+    pub(crate) async fn withdraw(
+        &self,
+        source: DepositWithdrawSource,
+        token_address: &str,
+        amount: u128,
+        destination_address: String,
+    ) -> Result<(), FundsManagerError> {
+        let client = self.get_fireblocks_client()?;
+        let symbol = self.get_erc20_token_symbol(token_address).await?;
+
+        // Get the vault account and asset to transfer from
+        let vault = self
+            .get_vault_account(&source)
+            .await?
+            .ok_or_else(|| FundsManagerError::Custom("Vault not found".to_string()))?;
+
+        let asset = self.get_wallet_for_ticker(&vault, &symbol).ok_or_else(|| {
+            FundsManagerError::Custom(format!("Asset not found for symbol: {}", symbol))
+        })?;
+
+        // Check if the available balance is sufficient
+        let withdraw_amount = BigDecimal::from_u128(amount).expect("amount too large");
+        if asset.available < withdraw_amount {
+            return Err(FundsManagerError::Custom(format!(
+                "Insufficient balance. Available: {}, Requested: {}",
+                asset.available, withdraw_amount
+            )));
+        }
+
+        // Transfer
+        let vault_name = source.get_vault_name();
+        let note = format!("Withdraw {amount} {symbol} from {vault_name} to {destination_address}");
+
+        let (resp, _rid) = client
+            .create_transaction_external(
+                vault.id,
+                destination_address,
+                asset.id,
+                withdraw_amount,
+                Some(&note),
+            )
+            .await?;
+
+        let tx = self.poll_fireblocks_transaction(&resp.id).await?;
+        if tx.status != TransactionStatus::COMPLETED && tx.status != TransactionStatus::CONFIRMING {
+            let err_msg = format!("Transaction failed: {:?}", tx.status);
+            return Err(FundsManagerError::Custom(err_msg));
+        }
+
+        Ok(())
+    }
+}

--- a/funds-manager/funds-manager-server/src/error.rs
+++ b/funds-manager/funds-manager-server/src/error.rs
@@ -71,7 +71,7 @@ impl Display for FundsManagerError {
             FundsManagerError::Http(e) => write!(f, "HTTP error: {}", e),
             FundsManagerError::Parse(e) => write!(f, "Parse error: {}", e),
             FundsManagerError::SecretsManager(e) => write!(f, "Secrets manager error: {}", e),
-            FundsManagerError::Custom(e) => write!(f, "Custom error: {}", e),
+            FundsManagerError::Custom(e) => write!(f, "Uncategorized error: {}", e),
             FundsManagerError::Fireblocks(e) => write!(f, "Fireblocks error: {}", e),
         }
     }

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -22,7 +22,7 @@ use funds_manager_api::{
     WITHDRAW_CUSTODY_ROUTE,
 };
 use handlers::{
-    get_deposit_address_handler, index_fees_handler, redeem_fees_handler, withdraw_funds_handler,
+    get_deposit_address_handler, index_fees_handler, quoter_withdraw_handler, redeem_fees_handler,
 };
 use relayer_client::RelayerClient;
 use renegade_circuit_types::elgamal::DecryptionKey;
@@ -228,8 +228,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(warp::path("custody"))
         .and(warp::path("quoters"))
         .and(warp::path(WITHDRAW_CUSTODY_ROUTE))
+        .and(warp::body::json())
         .and(with_server(Arc::new(server.clone())))
-        .and_then(withdraw_funds_handler);
+        .and_then(quoter_withdraw_handler);
 
     let get_deposit_address = warp::get()
         .and(warp::path("custody"))


### PR DESCRIPTION
### Purpose
This PR adds an endpoint handler for the withdrawal path in the `funds-manager`'s custody client. This endpoint will find the correct vault and asset to withdraw from (borrowing code from the deposit flow) then initiate a withdrawal through Fireblocks.

### Todo
- Authentication for custody API

### Testing
- Deposited a few ERC20s into Fireblocks, withdrew into a personal wallet through the endpoint