### PR TITLE
funds-manager: Add endpoint to create new hot wallets

### DIFF
--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -27,13 +27,35 @@ pub const WITHDRAW_GAS_ROUTE: &str = "withdraw-gas";
 
 /// The route to get fee wallets
 pub const GET_FEE_WALLETS_ROUTE: &str = "get-fee-wallets";
-
 /// The route to withdraw a fee balance
 pub const WITHDRAW_FEE_BALANCE_ROUTE: &str = "withdraw-fee-balance";
+
+/// The route to create a new hot wallet
+pub const CREATE_HOT_WALLET_ROUTE: &str = "create-hot-wallet";
 
 // -------------
 // | Api Types |
 // -------------
+
+// --- Fee Indexing & Management --- //
+
+/// The response containing fee wallets
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FeeWalletsResponse {
+    /// The wallets managed by the funds manager
+    pub wallets: Vec<ApiWallet>,
+}
+
+/// The request body for withdrawing a fee balance
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WithdrawFeeBalanceRequest {
+    /// The ID of the wallet to withdraw from
+    pub wallet_id: Uuid,
+    /// The mint of the asset to withdraw
+    pub mint: String,
+}
+
+// --- Quoters --- //
 
 /// A response containing the deposit address
 #[derive(Debug, Serialize, Deserialize)]
@@ -53,6 +75,8 @@ pub struct WithdrawFundsRequest {
     pub address: String,
 }
 
+// --- Gas --- //
+
 // Update request body name and documentation
 /// The request body for withdrawing gas from custody
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -63,18 +87,18 @@ pub struct WithdrawGasRequest {
     pub destination_address: String,
 }
 
-/// The response containing fee wallets
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FeeWalletsResponse {
-    /// The wallets managed by the funds manager
-    pub wallets: Vec<ApiWallet>,
+// --- Hot Wallets --- //
+
+/// The request body for creating a hot wallet
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateHotWalletRequest {
+    /// The name of the vault backing the hot wallet
+    pub vault: String,
 }
 
-/// The request body for withdrawing a fee balance
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WithdrawFeeBalanceRequest {
-    /// The ID of the wallet to withdraw from
-    pub wallet_id: Uuid,
-    /// The mint of the asset to withdraw
-    pub mint: String,
+/// The response containing the hot wallet's address
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateHotWalletResponse {
+    /// The address of the hot wallet
+    pub address: String,
 }

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -54,6 +54,7 @@ futures = "0.3"
 http = "1.1"
 itertools = "0.13"
 num-bigint = "0.4"
+rand = "0.8"
 reqwest = { version = "0.12", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -1,0 +1,43 @@
+//! Handlers for managing hot wallets
+//!
+//! We store funds in hot wallets to prevent excessive in/out-flow from
+//! Fireblocks
+
+use ethers::{
+    signers::{LocalWallet, Signer},
+    utils::hex::ToHexExt,
+};
+use rand::thread_rng;
+use tracing::info;
+
+use super::CustodyClient;
+use crate::{error::FundsManagerError, helpers::create_secrets_manager_entry_with_description};
+
+impl CustodyClient {
+    /// Create a new hot wallet
+    ///
+    /// Returns the Arbitrum address of the hot wallet
+    pub async fn create_hot_wallet(&self, vault: String) -> Result<String, FundsManagerError> {
+        // Generate a new Ethereum keypair
+        let wallet = LocalWallet::new(&mut thread_rng());
+        let address = wallet.address().encode_hex();
+        let private_key = wallet.signer().to_bytes();
+
+        // Store the private key in Secrets Manager
+        let secret_name = format!("hot-wallet-{}", address);
+        let secret_value = hex::encode(private_key);
+        let description = format!("Hot wallet for vault: {vault}");
+        create_secrets_manager_entry_with_description(
+            &secret_name,
+            &secret_value,
+            &self.aws_config,
+            &description,
+        )
+        .await?;
+
+        // Insert the wallet metadata into the database
+        self.insert_hot_wallet(&address, &vault, &secret_name).await?;
+        info!("Created hot wallet with address: {} for vault: {}", address, vault);
+        Ok(address)
+    }
+}

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -1,8 +1,11 @@
 //! Manages the custody backend for the funds manager
 #![allow(missing_docs)]
 pub mod deposit;
+mod hot_wallets;
+mod queries;
 pub mod withdraw;
 
+use aws_config::SdkConfig as AwsConfig;
 use ethers::prelude::abigen;
 use ethers::providers::{Http, Provider};
 use ethers::types::Address;
@@ -61,6 +64,8 @@ pub struct CustodyClient {
     arbitrum_rpc_url: String,
     /// The database connection pool
     db_pool: Arc<DbPool>,
+    /// The AWS config
+    aws_config: AwsConfig,
 }
 
 impl CustodyClient {
@@ -71,9 +76,10 @@ impl CustodyClient {
         fireblocks_api_secret: String,
         arbitrum_rpc_url: String,
         db_pool: Arc<DbPool>,
+        aws_config: AwsConfig,
     ) -> Self {
         let fireblocks_api_secret = fireblocks_api_secret.as_bytes().to_vec();
-        Self { fireblocks_api_key, fireblocks_api_secret, arbitrum_rpc_url, db_pool }
+        Self { fireblocks_api_key, fireblocks_api_secret, arbitrum_rpc_url, db_pool, aws_config }
     }
 
     /// Get a fireblocks client

--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -1,0 +1,29 @@
+//! Queries for managing custody data
+
+use diesel_async::RunQueryDsl;
+use renegade_util::err_str;
+
+use crate::db::models::HotWallet;
+use crate::db::schema::hot_wallets;
+use crate::error::FundsManagerError;
+use crate::CustodyClient;
+
+impl CustodyClient {
+    /// Insert a new hot wallet into the database
+    pub async fn insert_hot_wallet(
+        &self,
+        address: &str,
+        vault: &str,
+        secret_id: &str,
+    ) -> Result<(), FundsManagerError> {
+        let mut conn = self.get_db_conn().await?;
+        let entry = HotWallet::new(secret_id.to_string(), vault.to_string(), address.to_string());
+        diesel::insert_into(hot_wallets::table)
+            .values(entry)
+            .execute(&mut conn)
+            .await
+            .map_err(err_str!(FundsManagerError::Db))?;
+
+        Ok(())
+    }
+}

--- a/funds-manager/funds-manager-server/src/db/models.rs
+++ b/funds-manager/funds-manager-server/src/db/models.rs
@@ -64,15 +64,33 @@ pub struct Metadata {
 #[diesel(table_name = crate::db::schema::renegade_wallets)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[allow(missing_docs, clippy::missing_docs_in_private_items)]
-pub struct WalletMetadata {
+pub struct RenegadeWalletMetadata {
     pub id: Uuid,
     pub mints: Vec<Option<String>>,
     pub secret_id: String,
 }
 
-impl WalletMetadata {
+impl RenegadeWalletMetadata {
     /// Construct a new wallet metadata entry
     pub fn empty(id: Uuid, secret_id: String) -> Self {
-        WalletMetadata { id, mints: vec![], secret_id }
+        RenegadeWalletMetadata { id, mints: vec![], secret_id }
+    }
+}
+
+/// A hot wallet managed by the custody client
+#[derive(Clone, Queryable, Selectable, Insertable)]
+#[diesel(table_name = crate::db::schema::hot_wallets)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct HotWallet {
+    pub id: Uuid,
+    pub secret_id: String,
+    pub vault: String,
+    pub address: String,
+}
+
+impl HotWallet {
+    /// Construct a new hot wallet entry
+    pub fn new(secret_id: String, vault: String, address: String) -> Self {
+        HotWallet { id: Uuid::new_v4(), secret_id, vault, address }
     }
 }

--- a/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
@@ -1,7 +1,7 @@
 //! Fetch the balances of redeemed fees
 
 use crate::custody_client::DepositWithdrawSource;
-use crate::db::models::WalletMetadata;
+use crate::db::models::RenegadeWalletMetadata;
 use crate::error::FundsManagerError;
 use arbitrum_client::{conversion::to_contract_external_transfer, helpers::serialize_calldata};
 use ethers::{
@@ -77,7 +77,7 @@ impl Indexer {
     ///     2. Use the key to fetch the wallet from the relayer
     async fn fetch_wallet(
         &mut self,
-        wallet_metadata: WalletMetadata,
+        wallet_metadata: RenegadeWalletMetadata,
     ) -> Result<ApiWallet, FundsManagerError> {
         // Get the wallet's private key from secrets manager
         let eth_key = self.get_wallet_private_key(&wallet_metadata).await?;

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -5,8 +5,8 @@ use crate::error::ApiError;
 use crate::Server;
 use bytes::Bytes;
 use funds_manager_api::{
-    DepositAddressResponse, FeeWalletsResponse, WithdrawFeeBalanceRequest, WithdrawFundsRequest,
-    WithdrawGasRequest,
+    CreateHotWalletRequest, CreateHotWalletResponse, DepositAddressResponse, FeeWalletsResponse,
+    WithdrawFeeBalanceRequest, WithdrawFundsRequest, WithdrawGasRequest,
 };
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -128,4 +128,19 @@ pub(crate) async fn withdraw_fee_balance_handler(
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
     Ok(warp::reply::json(&"Fee withdrawal initiated..."))
+}
+
+/// Handler for creating a hot wallet
+pub(crate) async fn create_hot_wallet_handler(
+    req: CreateHotWalletRequest,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let address = server
+        .custody_client
+        .create_hot_wallet(req.vault)
+        .await
+        .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+
+    let resp = CreateHotWalletResponse { address };
+    Ok(warp::reply::json(&resp))
 }

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -1,0 +1,42 @@
+//! Helpers for the funds manager server
+
+use aws_config::SdkConfig;
+use aws_sdk_secretsmanager::client::Client as SecretsManagerClient;
+use renegade_util::err_str;
+
+use crate::error::FundsManagerError;
+
+/// Add a Renegade wallet to the secrets manager entry so that it may be
+/// recovered later
+///
+/// Returns the name of the secret
+pub async fn create_secrets_manager_entry(
+    name: &str,
+    value: &str,
+    config: &SdkConfig,
+) -> Result<(), FundsManagerError> {
+    create_secrets_manager_entry_with_description(name, value, config, "").await
+}
+
+/// Add a Renegade wallet to the secrets manager entry so that it may be
+/// recovered later
+///
+/// Returns the name of the secret
+pub async fn create_secrets_manager_entry_with_description(
+    name: &str,
+    value: &str,
+    config: &SdkConfig,
+    description: &str,
+) -> Result<(), FundsManagerError> {
+    let client = SecretsManagerClient::new(config);
+    client
+        .create_secret()
+        .name(name)
+        .secret_string(value)
+        .description(description)
+        .send()
+        .await
+        .map_err(err_str!(FundsManagerError::SecretsManager))?;
+
+    Ok(())
+}


### PR DESCRIPTION
### Purpose
This PR adds an endpoint to create a new hot wallet. Each hot wallet backs a singular vault for which it "caches" funds. We map hot wallets to vaults in a 1:1 manner to properly segment funds by their intended use. 

The hot wallet metadata is stored in the `FundsManager` database, and the private key is stored in AWS secrets manager.

### Testing
- Created hot wallets for each of our existing vaults