### PR TITLE
funds-manager-server: Use connection pool instead of raw connections

### DIFF
--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -24,8 +24,9 @@ warp = "0.3"
 # === Infra === #
 aws-sdk-secretsmanager = "1.37"
 aws-config = "1.5"
+bb8 = "0.8"
 diesel = { workspace = true, features = ["postgres", "numeric", "uuid"] }
-diesel-async = { workspace = true, features = ["postgres"] }
+diesel-async = { workspace = true, features = ["postgres", "bb8"] }
 fireblocks-sdk = { git = "https://github.com/renegade-fi/fireblocks-sdk-rs" }
 native-tls = "0.2"
 postgres-native-tls = "0.5"

--- a/funds-manager/funds-manager-server/src/db/mod.rs
+++ b/funds-manager/funds-manager-server/src/db/mod.rs
@@ -1,6 +1,11 @@
 //! Database code
 
-use diesel_async::AsyncPgConnection;
+use bb8::{Pool, PooledConnection};
+use diesel::ConnectionError;
+use diesel_async::{
+    pooled_connection::{AsyncDieselConnectionManager, ManagerConfig},
+    AsyncPgConnection,
+};
 use native_tls::TlsConnector;
 use postgres_native_tls::MakeTlsConnector;
 use renegade_util::err_str;
@@ -12,19 +17,33 @@ pub mod models;
 #[allow(missing_docs)]
 pub mod schema;
 
+/// The DB connection type
+pub type DbConn<'a> = PooledConnection<'a, AsyncDieselConnectionManager<AsyncPgConnection>>;
+/// The DB pool type
+pub type DbPool = Pool<AsyncDieselConnectionManager<AsyncPgConnection>>;
+
+/// Create a connection pool for the given database url
+pub async fn create_db_pool(db_url: &str) -> Result<DbPool, FundsManagerError> {
+    let mut conf = ManagerConfig::default();
+    conf.custom_setup = Box::new(move |url| Box::pin(establish_connection(url)));
+
+    let manager = AsyncDieselConnectionManager::new_with_config(db_url, conf);
+    Pool::builder().build(manager).await.map_err(err_str!(FundsManagerError::Db))
+}
+
 /// Establish a connection to the database
-pub async fn establish_connection(db_url: &str) -> Result<AsyncPgConnection, FundsManagerError> {
+pub async fn establish_connection(db_url: &str) -> Result<AsyncPgConnection, ConnectionError> {
     // Build a TLS connector, we don't validate certificates for simplicity.
     // Practically this is unnecessary because we will be limiting our traffic to
     // within a siloed environment when deployed
     let connector = TlsConnector::builder()
         .danger_accept_invalid_certs(true)
         .build()
-        .map_err(err_str!(FundsManagerError::Db))?;
+        .expect("failed to build tls connector");
     let connector = MakeTlsConnector::new(connector);
     let (client, conn) = tokio_postgres::connect(db_url, connector)
         .await
-        .map_err(err_str!(FundsManagerError::Db))?;
+        .map_err(err_str!(ConnectionError::BadConnection))?;
 
     // Spawn the connection handle in a separate task
     tokio::spawn(async move {
@@ -33,5 +52,5 @@ pub async fn establish_connection(db_url: &str) -> Result<AsyncPgConnection, Fun
         }
     });
 
-    AsyncPgConnection::try_from(client).await.map_err(err_str!(FundsManagerError::Db))
+    AsyncPgConnection::try_from(client).await
 }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -23,7 +23,6 @@ pub const MAX_GAS_WITHDRAWAL_AMOUNT: f64 = 0.1; // 0.1 ETH
 pub(crate) async fn index_fees_handler(server: Arc<Server>) -> Result<Json, warp::Rejection> {
     let mut indexer = server
         .build_indexer()
-        .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
     indexer
         .index_fees()
@@ -36,7 +35,6 @@ pub(crate) async fn index_fees_handler(server: Arc<Server>) -> Result<Json, warp
 pub(crate) async fn redeem_fees_handler(server: Arc<Server>) -> Result<Json, warp::Rejection> {
     let mut indexer = server
         .build_indexer()
-        .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
     indexer
         .redeem_fees()
@@ -113,7 +111,7 @@ pub(crate) async fn get_fee_wallets_handler(
     _body: Bytes, // no body
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let mut indexer = server.build_indexer().await?;
+    let mut indexer = server.build_indexer()?;
     let wallets = indexer.fetch_fee_wallets().await?;
     Ok(warp::reply::json(&FeeWalletsResponse { wallets }))
 }
@@ -123,7 +121,7 @@ pub(crate) async fn withdraw_fee_balance_handler(
     req: WithdrawFeeBalanceRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let mut indexer = server.build_indexer().await?;
+    let mut indexer = server.build_indexer()?;
     indexer
         .withdraw_fee_balance(req.wallet_id, req.mint)
         .await


### PR DESCRIPTION
### Purpose
This PR refactors the `funds-manager-server` to use a connection pool under the hood instead of a single connection. This allows multiple server workers to make progress simultaneously rather without messy dependency injection.

### Testing
- Tested server functionality