### PR TITLE
funds-manager: Lookup Fireblocks asset IDs via ERC20 address

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -113,8 +113,7 @@ impl CustodyClient {
         // Fetch the wallet info, then withdraw
         let wallet = self.get_hot_wallet_by_vault(vault).await?;
         let source = DepositWithdrawSource::from_vault_name(vault)?;
-        let symbol = self.get_erc20_token_symbol(mint).await?;
-        self.withdraw_from_fireblocks(source, &wallet.address, &symbol, amount).await
+        self.withdraw_from_fireblocks(source, &wallet.address, mint, amount).await
     }
 
     // ------------


### PR DESCRIPTION
### Purpose
This PR changes the way we resolve asset IDs in the Fireblocks client. Specifically, we lookup assets directly via the `/supported-assets` API, filter them by contract address, and use the asset ID in that API response.

Previously, we were using the ERC20 symbol name to find asset IDs, which plays poorly with the testnet setup.

### Testing
- Tested both the `/custody/hot-wallets/withdraw-to-hot-wallet` and `/custody/hot-wallets/transfer-to-vault` routes for functionality. These are the two routes that resolve asset IDs directly