### PR TITLE
funds-manager: Add internal wallet id mapping & use internal transaction

### DIFF
--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -96,6 +96,8 @@ pub struct WithdrawGasRequest {
 pub struct CreateHotWalletRequest {
     /// The name of the vault backing the hot wallet
     pub vault: String,
+    /// The internal wallet ID to associate with the hot wallet
+    pub internal_wallet_id: Uuid,
 }
 
 /// The response containing the hot wallet's address

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -118,8 +118,6 @@ impl CustodyClient {
     /// Get a fireblocks client
     pub fn get_fireblocks_client(&self) -> Result<FireblocksClient, FundsManagerError> {
         FireblocksClientBuilder::new(&self.fireblocks_api_key, &self.fireblocks_api_secret)
-            // TODO: Remove the sandbox config
-            .with_sandbox()
             .build()
             .map_err(FundsManagerError::fireblocks)
     }

--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -3,6 +3,7 @@
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use renegade_util::err_str;
+use uuid::Uuid;
 
 use crate::db::models::HotWallet;
 use crate::db::schema::hot_wallets;
@@ -27,9 +28,15 @@ impl CustodyClient {
         address: &str,
         vault: &str,
         secret_id: &str,
+        internal_wallet_id: &Uuid,
     ) -> Result<(), FundsManagerError> {
         let mut conn = self.get_db_conn().await?;
-        let entry = HotWallet::new(secret_id.to_string(), vault.to_string(), address.to_string());
+        let entry = HotWallet::new(
+            secret_id.to_string(),
+            vault.to_string(),
+            address.to_string(),
+            *internal_wallet_id,
+        );
         diesel::insert_into(hot_wallets::table)
             .values(entry)
             .execute(&mut conn)

--- a/funds-manager/funds-manager-server/src/db/models.rs
+++ b/funds-manager/funds-manager-server/src/db/models.rs
@@ -86,11 +86,17 @@ pub struct HotWallet {
     pub secret_id: String,
     pub vault: String,
     pub address: String,
+    pub internal_wallet_id: Uuid,
 }
 
 impl HotWallet {
     /// Construct a new hot wallet entry
-    pub fn new(secret_id: String, vault: String, address: String) -> Self {
-        HotWallet { id: Uuid::new_v4(), secret_id, vault, address }
+    pub fn new(
+        secret_id: String,
+        vault: String,
+        address: String,
+        internal_wallet_id: Uuid,
+    ) -> Self {
+        HotWallet { id: Uuid::new_v4(), secret_id, vault, address, internal_wallet_id }
     }
 }

--- a/funds-manager/funds-manager-server/src/db/schema.rs
+++ b/funds-manager/funds-manager-server/src/db/schema.rs
@@ -18,6 +18,7 @@ diesel::table! {
         secret_id -> Text,
         vault -> Text,
         address -> Text,
+        internal_wallet_id -> Uuid,
     }
 }
 

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -129,7 +129,7 @@ pub(crate) async fn create_hot_wallet_handler(
 ) -> Result<Json, warp::Rejection> {
     let address = server
         .custody_client
-        .create_hot_wallet(req.vault)
+        .create_hot_wallet(req.vault, req.internal_wallet_id)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 

--- a/funds-manager/migrations/2024-08-01-021728_add_internal_wallet_id/down.sql
+++ b/funds-manager/migrations/2024-08-01-021728_add_internal_wallet_id/down.sql
@@ -1,0 +1,2 @@
+-- Drop the internal_wallet_id column from the hot_wallets table
+ALTER TABLE hot_wallets DROP COLUMN internal_wallet_id;

--- a/funds-manager/migrations/2024-08-01-021728_add_internal_wallet_id/up.sql
+++ b/funds-manager/migrations/2024-08-01-021728_add_internal_wallet_id/up.sql
@@ -1,0 +1,11 @@
+-- Add internal_wallet_id column as UUID
+ALTER TABLE hot_wallets ADD COLUMN internal_wallet_id UUID;
+
+-- Generate default UUID values for existing rows
+UPDATE hot_wallets
+SET internal_wallet_id = gen_random_uuid()
+WHERE internal_wallet_id IS NULL;
+
+-- Make the column NOT NULL
+ALTER TABLE hot_wallets
+ALTER COLUMN internal_wallet_id SET NOT NULL;


### PR DESCRIPTION
### Purpose
This PR makes the following changes to bring the `funds-manager` into a working state with our testnet environment:
- Remove the sandbox flag on the Fireblocks client
- Add an `internal_wallet_id` mapping to the hot wallets table. Fireblocks requires that we specify whitelisted withdrawals to a wallet ID rather than its address. I manually added wallet IDs for each of the existing hot wallets
- Use a `create_transaction_peer` with `PeerType::INTERNAL_WALLET` to withdraw from Fireblocks. This allows us to control where our funds flow to via a TAP

### Testing
- Tested withdrawing from fireblocks and depositing into it