### PR TITLE
funds-manager: migrations: Add `gas_wallets` table

### DIFF
--- a/funds-manager/funds-manager-server/src/db/schema.rs
+++ b/funds-manager/funds-manager-server/src/db/schema.rs
@@ -13,6 +13,16 @@ diesel::table! {
 }
 
 diesel::table! {
+    gas_wallets (id) {
+        id -> Uuid,
+        address -> Text,
+        peer_id -> Nullable<Text>,
+        status -> Text,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     hot_wallets (id) {
         id -> Uuid,
         secret_id -> Text,
@@ -39,6 +49,7 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     fees,
+    gas_wallets,
     hot_wallets,
     indexing_metadata,
     renegade_wallets,

--- a/funds-manager/migrations/2024-08-01-214330_add_gas_wallets_table/down.sql
+++ b/funds-manager/migrations/2024-08-01-214330_add_gas_wallets_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the gas_wallets table
+DROP TABLE IF EXISTS gas_wallets;

--- a/funds-manager/migrations/2024-08-01-214330_add_gas_wallets_table/up.sql
+++ b/funds-manager/migrations/2024-08-01-214330_add_gas_wallets_table/up.sql
@@ -1,0 +1,8 @@
+-- Create a table to store gas wallets
+CREATE TABLE gas_wallets (
+    id UUID PRIMARY KEY,
+    address TEXT NOT NULL UNIQUE,
+    peer_id TEXT,
+    status TEXT NOT NULL DEFAULT 'inactive',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
### Purpose
This PR adds the `gas_wallets` table to the funds manager. The funds manager will use this to track gas wallets active in the relayer cluster, allocating new relayers inactive gas wallets.

### Testing
- Applied the migration