### PR TITLE
funds-manager: Add gas refuel api

### DIFF
--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -20,6 +20,9 @@ pub const GET_DEPOSIT_ADDRESS_ROUTE: &str = "deposit-address";
 /// The route to withdraw funds from custody
 pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
 
+/// The route to withdraw gas from custody
+pub const WITHDRAW_GAS_ROUTE: &str = "withdraw-gas";
+
 // -------------
 // | Api Types |
 // -------------
@@ -37,7 +40,17 @@ pub struct WithdrawFundsRequest {
     /// The mint of the asset to withdraw
     pub mint: String,
     /// The amount of funds to withdraw
-    pub amount: u128,
+    pub amount: f64,
     /// The address to withdraw to
     pub address: String,
+}
+
+// Update request body name and documentation
+/// The request body for withdrawing gas from custody
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WithdrawGasRequest {
+    /// The amount of gas to withdraw
+    pub amount: f64,
+    /// The address to withdraw to
+    pub destination_address: String,
 }

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -44,7 +44,7 @@ impl DepositWithdrawSource {
         match self {
             Self::Quoter => "Quoters",
             Self::FeeRedemption => unimplemented!("no vault for fee redemption yet"),
-            Self::Gas => unimplemented!("no vault for gas yet"),
+            Self::Gas => "Arbitrum Gas",
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -5,16 +5,27 @@ use fireblocks_sdk::types::TransactionStatus;
 use super::{CustodyClient, DepositWithdrawSource};
 
 impl CustodyClient {
+    /// Withdraw gas from custody
+    pub(crate) async fn withdraw_with_token_addr(
+        &self,
+        source: DepositWithdrawSource,
+        destination_address: &str,
+        token_address: &str,
+        amount: f64,
+    ) -> Result<(), FundsManagerError> {
+        let symbol = self.get_erc20_token_symbol(token_address).await?;
+        self.withdraw(source, destination_address, &symbol, amount).await
+    }
+
     /// Withdraw funds from custody
     pub(crate) async fn withdraw(
         &self,
         source: DepositWithdrawSource,
-        token_address: &str,
-        amount: u128,
-        destination_address: String,
+        destination_address: &str,
+        symbol: &str,
+        amount: f64,
     ) -> Result<(), FundsManagerError> {
         let client = self.get_fireblocks_client()?;
-        let symbol = self.get_erc20_token_symbol(token_address).await?;
 
         // Get the vault account and asset to transfer from
         let vault = self
@@ -22,12 +33,13 @@ impl CustodyClient {
             .await?
             .ok_or_else(|| FundsManagerError::Custom("Vault not found".to_string()))?;
 
-        let asset = self.get_wallet_for_ticker(&vault, &symbol).ok_or_else(|| {
+        let asset = self.get_wallet_for_ticker(&vault, symbol).ok_or_else(|| {
             FundsManagerError::Custom(format!("Asset not found for symbol: {}", symbol))
         })?;
 
         // Check if the available balance is sufficient
-        let withdraw_amount = BigDecimal::from_u128(amount).expect("amount too large");
+        let withdraw_amount = BigDecimal::from_f64(amount)
+            .ok_or_else(|| FundsManagerError::Custom("Invalid amount".to_string()))?;
         if asset.available < withdraw_amount {
             return Err(FundsManagerError::Custom(format!(
                 "Insufficient balance. Available: {}, Requested: {}",


### PR DESCRIPTION
### Purpose
This PR adds an API endpoint for refueling gas. We segment the vaults from which gas and quoter funds are drawn to more accurately track and allocate our custodied funds.

### Testing
- Hit the endpoint to withdraw gas to a personal wallet