### PR TITLE
auth-server: Initialze DB migrations and api keys table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "clap",
+ "diesel",
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",

--- a/auth-server/Cargo.toml
+++ b/auth-server/Cargo.toml
@@ -12,6 +12,9 @@ reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 
+# === Database === #
+diesel = { version = "2", features = ["postgres"] }
+
 # === Misc Dependencies === #
 bytes = "1.0"
 futures-util = "0.3"

--- a/auth-server/diesel.toml
+++ b/auth-server/diesel.toml
@@ -1,0 +1,9 @@
+# For documentation on how to configure this file,
+# see https://diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"
+custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
+
+[migrations_directory]
+dir = "./migrations"

--- a/auth-server/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/auth-server/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/auth-server/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/auth-server/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/auth-server/migrations/2024-10-21-205301_add_api_keys_table/down.sql
+++ b/auth-server/migrations/2024-10-21-205301_add_api_keys_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the api_keys table
+DROP TABLE IF EXISTS api_keys;

--- a/auth-server/migrations/2024-10-21-205301_add_api_keys_table/up.sql
+++ b/auth-server/migrations/2024-10-21-205301_add_api_keys_table/up.sql
@@ -1,0 +1,9 @@
+-- Create the api_keys table
+CREATE TABLE api_keys (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    encrypted_key VARCHAR NOT NULL UNIQUE,
+    username VARCHAR NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE
+);
+

--- a/auth-server/src/main.rs
+++ b/auth-server/src/main.rs
@@ -11,6 +11,9 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![feature(trivial_bounds)]
 
+#[allow(missing_docs, clippy::missing_docs_in_private_items)]
+pub(crate) mod schema;
+
 use bytes::Bytes;
 use clap::Parser;
 use reqwest::{Client, Method, StatusCode};

--- a/auth-server/src/schema.rs
+++ b/auth-server/src/schema.rs
@@ -1,0 +1,11 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    api_keys (id) {
+        id -> Uuid,
+        encrypted_key -> Varchar,
+        username -> Varchar,
+        created_at -> Timestamp,
+        is_active -> Bool,
+    }
+}


### PR DESCRIPTION
### Purpose
This PR initializes the db migration setup for the auth server as well and creates the API keys table through the first migration. This table stores both the API key IDs and encrypted API secrets.

### Testing
- Applied the migration