### PR TITLE
funds-manager: migrations: Add `hot_wallets` table

### DIFF
--- a/funds-manager/funds-manager-server/src/db/models.rs
+++ b/funds-manager/funds-manager-server/src/db/models.rs
@@ -61,7 +61,7 @@ pub struct Metadata {
 
 /// A metadata entry for a wallet managed by the indexer
 #[derive(Clone, Queryable, Selectable, Insertable)]
-#[diesel(table_name = crate::db::schema::wallets)]
+#[diesel(table_name = crate::db::schema::renegade_wallets)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[allow(missing_docs, clippy::missing_docs_in_private_items)]
 pub struct WalletMetadata {

--- a/funds-manager/funds-manager-server/src/db/schema.rs
+++ b/funds-manager/funds-manager-server/src/db/schema.rs
@@ -13,6 +13,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    hot_wallets (id) {
+        id -> Uuid,
+        secret_id -> Text,
+        vault -> Text,
+        address -> Text,
+    }
+}
+
+diesel::table! {
     indexing_metadata (key) {
         key -> Text,
         value -> Text,
@@ -20,11 +29,16 @@ diesel::table! {
 }
 
 diesel::table! {
-    wallets (id) {
+    renegade_wallets (id) {
         id -> Uuid,
         mints -> Array<Nullable<Text>>,
         secret_id -> Text,
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(fees, indexing_metadata, wallets,);
+diesel::allow_tables_to_appear_in_same_query!(
+    fees,
+    hot_wallets,
+    indexing_metadata,
+    renegade_wallets,
+);

--- a/funds-manager/migrations/2024-07-27-200942_create_hot_wallets_table/down.sql
+++ b/funds-manager/migrations/2024-07-27-200942_create_hot_wallets_table/down.sql
@@ -1,0 +1,3 @@
+-- Drop the hot wallets table
+DROP TABLE hot_wallets;
+ALTER TABLE renegade_wallets RENAME TO wallets;

--- a/funds-manager/migrations/2024-07-27-200942_create_hot_wallets_table/up.sql
+++ b/funds-manager/migrations/2024-07-27-200942_create_hot_wallets_table/up.sql
@@ -1,0 +1,10 @@
+-- Create a table for storing hot wallets
+CREATE TABLE hot_wallets(
+    id UUID PRIMARY KEY,
+    secret_id TEXT NOT NULL, -- The AWS Secrets Manager secret that holds the hot wallet's key
+    vault TEXT NOT NULL,     -- The fireblocks vault that the hot wallet writes back to
+    address TEXT NOT NULL    -- The Arbitrum address of the hot wallet
+);
+
+--- Rename the wallets table to renegade_wallets for clarity
+ALTER TABLE wallets RENAME TO renegade_wallets;


### PR DESCRIPTION
### Purpose
This PR adds a table to store metadata about hot wallets managed by the `funds-manager`. We will allocate one hot wallet per vault (which separates out funds by use case) and use it to holds funds on-chain that we do not want to deposit/withdraw from Fireblocks.

### Testing
- Applied the migration, verified server functionality afterwards