### PR TITLE
funds-manager: api: types: quoters: add `estimated_gas` field to `ExecutionQuote`

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -73,6 +73,9 @@ pub struct ExecutionQuote {
     /// The gas price used in the swap
     #[serde(with = "u256_string_serialization")]
     pub gas_price: U256,
+    /// The estimated gas for the swap
+    #[serde(with = "u256_string_serialization")]
+    pub estimated_gas: U256,
 }
 
 /// The request body for fetching a quote from the execution venue


### PR DESCRIPTION
This PR adds the [`estimatedGas` field](https://0x.org/docs/1.0/0x-swap-api/api-references/get-swap-v1-quote#response) to the subset of Matcha `/swap/v1/quote` response fields captured by the `ExecutionQuote` struct.

This is purely for convenience, we would like to be able to view the all-in estimated gas cost when considering an execution.