### PR TITLE
funds-manager: custody-client: Add endpoint for creating gas wallets

### DIFF
--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -79,7 +79,6 @@ pub struct WithdrawFundsRequest {
 
 // --- Gas --- //
 
-// Update request body name and documentation
 /// The request body for withdrawing gas from custody
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WithdrawGasRequest {
@@ -87,6 +86,13 @@ pub struct WithdrawGasRequest {
     pub amount: f64,
     /// The address to withdraw to
     pub destination_address: String,
+}
+
+/// The response containing the gas wallet's address
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateGasWalletResponse {
+    /// The address of the gas wallet
+    pub address: String,
 }
 
 // --- Hot Wallets --- //

--- a/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
@@ -1,0 +1,45 @@
+//! Handlers for gas wallet operations
+
+use ethers::{
+    signers::{LocalWallet, Signer},
+    utils::hex::ToHexExt,
+};
+use rand::thread_rng;
+use tracing::info;
+
+use crate::{error::FundsManagerError, helpers::create_secrets_manager_entry_with_description};
+
+use super::CustodyClient;
+
+impl CustodyClient {
+    /// Create a new gas wallet
+    pub(crate) async fn create_gas_wallet(&self) -> Result<String, FundsManagerError> {
+        // Sample a new ethereum keypair
+        let keypair = LocalWallet::new(&mut thread_rng());
+        let address = keypair.address().encode_hex();
+
+        // Add the gas wallet to the database
+        self.add_gas_wallet(&address).await?;
+
+        // Store the private key in secrets manager
+        let secret_name = Self::gas_wallet_secret_name(&address);
+        let private_key = keypair.signer().to_bytes();
+        let secret_value = hex::encode(private_key);
+        let description = "Gas wallet private key for use by Renegade relayers";
+        create_secrets_manager_entry_with_description(
+            &secret_name,
+            &secret_value,
+            &self.aws_config,
+            description,
+        )
+        .await?;
+        info!("Created gas wallet with address: {}", address);
+
+        Ok(address)
+    }
+
+    /// Get the secret name for a gas wallet's private key
+    fn gas_wallet_secret_name(address: &str) -> String {
+        format!("gas-wallet-{}", address)
+    }
+}

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -1,6 +1,7 @@
 //! Manages the custody backend for the funds manager
 #![allow(missing_docs)]
 pub mod deposit;
+pub mod gas_wallets;
 mod hot_wallets;
 mod queries;
 pub mod withdraw;

--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -5,12 +5,30 @@ use diesel_async::RunQueryDsl;
 use renegade_util::err_str;
 use uuid::Uuid;
 
-use crate::db::models::HotWallet;
+use crate::db::models::{GasWallet, HotWallet};
+use crate::db::schema::gas_wallets;
 use crate::db::schema::hot_wallets;
 use crate::error::FundsManagerError;
 use crate::CustodyClient;
 
 impl CustodyClient {
+    // --- Gas Wallets --- //
+
+    /// Add a new gas wallet
+    pub async fn add_gas_wallet(&self, address: &str) -> Result<(), FundsManagerError> {
+        let mut conn = self.get_db_conn().await?;
+        let entry = GasWallet::new(address.to_string());
+        diesel::insert_into(gas_wallets::table)
+            .values(entry)
+            .execute(&mut conn)
+            .await
+            .map_err(err_str!(FundsManagerError::Db))?;
+
+        Ok(())
+    }
+
+    // --- Hot Wallets --- //
+
     /// Get all hot wallets
     pub async fn get_all_hot_wallets(&self) -> Result<Vec<HotWallet>, FundsManagerError> {
         let mut conn = self.get_db_conn().await?;

--- a/funds-manager/funds-manager-server/src/db/models.rs
+++ b/funds-manager/funds-manager-server/src/db/models.rs
@@ -164,3 +164,12 @@ pub struct GasWallet {
     pub status: String,
     pub created_at: SystemTime,
 }
+
+impl GasWallet {
+    /// Construct a new gas wallet
+    pub fn new(address: String) -> Self {
+        let id = Uuid::new_v4();
+        let status = GasWalletStatus::Inactive.to_string();
+        GasWallet { id, address, peer_id: None, status, created_at: SystemTime::now() }
+    }
+}

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -27,10 +27,10 @@ use funds_manager_api::{
     WITHDRAW_FEE_BALANCE_ROUTE, WITHDRAW_GAS_ROUTE, WITHDRAW_TO_HOT_WALLET_ROUTE,
 };
 use handlers::{
-    create_hot_wallet_handler, get_deposit_address_handler, get_fee_wallets_handler,
-    get_hot_wallet_balances_handler, index_fees_handler, quoter_withdraw_handler,
-    redeem_fees_handler, transfer_to_vault_handler, withdraw_fee_balance_handler,
-    withdraw_from_vault_handler, withdraw_gas_handler,
+    create_gas_wallet_handler, create_hot_wallet_handler, get_deposit_address_handler,
+    get_fee_wallets_handler, get_hot_wallet_balances_handler, index_fees_handler,
+    quoter_withdraw_handler, redeem_fees_handler, transfer_to_vault_handler,
+    withdraw_fee_balance_handler, withdraw_from_vault_handler, withdraw_gas_handler,
 };
 use middleware::{identity, with_hmac_auth, with_json_body};
 use relayer_client::RelayerClient;
@@ -340,6 +340,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(withdraw_gas_handler);
 
+    let add_gas_wallet = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas-wallets"))
+        .and(with_hmac_auth(server.clone()))
+        .and(with_server(server.clone()))
+        .and_then(create_gas_wallet_handler);
+
     // --- Hot Wallets --- //
 
     let create_hot_wallet = warp::post()
@@ -385,6 +392,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(withdraw_custody)
         .or(get_deposit_address)
         .or(withdraw_gas)
+        .or(add_gas_wallet)
         .or(get_balances)
         .or(withdraw_fee_balance)
         .or(transfer_to_vault)


### PR DESCRIPTION
### Purpose
This PR adds an endpoint for creating new gas wallets in the funds manager. These wallets are all marked as inactive and eligible to be allocated to a relayer upon request.

### Testing
- Created a few new gas wallets