### PR TITLE
funds-manager: Ingest API changes from key rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,25 +94,6 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-primitives"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 0.99.18",
- "hex-literal",
- "itoa",
- "proptest",
- "ruint",
- "serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-primitives"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
@@ -145,21 +126,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7720130c58db647103587b0c39aad4e669eea261e256040301d6c7983fdbb461"
-dependencies = [
- "dunce",
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.76",
- "syn-solidity 0.3.2",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
@@ -186,7 +152,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.76",
- "syn-solidity 0.7.7",
+ "syn-solidity",
  "tiny-keccak",
 ]
 
@@ -202,19 +168,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.76",
- "syn-solidity 0.7.7",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa7c9a4354b1ff9f1c85adf22802af046e20e4bb55e19b9dc6ca8cbc6f7f4e5"
-dependencies = [
- "alloy-primitives 0.3.3",
- "alloy-sol-macro 0.3.2",
- "const-hex",
- "serde",
+ "syn-solidity",
 ]
 
 [[package]]
@@ -223,8 +177,8 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-macro 0.7.7",
+ "alloy-primitives",
+ "alloy-sol-macro",
  "const-hex",
  "serde",
 ]
@@ -320,10 +274,10 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-types 0.7.7",
+ "alloy-primitives",
+ "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -1391,7 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.76",
@@ -1478,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
 
 [[package]]
 name = "byteorder"
@@ -1645,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1656,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1687,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -1831,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -1896,7 +1850,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
@@ -1947,7 +1901,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1960,8 +1914,8 @@ name = "contracts-common"
 version = "0.1.0"
 source = "git+https://github.com/renegade-fi/renegade-contracts.git#c133f9c903d88b653e961de1bea63402b8cb9ac6"
 dependencies = [
- "alloy-primitives 0.7.7",
- "alloy-sol-types 0.7.7",
+ "alloy-primitives",
+ "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -3002,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "circuit-types",
  "common",
@@ -3172,7 +3126,7 @@ dependencies = [
 name = "funds-manager"
 version = "0.1.0"
 dependencies = [
- "alloy-sol-types 0.3.2",
+ "alloy-sol-types",
  "arbitrum-client",
  "aws-config",
  "aws-sdk-secretsmanager",
@@ -3431,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -4115,7 +4069,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -4920,7 +4874,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 2.0.76",
@@ -5240,7 +5194,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5584,7 +5538,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -5652,11 +5606,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6105,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -6169,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "atomic_float 1.0.0",
  "circuit-types",
@@ -6487,9 +6441,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -6530,7 +6484,7 @@ checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -6584,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -6673,7 +6627,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -7368,18 +7322,6 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397f229dc34c7b8231b6ef85502f9ca4e3425b8625e6d403bb74779e6b1917b5"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.76",
-]
-
-[[package]]
-name = "syn-solidity"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
@@ -7432,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "bus",
  "common",
@@ -7821,7 +7763,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.20",
+ "toml_edit",
 ]
 
 [[package]]
@@ -7835,17 +7777,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
@@ -7854,7 +7785,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow",
 ]
 
 [[package]]
@@ -8232,7 +8163,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#254260624e742cb5faf973a213b9dc0686536f8e"
+source = "git+https://github.com/renegade-fi/renegade.git#41712fbb77818687271cf71352e11b6f6691f717"
 dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",
@@ -8849,15 +8780,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -31,7 +31,7 @@ postgres-native-tls = "0.5"
 tokio-postgres = "0.7.7"
 
 # === Blockchain Interaction === #
-alloy-sol-types = "0.3.1"
+alloy-sol-types = "=0.7.7"
 ethers = "2"
 
 # === Renegade Dependencies === #

--- a/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
@@ -38,7 +38,7 @@ impl CustodyClient {
 
         // Filter out those that don't need refilling
         let mut wallets_to_fill: Vec<(String, f64)> = Vec::new(); // (address, fill amount)
-        for wallet in active_wallets {
+        for wallet in gas_wallets.into_iter() {
             let bal = self.get_ether_balance(&wallet.address).await?;
             if bal + GAS_REFILL_TOLERANCE < fill_to {
                 wallets_to_fill.push((wallet.address, fill_to - bal));
@@ -92,7 +92,7 @@ impl CustodyClient {
 
         // Update the gas wallet to be active, top up wallets, and return the key
         self.mark_gas_wallet_active(&gas_wallet.address, peer_id).await?;
-        self.refill_gas_for_active_wallets(DEFAULT_TOP_UP_AMOUNT).await?;
+        self.refill_gas_wallets(DEFAULT_TOP_UP_AMOUNT).await?;
         Ok(secret_value)
     }
 

--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -3,6 +3,7 @@
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use renegade_util::err_str;
+use tracing::info;
 use uuid::Uuid;
 
 use crate::db::models::{GasWallet, GasWalletStatus, HotWallet};

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -31,7 +31,7 @@ impl CustodyClient {
         // Execute the erc20 transfer
         let tx = self.erc20_transfer(token_address, destination_address, amount, wallet).await?;
         info!(
-            "Withdrew {amount} {token_address} from hot wallet to {destination_address}. Tx: {:#}",
+            "Withdrew {amount} {token_address} from hot wallet to {destination_address}. Tx: {:?}",
             tx.transaction_hash
         );
 


### PR DESCRIPTION
### Purpose
This changes the funds manager to be compatible with the new key rotation changes in the relayer. Specifically, this changes the shape of requests to the relayer that now do not necessarily send the whole keychain. As well, the auth between the client and the relayer now uses the wallet's symmetric key.

### Testing
- [ ] Deploy to testnet and test the various flows