### PR TITLE
funds-manager: Refill gas to active wallets

### DIFF
--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -24,6 +24,8 @@ pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
 
 /// The route to withdraw gas from custody
 pub const WITHDRAW_GAS_ROUTE: &str = "withdraw-gas";
+/// The route to refill gas for all active wallets
+pub const REFILL_GAS_ROUTE: &str = "refill-gas";
 /// The route to register a gas wallet for a peer
 pub const REGISTER_GAS_WALLET_ROUTE: &str = "register-gas-wallet";
 /// The route to report active peers
@@ -90,6 +92,13 @@ pub struct WithdrawGasRequest {
     pub amount: f64,
     /// The address to withdraw to
     pub destination_address: String,
+}
+
+/// The request body for refilling gas for all active wallets
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RefillGasRequest {
+    /// The amount of gas to top up each wallet to
+    pub amount: f64,
 }
 
 /// The response containing the gas wallet's address

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -129,6 +129,17 @@ impl CustodyClient {
         format!("hot-wallet-{address}")
     }
 
+    /// Get the hot wallet private key for a vault
+    pub async fn get_hot_wallet_private_key(
+        &self,
+        address: &str,
+    ) -> Result<LocalWallet, FundsManagerError> {
+        let secret_name = Self::hot_wallet_secret_name(address);
+        let secret_value = get_secret(&secret_name, &self.aws_config).await?;
+
+        LocalWallet::from_str(&secret_value).map_err(FundsManagerError::parse)
+    }
+
     /// Fetch the token balance at the given address for a wallet
     async fn get_token_balance(
         &self,

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -11,7 +11,7 @@ use ethers::middleware::SignerMiddleware;
 use ethers::prelude::abigen;
 use ethers::providers::{Http, Middleware, Provider};
 use ethers::signers::{LocalWallet, Signer};
-use ethers::types::{Address, TransactionReceipt, TransactionRequest, U256};
+use ethers::types::{Address, TransactionReceipt, TransactionRequest};
 use ethers::utils::format_units;
 use fireblocks_sdk::types::Transaction;
 use fireblocks_sdk::{
@@ -211,10 +211,11 @@ impl CustodyClient {
         let client = SignerMiddleware::new(provider, wallet);
 
         let to = Address::from_str(to).map_err(FundsManagerError::parse)?;
-        let amount = ethers::utils::parse_units(amount.to_string(), "ether")
+        let amount_units = ethers::utils::parse_units(amount.to_string(), "ether")
             .map_err(FundsManagerError::parse)?;
 
-        let tx = TransactionRequest::new().to(to).value(U256::from(amount));
+        info!("Transferring {amount} ETH to {to:#x}");
+        let tx = TransactionRequest::new().to(to).value(amount_units);
         let pending_tx =
             client.send_transaction(tx, None).await.map_err(FundsManagerError::arbitrum)?;
         pending_tx

--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -27,6 +27,17 @@ impl CustodyClient {
             .map_err(err_str!(FundsManagerError::Db))
     }
 
+    /// Get all active gas wallets
+    pub async fn get_active_gas_wallets(&self) -> Result<Vec<GasWallet>, FundsManagerError> {
+        let mut conn = self.get_db_conn().await?;
+        let active = GasWalletStatus::Active.to_string();
+        gas_wallets::table
+            .filter(gas_wallets::status.eq(active))
+            .load::<GasWallet>(&mut conn)
+            .await
+            .map_err(err_str!(FundsManagerError::Db))
+    }
+
     /// Find an inactive gas wallet
     pub async fn find_inactive_gas_wallet(&self) -> Result<GasWallet, FundsManagerError> {
         let mut conn = self.get_db_conn().await?;

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -25,10 +25,7 @@ impl CustodyClient {
         }
 
         // Fetch the wallet private key
-        let secret_name = Self::hot_wallet_secret_name(&wallet.address);
-        let private_key = get_secret(&secret_name, &self.aws_config).await?;
-        let wallet =
-            LocalWallet::from_str(private_key.as_str()).map_err(FundsManagerError::parse)?;
+        let wallet = self.get_hot_wallet_private_key(&wallet.address).await?;
 
         // Execute the erc20 transfer
         let tx = self.erc20_transfer(token_address, destination_address, amount, wallet).await?;

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -21,17 +21,17 @@ use error::FundsManagerError;
 use ethers::signers::LocalWallet;
 use fee_indexer::Indexer;
 use funds_manager_api::{
-    CreateHotWalletRequest, RegisterGasWalletRequest, ReportActivePeersRequest,
+    CreateHotWalletRequest, RefillGasRequest, RegisterGasWalletRequest, ReportActivePeersRequest,
     TransferToVaultRequest, WithdrawFeeBalanceRequest, WithdrawGasRequest,
     WithdrawToHotWalletRequest, GET_DEPOSIT_ADDRESS_ROUTE, GET_FEE_WALLETS_ROUTE, INDEX_FEES_ROUTE,
-    PING_ROUTE, REDEEM_FEES_ROUTE, REGISTER_GAS_WALLET_ROUTE, REPORT_ACTIVE_PEERS_ROUTE,
-    TRANSFER_TO_VAULT_ROUTE, WITHDRAW_CUSTODY_ROUTE, WITHDRAW_FEE_BALANCE_ROUTE,
-    WITHDRAW_GAS_ROUTE, WITHDRAW_TO_HOT_WALLET_ROUTE,
+    PING_ROUTE, REDEEM_FEES_ROUTE, REFILL_GAS_ROUTE, REGISTER_GAS_WALLET_ROUTE,
+    REPORT_ACTIVE_PEERS_ROUTE, TRANSFER_TO_VAULT_ROUTE, WITHDRAW_CUSTODY_ROUTE,
+    WITHDRAW_FEE_BALANCE_ROUTE, WITHDRAW_GAS_ROUTE, WITHDRAW_TO_HOT_WALLET_ROUTE,
 };
 use handlers::{
     create_gas_wallet_handler, create_hot_wallet_handler, get_deposit_address_handler,
     get_fee_wallets_handler, get_hot_wallet_balances_handler, index_fees_handler,
-    quoter_withdraw_handler, redeem_fees_handler, register_gas_wallet_handler,
+    quoter_withdraw_handler, redeem_fees_handler, refill_gas_handler, register_gas_wallet_handler,
     report_active_peers_handler, transfer_to_vault_handler, withdraw_fee_balance_handler,
     withdraw_from_vault_handler, withdraw_gas_handler,
 };
@@ -343,6 +343,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(withdraw_gas_handler);
 
+    let refill_gas = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas"))
+        .and(warp::path(REFILL_GAS_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<RefillGasRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(refill_gas_handler);
+
     let add_gas_wallet = warp::post()
         .and(warp::path("custody"))
         .and(warp::path("gas-wallets"))
@@ -415,6 +425,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(withdraw_custody)
         .or(get_deposit_address)
         .or(withdraw_gas)
+        .or(refill_gas)
         .or(report_active_peers)
         .or(register_gas_wallet)
         .or(add_gas_wallet)


### PR DESCRIPTION
### Purpose
This PR refactors the way in which we refill gas in the `funds-manager`. Specifically, we now refill gas by looking up active gas wallets and topping off their balances directly.

### Testing
- Registered a new wallet as active then refilled its gas to 0.1 ETH