### PR TITLE
funds-manager: middleware: Add symmetric key auth for withdrawal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ debug = true
 opt-level = 3 # Full optimizations
 lto = true
 
-[http]
-check-revoke = false
-
 [workspace.dependencies]
 # === Renegade Dependencies === #
 arbitrum-client = { git = "https://github.com/renegade-fi/renegade.git", features = [

--- a/bin/build_and_push.sh
+++ b/bin/build_and_push.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 REGION=${REGION:-us-east-2}
-ENVIRONMENT=testnet
 ECR_REGISTRY=377928551571.dkr.ecr.$REGION.amazonaws.com
 
 # Parse command line arguments
@@ -8,7 +7,6 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         --dockerfile) DOCKERFILE="$2"; shift ;;
         --ecr-repo) ECR_REPO="$2"; shift ;;
-        --environment) ENVIRONMENT="$2"; shift ;;
         --region) REGION="$2"; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac

--- a/funds-manager/Dockerfile
+++ b/funds-manager/Dockerfile
@@ -19,12 +19,18 @@ COPY ./funds-manager ./funds-manager
 # === Builder === #
 # Pull the sources into their own layer
 FROM chef AS builder
+
+# Disable compiler warnings and enable backtraces for panic debugging
+ENV RUSTFLAGS=-Awarnings
+ENV RUST_BACKTRACE=1
+ENV CARGO_HTTP_CHECK_REVOKE=false
+
 COPY --from=sources /build /build
 WORKDIR /build
 
 # Install protoc, openssl, and pkg-config
 RUN apt-get update && \
-    apt-get install -y pkg-config libssl-dev libclang-dev libpq-dev
+    apt-get install -y pkg-config libssl-dev libclang-dev libpq-dev ca-certificates
 
 # Update Cargo.toml to include only "funds-manager/funds-manager-server" in workspace members
 RUN sed -i '/members[[:space:]]*=[[:space:]]*\[/,/\]/c\members = ["funds-manager/funds-manager-server"]' Cargo.toml
@@ -32,10 +38,6 @@ RUN cargo chef prepare --recipe-path recipe.json --bin funds-manager
 
 # Build only the dependencies to cache them in this layer
 RUN cargo chef cook --release --recipe-path recipe.json
-
-# Disable compiler warnings and enable backtraces for panic debugging
-ENV RUSTFLAGS=-Awarnings
-ENV RUST_BACKTRACE=1
 
 COPY --from=sources /build/funds-manager /build/funds-manager
 WORKDIR /build

--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -32,7 +32,7 @@ pub struct DepositAddressResponse {
 }
 
 /// The request body for withdrawing funds from custody
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WithdrawFundsRequest {
     /// The mint of the asset to withdraw
     pub mint: String,

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -4,11 +4,20 @@ description = "Manages custody of funds for protocol operator"
 version = "0.1.0"
 edition = "2021"
 
+[net]
+git-fetch-with-cli = true
+
+[http]
+check-revoke = false
+
 [dependencies]
 # === CLI + Server === #
 clap = { version = "4.5.3", features = ["derive", "env"] }
 funds-manager-api = { path = "../funds-manager-api" }
+hex = "0.4.3"
+hmac = "0.12.1"
 http-body-util = "0.1.0"
+sha2 = "0.10.6"
 tokio = { version = "1.10", features = ["full"] }
 warp = "0.3"
 
@@ -39,8 +48,10 @@ renegade-util = { package = "util", workspace = true }
 # === Misc Dependencies === #
 base64 = "0.22"
 bigdecimal = { version = "0.4", features = ["serde"] }
+bytes = "1.5.0"
 futures = "0.3"
 http = "1.1"
+itertools = "0.13"
 num-bigint = "0.4"
 reqwest = { version = "0.12", features = ["json"] }
 serde = "1.0"

--- a/funds-manager/funds-manager-server/src/error.rs
+++ b/funds-manager/funds-manager-server/src/error.rs
@@ -102,6 +102,8 @@ pub enum ApiError {
     InternalError(String),
     /// Bad request error
     BadRequest(String),
+    /// Unauthenticated error
+    Unauthenticated(String),
 }
 
 impl Reject for ApiError {}
@@ -113,6 +115,7 @@ impl Display for ApiError {
             ApiError::RedemptionError(e) => write!(f, "Redemption error: {}", e),
             ApiError::InternalError(e) => write!(f, "Internal error: {}", e),
             ApiError::BadRequest(e) => write!(f, "Bad request: {}", e),
+            ApiError::Unauthenticated(e) => write!(f, "Unauthenticated: {}", e),
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/middleware.rs
+++ b/funds-manager/funds-manager-server/src/middleware.rs
@@ -1,0 +1,112 @@
+//! Middleware for the funds manager server
+
+use crate::error::ApiError;
+use crate::Server;
+use bytes::Bytes;
+use hmac::{Hmac, Mac};
+use itertools::Itertools;
+use serde::de::DeserializeOwned;
+use sha2::Sha256;
+use std::sync::Arc;
+use warp::Filter;
+
+/// The header key for the HMAC signature
+const X_SIGNATURE_HEADER: &str = "X-Signature";
+/// The prefix for Renegade headers, these headers are included in the HMAC
+/// signature
+const RENEGADE_HEADER_PREFIX: &str = "x-renegade-";
+
+/// Add HMAC authentication to a route
+pub(crate) fn with_hmac_auth(
+    server: Arc<Server>,
+) -> impl Filter<Extract = (Bytes,), Error = warp::Rejection> + Clone {
+    warp::any()
+        .and(warp::any().map(move || server.clone()))
+        .and(warp::header::optional::<String>(X_SIGNATURE_HEADER))
+        .and(warp::method())
+        .and(warp::path::full())
+        .and(warp::header::headers_cloned())
+        .and(warp::body::bytes())
+        .and_then(verify_hmac)
+}
+
+/// Verify the HMAC signature
+async fn verify_hmac(
+    server: Arc<Server>,
+    signature: Option<String>,
+    method: warp::http::Method,
+    path: warp::path::FullPath,
+    headers: warp::http::HeaderMap,
+    body: Bytes,
+) -> Result<Bytes, warp::Rejection> {
+    // Unwrap the key and signature
+    let hmac_key = match &server.hmac_key {
+        Some(hmac_key) => hmac_key,
+        None => return Ok(body), // Auth is disabled, allow the request
+    };
+
+    let signature = match signature {
+        Some(sig) => sig,
+        None => {
+            return Err(warp::reject::custom(ApiError::Unauthenticated(
+                "Missing signature".to_string(),
+            )))
+        },
+    };
+
+    // Construct the MAC
+    let mut mac = Hmac::<Sha256>::new_from_slice(hmac_key)
+        .map_err(|_| warp::reject::custom(ApiError::InternalError("HMAC error".to_string())))?;
+
+    // Update with method, path, headers and body in order
+    mac.update(method.as_str().as_bytes());
+    mac.update(path.as_str().as_bytes());
+    add_headers_to_hmac(&mut mac, &headers);
+    mac.update(&body);
+
+    // Check the signature
+    let expected = mac.finalize().into_bytes();
+    let provided = hex::decode(signature)
+        .map_err(|_| warp::reject::custom(ApiError::BadRequest("Invalid signature".to_string())))?;
+    if expected.as_slice() != provided.as_slice() {
+        return Err(warp::reject::custom(ApiError::Unauthenticated(
+            "Invalid signature".to_string(),
+        )));
+    }
+
+    Ok(body)
+}
+
+/// Hash headers into an HMAC
+fn add_headers_to_hmac(mac: &mut Hmac<Sha256>, headers: &warp::http::HeaderMap) {
+    let mut renegade_headers = headers
+        .iter()
+        .filter_map(|(k, v)| {
+            let key = k.as_str().to_lowercase();
+            if key.starts_with(RENEGADE_HEADER_PREFIX) {
+                Some((key, v.to_str().unwrap_or("").to_string()))
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+    renegade_headers.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (key, value) in renegade_headers {
+        mac.update(key.as_bytes());
+        mac.update(value.as_bytes());
+    }
+}
+
+/// Extract a JSON body from a request
+#[allow(clippy::needless_pass_by_value)]
+pub fn with_json_body<T: DeserializeOwned + Send>(body: Bytes) -> Result<T, warp::Rejection> {
+    serde_json::from_slice(&body)
+        .map_err(|e| warp::reject::custom(ApiError::BadRequest(format!("Invalid JSON: {}", e))))
+}
+
+/// Identity map for a handler's middleware, used to chain together `map`s and
+/// `and_then`s
+pub async fn identity<T>(res: T) -> T {
+    res
+}


### PR DESCRIPTION
### Purpose
This PR adds HMAC authentication for the server and applies it to the custody withdrawal endpoint. The HMAC key is a 32-byte array configured via the CLI. Users may disable auth, but must explicitly specify `--disable-auth` to do so, ensuring consent for unsafe operations.

### Testing
- Wrote a proxy to attach HMACs and proxied requests to the server