### PR TITLE
funds-manager: execution-client: Add quote and price helpers

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/error.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/error.rs
@@ -1,0 +1,43 @@
+//! Error types for the execution client
+
+use std::fmt::Display;
+
+/// An error returned by the execution client
+#[derive(Debug, Clone)]
+pub enum ExecutionClientError {
+    /// An error returned by the execution client
+    Http(String),
+    /// An error parsing a value
+    Parse(String),
+}
+
+impl ExecutionClientError {
+    /// Create a new http error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn http<T: ToString>(e: T) -> Self {
+        ExecutionClientError::Http(e.to_string())
+    }
+
+    /// Create a new parse error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn parse<T: ToString>(e: T) -> Self {
+        ExecutionClientError::Parse(e.to_string())
+    }
+}
+
+impl Display for ExecutionClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            ExecutionClientError::Http(e) => format!("HTTP error: {e}"),
+            ExecutionClientError::Parse(e) => format!("Parse error: {e}"),
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl From<reqwest::Error> for ExecutionClientError {
+    fn from(e: reqwest::Error) -> Self {
+        ExecutionClientError::http(e)
+    }
+}

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -1,0 +1,64 @@
+//! Client for interacting with execution venues, currently this is the 0x swap
+//! API
+pub mod error;
+pub mod quotes;
+
+use std::sync::Arc;
+
+use reqwest::{Client, Url};
+use serde::Deserialize;
+
+use self::error::ExecutionClientError;
+
+/// The 0x api key header
+const API_KEY_HEADER: &str = "0x-api-key";
+
+/// The client for interacting with the execution venue
+#[derive(Clone)]
+pub struct ExecutionClient {
+    /// The API key to use for requests
+    api_key: String,
+    /// The base URL for the execution client
+    base_url: String,
+    /// The underlying HTTP client
+    http_client: Arc<Client>,
+}
+
+impl ExecutionClient {
+    /// Create a new client
+    pub fn new(api_key: String, base_url: String) -> Self {
+        Self { api_key, base_url, http_client: Arc::new(Client::new()) }
+    }
+
+    /// Get a full URL for a given endpoint
+    fn build_url(
+        &self,
+        endpoint: &str,
+        params: &[(&str, &str)],
+    ) -> Result<Url, ExecutionClientError> {
+        let url = if !endpoint.starts_with('/') {
+            format!("{}/{}", self.base_url, endpoint)
+        } else {
+            format!("{}{}", self.base_url, endpoint)
+        };
+
+        Url::parse_with_params(&url, params).map_err(ExecutionClientError::parse)
+    }
+
+    /// Send a get request to the execution venue
+    async fn send_get_request<T: for<'de> Deserialize<'de>>(
+        &self,
+        endpoint: &str,
+        params: &[(&str, &str)],
+    ) -> Result<T, ExecutionClientError> {
+        let url = self.build_url(endpoint, params)?;
+        self.http_client
+            .get(url)
+            .header(API_KEY_HEADER, &self.api_key)
+            .send()
+            .await?
+            .json::<T>()
+            .await
+            .map_err(ExecutionClientError::http)
+    }
+}

--- a/funds-manager/funds-manager-server/src/execution_client/quotes.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/quotes.rs
@@ -1,0 +1,80 @@
+//! Client methods for fetching quotes and prices from the execution venue
+
+use serde::Deserialize;
+
+use super::{error::ExecutionClientError, ExecutionClient};
+
+/// The price endpoint
+const PRICE_ENDPOINT: &str = "swap/v1/price";
+/// The quote endpoint
+const QUOTE_ENDPOINT: &str = "swap/v1/quote";
+
+/// The buy token url param
+const BUY_TOKEN: &str = "buyToken";
+/// The sell token url param
+const SELL_TOKEN: &str = "sellToken";
+/// The sell amount url param
+const SELL_AMOUNT: &str = "sellAmount";
+/// The taker address url param
+const TAKER_ADDRESS: &str = "takerAddress";
+
+/// The price response
+#[derive(Debug, Deserialize)]
+pub struct PriceResponse {
+    /// The price
+    pub price: String,
+}
+
+/// The subset of the quote response forwarded to consumers of this client
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionQuote {
+    /// The quoted price
+    pub price: String,
+    /// The submitting address
+    pub from: String,
+    /// The 0x swap contract address
+    pub to: String,
+    /// The calldata for the swap
+    pub data: String,
+    /// The value of the tx; should be zero
+    pub value: String,
+    /// The gas price used in the swap
+    pub gas_price: String,
+}
+
+impl ExecutionClient {
+    /// Fetch a price for an asset
+    pub async fn get_price(
+        &self,
+        buy_asset: &str,
+        sell_asset: &str,
+        amount: u128,
+    ) -> Result<f64, ExecutionClientError> {
+        let amount_str = amount.to_string();
+        let params =
+            [(BUY_TOKEN, buy_asset), (SELL_TOKEN, sell_asset), (SELL_AMOUNT, amount_str.as_str())];
+
+        let resp: PriceResponse = self.send_get_request(PRICE_ENDPOINT, &params).await?;
+        resp.price.parse::<f64>().map_err(ExecutionClientError::parse)
+    }
+
+    /// Fetch a quote for an asset
+    pub async fn get_quote(
+        &self,
+        buy_asset: &str,
+        sell_asset: &str,
+        amount: u128,
+        recipient: &str,
+    ) -> Result<ExecutionQuote, ExecutionClientError> {
+        let amount_str = amount.to_string();
+        let params = [
+            (BUY_TOKEN, buy_asset),
+            (SELL_TOKEN, sell_asset),
+            (SELL_AMOUNT, amount_str.as_str()),
+            (TAKER_ADDRESS, recipient),
+        ];
+
+        self.send_get_request(QUOTE_ENDPOINT, &params).await
+    }
+}

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -9,6 +9,7 @@
 pub mod custody_client;
 pub mod db;
 pub mod error;
+pub mod execution_client;
 pub mod fee_indexer;
 pub mod handlers;
 pub mod helpers;


### PR DESCRIPTION
### Purpose
This PR bootstraps the `ExecutionClient` and adds quote and price fetch helpers from the 0x swap API. We will have a human in the loop to begin with the quote API exposed directly. When a user accepts the quote they will send to the funds manager's swap API for execution.

### Testing
- Tested both APIs via temporary unit tests in the codebase