### PR TITLE
funds-manager: Change external deposit/withdraw target to hot wallets

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/deposit.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/deposit.rs
@@ -8,15 +8,22 @@ impl CustodyClient {
     /// Get the deposit address for the given mint
     pub(crate) async fn get_deposit_address(
         &self,
-        mint: &str,
         source: DepositWithdrawSource,
     ) -> Result<String, FundsManagerError> {
         let vault_name = source.vault_name();
-        self.get_deposit_address_by_vault_name(mint, vault_name).await
+        self.get_deposit_address_by_vault_name(vault_name).await
     }
 
     /// Get the deposit address given a vault name
     pub(crate) async fn get_deposit_address_by_vault_name(
+        &self,
+        vault_name: &str,
+    ) -> Result<String, FundsManagerError> {
+        self.get_hot_wallet_by_vault(vault_name).await.map(|w| w.address)
+    }
+
+    /// Get the deposit address given a vault name
+    pub(crate) async fn get_fireblocks_deposit_address(
         &self,
         mint: &str,
         vault_name: &str,

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -92,8 +92,7 @@ impl CustodyClient {
         let wallet = LocalWallet::from_str(&secret_value).map_err(FundsManagerError::parse)?;
 
         // 3. Look up the vault deposit address
-        let deposit_address =
-            self.get_deposit_address_by_vault_name(mint, &hot_wallet.vault).await?;
+        let deposit_address = self.get_fireblocks_deposit_address(mint, &hot_wallet.vault).await?;
 
         // 4. Transfer the tokens
         let receipt = self.erc20_transfer(mint, &deposit_address, amount, wallet).await?;
@@ -114,7 +113,8 @@ impl CustodyClient {
         // Fetch the wallet info, then withdraw
         let wallet = self.get_hot_wallet_by_vault(vault).await?;
         let source = DepositWithdrawSource::from_vault_name(vault)?;
-        self.withdraw_with_token_addr(source, &wallet.address, mint, amount).await
+        let symbol = self.get_erc20_token_symbol(mint).await?;
+        self.withdraw_from_fireblocks(source, &wallet.address, &symbol, amount).await
     }
 
     // ------------
@@ -122,7 +122,7 @@ impl CustodyClient {
     // ------------
 
     /// The secret name for a hot wallet
-    fn hot_wallet_secret_name(address: &str) -> String {
+    pub(crate) fn hot_wallet_secret_name(address: &str) -> String {
         format!("hot-wallet-{address}")
     }
 

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -1,24 +1,47 @@
-use crate::error::FundsManagerError;
+use std::str::FromStr;
+
+use crate::{error::FundsManagerError, helpers::get_secret};
 use bigdecimal::{BigDecimal, FromPrimitive};
+use ethers::signers::LocalWallet;
 use fireblocks_sdk::types::TransactionStatus;
+use tracing::info;
 
 use super::{CustodyClient, DepositWithdrawSource};
 
 impl CustodyClient {
-    /// Withdraw gas from custody
-    pub(crate) async fn withdraw_with_token_addr(
+    /// Withdraw from hot wallet custody with a provided token address
+    pub(crate) async fn withdraw_from_hot_wallet(
         &self,
         source: DepositWithdrawSource,
         destination_address: &str,
         token_address: &str,
         amount: f64,
     ) -> Result<(), FundsManagerError> {
-        let symbol = self.get_erc20_token_symbol(token_address).await?;
-        self.withdraw(source, destination_address, &symbol, amount).await
+        // Find the wallet for the given destination and check its balance
+        let wallet = self.get_hot_wallet_by_vault(source.vault_name()).await?;
+        let bal = self.get_erc20_balance(token_address, &wallet.address).await?;
+        if bal < amount {
+            return Err(FundsManagerError::Custom("Insufficient balance".to_string()));
+        }
+
+        // Fetch the wallet private key
+        let secret_name = Self::hot_wallet_secret_name(&wallet.address);
+        let private_key = get_secret(&secret_name, &self.aws_config).await?;
+        let wallet =
+            LocalWallet::from_str(private_key.as_str()).map_err(FundsManagerError::parse)?;
+
+        // Execute the erc20 transfer
+        let tx = self.erc20_transfer(token_address, destination_address, amount, wallet).await?;
+        info!(
+            "Withdrew {amount} {token_address} from hot wallet to {destination_address}. Tx: {:#}",
+            tx.transaction_hash
+        );
+
+        Ok(())
     }
 
     /// Withdraw funds from custody
-    pub(crate) async fn withdraw(
+    pub(crate) async fn withdraw_from_fireblocks(
         &self,
         source: DepositWithdrawSource,
         destination_address: &str,
@@ -66,6 +89,33 @@ impl CustodyClient {
             let err_msg = format!("Transaction failed: {:?}", tx.status);
             return Err(FundsManagerError::Custom(err_msg));
         }
+
+        Ok(())
+    }
+
+    /// Withdraw gas
+    pub(crate) async fn withdraw_gas(
+        &self,
+        amount: f64,
+        to: &str,
+    ) -> Result<(), FundsManagerError> {
+        // Check the gas wallet's balance
+        let gas_vault_name = DepositWithdrawSource::Gas.vault_name();
+        let gas_wallet = self.get_hot_wallet_by_vault(gas_vault_name).await?;
+        let bal = self.get_ether_balance(&gas_wallet.address).await?;
+        if bal < amount {
+            return Err(FundsManagerError::custom("Insufficient balance"));
+        }
+
+        // Fetch the gas wallet's private key
+        let secret_name = Self::hot_wallet_secret_name(&gas_wallet.address);
+        let private_key = get_secret(&secret_name, &self.aws_config).await?;
+        let wallet =
+            LocalWallet::from_str(private_key.as_str()).map_err(FundsManagerError::parse)?;
+
+        // Execute the transfer
+        let tx = self.transfer_ether(to, amount, wallet).await?;
+        info!("Withdrew {amount} ETH from gas wallet to {to}. Tx: {:#}", tx.transaction_hash);
 
         Ok(())
     }

--- a/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
@@ -54,10 +54,8 @@ impl Indexer {
             old_wallet.key_chain.secret_keys.sk_root.as_ref().expect("root key not present");
 
         // Get the deposit address for the fee withdrawal
-        let deposit_address = self
-            .custody_client
-            .get_deposit_address(&mint, DepositWithdrawSource::FeeRedemption)
-            .await?;
+        let deposit_address =
+            self.custody_client.get_deposit_address(DepositWithdrawSource::FeeRedemption).await?;
 
         // Send a withdrawal request to the relayer
         let req = Self::build_withdrawal_request(&mint, &deposit_address, &old_wallet)?;

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -52,7 +52,7 @@ pub(crate) async fn quoter_withdraw_handler(
 ) -> Result<Json, warp::Rejection> {
     server
         .custody_client
-        .withdraw_with_token_addr(
+        .withdraw_from_hot_wallet(
             DepositWithdrawSource::Quoter,
             &withdraw_request.address,
             &withdraw_request.mint,
@@ -66,16 +66,11 @@ pub(crate) async fn quoter_withdraw_handler(
 
 /// Handler for retrieving the address to deposit custody funds to
 pub(crate) async fn get_deposit_address_handler(
-    query_params: HashMap<String, String>,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let mint = query_params.get(MINTS_QUERY_PARAM).ok_or_else(|| {
-        warp::reject::custom(ApiError::BadRequest("Missing 'mints' query parameter".to_string()))
-    })?;
-
     let address = server
         .custody_client
-        .get_deposit_address(mint, DepositWithdrawSource::Quoter)
+        .get_deposit_address(DepositWithdrawSource::Quoter)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
     let resp = DepositAddressResponse { address };
@@ -96,12 +91,7 @@ pub(crate) async fn withdraw_gas_handler(
 
     server
         .custody_client
-        .withdraw(
-            DepositWithdrawSource::Gas,
-            &withdraw_request.destination_address,
-            GAS_ASSET_NAME,
-            withdraw_request.amount,
-        )
+        .withdraw_gas(withdraw_request.amount, &withdraw_request.destination_address)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -46,7 +46,7 @@ use arbitrum_client::{
 use clap::Parser;
 use funds_manager_api::WithdrawFundsRequest;
 use tracing::{error, warn};
-use warp::{filters::query::query, Filter};
+use warp::Filter;
 
 use crate::custody_client::CustodyClient;
 use crate::error::ApiError;
@@ -325,7 +325,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(warp::path("custody"))
         .and(warp::path("quoters"))
         .and(warp::path(GET_DEPOSIT_ADDRESS_ROUTE))
-        .and(query::<HashMap<String, String>>())
         .and(with_server(server.clone()))
         .and_then(get_deposit_address_handler);
 


### PR DESCRIPTION
### Purpose
This PR updates the deposit/withdraw target for all clients of the funds manager to target hot wallets. Movement between fireblocks and hot wallets will initially be done manually via the admin panel. All automated movements will target the hot wallets.

### Testing
- Tested all deposit/withdraw endpoints after these changes