### PR TITLE
funds-manager: fee-indexer: Add endpoint to view wallet fee balances

### DIFF
--- a/funds-manager/funds-manager-api/Cargo.toml
+++ b/funds-manager/funds-manager-api/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 
+renegade-api = { package = "external-api", workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.117"

--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(missing_docs)]
 #![deny(clippy::missing_docs_in_private_items)]
 
+use renegade_api::types::ApiWallet;
 use serde::{Deserialize, Serialize};
 
 // --------------
@@ -22,6 +23,9 @@ pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
 
 /// The route to withdraw gas from custody
 pub const WITHDRAW_GAS_ROUTE: &str = "withdraw-gas";
+
+/// The route to get fee wallets
+pub const GET_FEE_WALLETS_ROUTE: &str = "get-fee-wallets";
 
 // -------------
 // | Api Types |
@@ -53,4 +57,11 @@ pub struct WithdrawGasRequest {
     pub amount: f64,
     /// The address to withdraw to
     pub destination_address: String,
+}
+
+/// The response containing fee wallets
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FeeWalletsResponse {
+    /// The wallets managed by the funds manager
+    pub wallets: Vec<ApiWallet>,
 }

--- a/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
@@ -1,0 +1,45 @@
+//! Fetch the balances of redeemed fees
+
+use crate::db::models::WalletMetadata;
+use crate::error::FundsManagerError;
+use renegade_api::types::ApiWallet;
+use renegade_common::types::wallet::derivation::derive_wallet_keychain;
+
+use super::Indexer;
+
+impl Indexer {
+    /// Fetch fee balances for wallets managed by the funds manager
+    pub async fn fetch_fee_wallets(&mut self) -> Result<Vec<ApiWallet>, FundsManagerError> {
+        // Query the wallets and fetch from the relayer
+        let wallet_metadata = self.get_all_wallets().await?;
+        let mut wallets = Vec::with_capacity(wallet_metadata.len());
+        for meta in wallet_metadata.into_iter() {
+            let wallet = self.fetch_wallet(meta).await?;
+            wallets.push(wallet);
+        }
+
+        Ok(wallets)
+    }
+
+    /// Fetch a wallet given its metadata
+    ///
+    /// This is done by:
+    ///     1. Fetch the wallet's key from secrets manager
+    ///     2. Use the key to fetch the wallet from the relayer
+    async fn fetch_wallet(
+        &mut self,
+        wallet_metadata: WalletMetadata,
+    ) -> Result<ApiWallet, FundsManagerError> {
+        // Get the wallet's private key from secrets manager
+        let eth_key = self.get_wallet_private_key(&wallet_metadata).await?;
+
+        // Derive the wallet keychain
+        let wallet_keychain =
+            derive_wallet_keychain(&eth_key, self.chain_id).map_err(FundsManagerError::custom)?;
+        let root_key = wallet_keychain.secret_keys.sk_root.clone().expect("root key not present");
+
+        // Fetch the wallet from the relayer
+        let wallet = self.relayer_client.get_wallet(wallet_metadata.id, &root_key).await?;
+        Ok(wallet.wallet)
+    }
+}

--- a/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
@@ -8,6 +8,7 @@ use renegade_util::hex::jubjub_from_hex_string;
 
 use crate::relayer_client::RelayerClient;
 
+pub mod fee_balances;
 pub mod index_fees;
 pub mod queries;
 pub mod redeem_fees;

--- a/funds-manager/funds-manager-server/src/fee_indexer/queries.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/queries.rs
@@ -208,6 +208,17 @@ impl Indexer {
     // | Wallets Table |
     // -----------------
 
+    /// Get all wallets in the table
+    pub(crate) async fn get_all_wallets(
+        &mut self,
+    ) -> Result<Vec<WalletMetadata>, FundsManagerError> {
+        let wallets = wallet_table
+            .load::<WalletMetadata>(&mut self.db_conn)
+            .await
+            .map_err(|e| FundsManagerError::db(format!("failed to load wallets: {}", e)))?;
+        Ok(wallets)
+    }
+
     /// Get the wallet managing an mint, if it exists
     ///
     /// Returns the id and secret id of the wallet

--- a/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+use diesel::IntoSql;
 use ethers::core::rand::thread_rng;
 use ethers::signers::LocalWallet;
 use ethers::types::TxHash;

--- a/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
-use diesel::IntoSql;
 use ethers::core::rand::thread_rng;
 use ethers::signers::LocalWallet;
 use ethers::types::TxHash;
@@ -213,7 +212,7 @@ impl Indexer {
     }
 
     /// Get the private key for a wallet specified by its metadata
-    async fn get_wallet_private_key(
+    pub(crate) async fn get_wallet_private_key(
         &mut self,
         metadata: &WalletMetadata,
     ) -> Result<LocalWallet, FundsManagerError> {

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -3,7 +3,10 @@
 use crate::custody_client::DepositWithdrawSource;
 use crate::error::ApiError;
 use crate::Server;
-use funds_manager_api::{DepositAddressResponse, WithdrawFundsRequest, WithdrawGasRequest};
+use bytes::Bytes;
+use funds_manager_api::{
+    DepositAddressResponse, FeeWalletsResponse, WithdrawFundsRequest, WithdrawGasRequest,
+};
 use std::collections::HashMap;
 use std::sync::Arc;
 use warp::reply::Json;
@@ -102,4 +105,14 @@ pub(crate) async fn withdraw_gas_handler(
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
     Ok(warp::reply::json(&format!("Gas withdrawal of {} ETH complete", withdraw_request.amount)))
+}
+
+/// Handler for getting fee wallets
+pub(crate) async fn get_fee_wallets_handler(
+    _body: Bytes, // no body
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let mut indexer = server.build_indexer().await?;
+    let wallets = indexer.fetch_fee_wallets().await?;
+    Ok(warp::reply::json(&FeeWalletsResponse { wallets }))
 }

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -19,12 +19,12 @@ use error::FundsManagerError;
 use ethers::signers::LocalWallet;
 use fee_indexer::Indexer;
 use funds_manager_api::{
-    WithdrawGasRequest, GET_DEPOSIT_ADDRESS_ROUTE, INDEX_FEES_ROUTE, PING_ROUTE, REDEEM_FEES_ROUTE,
-    WITHDRAW_CUSTODY_ROUTE, WITHDRAW_GAS_ROUTE,
+    WithdrawGasRequest, GET_DEPOSIT_ADDRESS_ROUTE, GET_FEE_WALLETS_ROUTE, INDEX_FEES_ROUTE,
+    PING_ROUTE, REDEEM_FEES_ROUTE, WITHDRAW_CUSTODY_ROUTE, WITHDRAW_GAS_ROUTE,
 };
 use handlers::{
-    get_deposit_address_handler, index_fees_handler, quoter_withdraw_handler, redeem_fees_handler,
-    withdraw_gas_handler,
+    get_deposit_address_handler, get_fee_wallets_handler, index_fees_handler,
+    quoter_withdraw_handler, redeem_fees_handler, withdraw_gas_handler,
 };
 use middleware::{identity, with_hmac_auth, with_json_body};
 use relayer_client::RelayerClient;
@@ -299,12 +299,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(withdraw_gas_handler);
 
+    let get_balances = warp::get()
+        .and(warp::path("fees"))
+        .and(warp::path(GET_FEE_WALLETS_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .and(with_server(server.clone()))
+        .and_then(get_fee_wallets_handler);
+
     let routes = ping
         .or(index_fees)
         .or(redeem_fees)
         .or(withdraw_custody)
         .or(get_deposit_address)
         .or(withdraw_gas)
+        .or(get_balances)
         .recover(handle_rejection);
     warp::serve(routes).run(([0, 0, 0, 0], cli.port)).await;
 

--- a/funds-manager/funds-manager-server/src/relayer_client.rs
+++ b/funds-manager/funds-manager-server/src/relayer_client.rs
@@ -85,6 +85,17 @@ impl RelayerClient {
     // | Wallet Methods |
     // ------------------
 
+    /// Get the wallet for a given id
+    pub async fn get_wallet(
+        &self,
+        wallet_id: WalletIdentifier,
+        root_key: &SecretSigningKey,
+    ) -> Result<GetWalletResponse, FundsManagerError> {
+        let mut path = GET_WALLET_ROUTE.to_string();
+        path = path.replace(":wallet_id", &wallet_id.to_string());
+        self.get_relayer_with_auth::<GetWalletResponse>(&path, root_key).await
+    }
+
     /// Check that the relayer has a given wallet, lookup the wallet if not
     pub async fn check_wallet_indexed(
         &self,


### PR DESCRIPTION
### Purpose
This PR adds an endpoint to fetch Renegade wallets for which we redeem fees into. This will allow an admin to view the current fee balances in the indexer and withdraw as desired.

### Testing
- Tested locally against a running server