### PR TITLE
auth-server: Use api keys to authenticate proxy requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,17 +276,17 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
- "circuit-types",
- "circuits",
- "common",
- "constants",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "contracts-common",
  "ethers",
  "itertools 0.12.1",
@@ -296,13 +296,13 @@ dependencies = [
  "num-traits",
  "postcard",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "renegade-metrics",
  "ruint",
  "serde",
  "serde_with",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
 ]
 
 [[package]]
@@ -723,8 +723,10 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "diesel",
  "diesel-async",
+ "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",
@@ -738,7 +740,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "uuid 1.10.0",
  "warp",
 ]
@@ -1642,7 +1644,18 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "circuit-macros"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1653,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1663,8 +1676,8 @@ dependencies = [
  "async-trait",
  "bigdecimal 0.3.1",
  "byteorder",
- "circuit-macros",
- "constants",
+ "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "futures",
  "hex 0.4.3",
  "itertools 0.10.5",
@@ -1676,7 +1689,38 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "circuit-types"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-mpc",
+ "ark-serialize 0.4.2",
+ "async-trait",
+ "bigdecimal 0.3.1",
+ "byteorder",
+ "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "futures",
+ "hex 0.4.3",
+ "itertools 0.10.5",
+ "jf-primitives",
+ "k256",
+ "lazy_static",
+ "mpc-plonk",
+ "mpc-relation",
+ "num-bigint",
+ "num-integer",
+ "rand 0.8.5",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "serde",
  "serde_json",
 ]
@@ -1684,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -1692,9 +1736,9 @@ dependencies = [
  "ark-mpc",
  "bigdecimal 0.3.1",
  "bitvec 1.0.1",
- "circuit-macros",
- "circuit-types",
- "constants",
+ "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "futures",
  "itertools 0.10.5",
  "jf-primitives",
@@ -1704,11 +1748,41 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "serde",
  "serde_json",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+]
+
+[[package]]
+name = "circuits"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+dependencies = [
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-mpc",
+ "bigdecimal 0.3.1",
+ "bitvec 1.0.1",
+ "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "futures",
+ "itertools 0.10.5",
+ "jf-primitives",
+ "lazy_static",
+ "mpc-plonk",
+ "mpc-relation",
+ "num-bigint",
+ "num-integer",
+ "rand 0.8.5",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "serde",
+ "serde_json",
+ "tracing",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
 ]
 
 [[package]]
@@ -1828,15 +1902,15 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
 dependencies = [
  "ark-mpc",
  "async-trait",
- "base64 0.13.1",
+ "base64 0.22.1",
  "bimap",
- "circuit-types",
- "circuits",
- "constants",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "contracts-common",
  "crossbeam",
  "derivative",
@@ -1853,7 +1927,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "renegade-dealer-api 0.1.0 (git+https://github.com/renegade-fi/renegade-dealer.git)",
  "serde",
  "serde_json",
@@ -1861,7 +1935,47 @@ dependencies = [
  "signature 2.2.0",
  "tokio",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "common"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+dependencies = [
+ "ark-mpc",
+ "async-trait",
+ "base64 0.13.1",
+ "bimap",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "contracts-common",
+ "crossbeam",
+ "derivative",
+ "ed25519-dalek 1.0.1",
+ "ethers",
+ "hmac",
+ "indexmap 2.5.0",
+ "itertools 0.10.5",
+ "k256",
+ "lazy_static",
+ "libp2p",
+ "libp2p-identity",
+ "metrics",
+ "num-bigint",
+ "num-traits",
+ "rand 0.8.5",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "renegade-dealer-api 0.1.0 (git+https://github.com/renegade-fi/renegade-dealer.git)",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "signature 2.2.0",
+ "tokio",
+ "tracing",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "uuid 1.10.0",
 ]
 
@@ -1886,23 +2000,23 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "warp",
 ]
 
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
  "bimap",
- "circuit-types",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "clap",
  "colored",
- "common",
- "constants",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "ed25519-dalek 1.0.1",
  "ethers",
  "json",
@@ -1914,7 +2028,7 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "url",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
 ]
 
 [[package]]
@@ -1945,7 +2059,18 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ed-on-bn254",
+ "ark-mpc",
+]
+
+[[package]]
+name = "constants"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3001,19 +3126,41 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
 dependencies = [
  "base64 0.22.1",
- "circuit-types",
- "common",
- "constants",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "ethers",
+ "hex 0.4.3",
+ "http 0.2.12",
+ "itertools 0.10.5",
+ "num-bigint",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "external-api"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+dependencies = [
+ "base64 0.22.1",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "hex 0.4.3",
  "itertools 0.10.5",
  "num-bigint",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "serde",
  "serde_json",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "uuid 1.10.0",
 ]
 
@@ -3180,15 +3327,15 @@ dependencies = [
  "bb8",
  "bigdecimal 0.4.5",
  "bytes",
- "circuit-types",
- "circuits",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "clap",
- "common",
- "constants",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "diesel",
  "diesel-async",
  "ethers",
- "external-api",
+ "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "fireblocks-sdk",
  "funds-manager-api",
  "futures",
@@ -3200,14 +3347,14 @@ dependencies = [
  "num-bigint",
  "postgres-native-tls",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "reqwest 0.12.8",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "uuid 1.10.0",
  "warp",
 ]
@@ -3217,7 +3364,7 @@ name = "funds-manager-api"
 version = "0.1.0"
 dependencies = [
  "ethers",
- "external-api",
+ "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "hex 0.4.3",
  "hmac",
  "http 0.2.12",
@@ -3441,11 +3588,11 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "bincode",
- "circuit-types",
- "common",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "hmac",
  "libp2p",
  "openraft",
@@ -3453,7 +3600,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "uuid 1.10.0",
 ]
 
@@ -4123,19 +4270,19 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "ark-mpc",
- "circuit-types",
- "circuits",
- "common",
- "constants",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "crossbeam",
  "gossip-api",
  "libp2p",
  "libp2p-core",
  "tokio",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "uuid 1.10.0",
 ]
 
@@ -5598,14 +5745,14 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
- "common",
- "constants",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "create2",
- "external-api",
+ "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "futures",
  "futures-util",
  "hex 0.3.2",
@@ -5624,7 +5771,7 @@ dependencies = [
  "tracing",
  "tungstenite 0.18.0",
  "url",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "web3",
 ]
 
@@ -6111,13 +6258,32 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal 0.3.1",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "ethers-core",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-bigint",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "renegade-crypto"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-mpc",
+ "bigdecimal 0.3.1",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "ethers-core",
  "itertools 0.10.5",
  "lazy_static",
@@ -6175,16 +6341,16 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "atomic_float 1.1.0",
- "circuit-types",
- "common",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "lazy_static",
  "metrics",
  "num-bigint",
  "tracing",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
 ]
 
 [[package]]
@@ -6193,9 +6359,9 @@ version = "0.1.0"
 dependencies = [
  "arbitrum-client",
  "async-trait",
- "common",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "config",
- "external-api",
+ "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "futures-util",
  "hyper 0.14.30",
  "matchit",
@@ -6208,7 +6374,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "tungstenite 0.18.0",
- "util",
+ "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
 ]
 
 [[package]]
@@ -7427,10 +7593,10 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
 dependencies = [
  "bus",
- "common",
+ "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "futures",
  "serde",
  "tokio",
@@ -8216,13 +8382,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
 dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",
  "chrono",
- "circuit-types",
- "constants",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
  "crossbeam",
  "eyre",
  "futures",
@@ -8241,7 +8407,45 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-serde",
+ "tracing-subscriber 0.3.18",
+]
+
+[[package]]
+name = "util"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+dependencies = [
+ "ark-ec",
+ "ark-serialize 0.4.2",
+ "chrono",
+ "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "crossbeam",
+ "eyre",
+ "futures",
+ "hex 0.4.3",
+ "json",
+ "libp2p",
+ "metrics",
+ "metrics-exporter-statsd",
+ "metrics-tracing-context",
+ "metrics-util",
+ "num-bigint",
+ "num-traits",
+ "opentelemetry",
+ "opentelemetry-datadog",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "rand 0.8.5",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "serde",
  "serde_json",
  "tokio",

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -9,6 +9,9 @@
 use serde::Deserialize;
 use uuid::Uuid;
 
+/// The Renegade API key header
+pub const RENEGADE_API_KEY_HEADER: &str = "X-Renegade-Api-Key";
+
 // ----------------------
 // | API Key Management |
 // ----------------------

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -26,7 +26,11 @@ rand = "0.8.5"
 
 # === Renegade Dependencies === #
 auth-server-api = { path = "../auth-server-api" }
-renegade-utils = { package = "util", git = "https://github.com/renegade-fi/renegade" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
+    "auth",
+] }
 
 # === Misc Dependencies === #
 base64 = "0.22.1"

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -2,20 +2,29 @@
 
 use thiserror::Error;
 
+use crate::ApiError;
+
 /// Custom error type for server errors
 #[derive(Error, Debug)]
 pub enum AuthServerError {
+    /// API key inactive
+    #[error("API key inactive")]
+    ApiKeyInactive,
     /// Database connection error
     #[error("Database connection error: {0}")]
     DatabaseConnection(String),
-
     /// Encryption error
     #[error("Encryption error: {0}")]
     Encryption(String),
-
     /// Decryption error
     #[error("Decryption error: {0}")]
     Decryption(String),
+    /// Error serializing or deserializing a stored value
+    #[error("Error serializing/deserializing a stored value: {0}")]
+    Serde(String),
+    /// Unauthorized
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
 }
 
 impl AuthServerError {
@@ -33,6 +42,27 @@ impl AuthServerError {
     pub fn decryption<T: ToString>(msg: T) -> Self {
         Self::Decryption(msg.to_string())
     }
+
+    /// Create a new serde error
+    pub fn serde<T: ToString>(msg: T) -> Self {
+        Self::Serde(msg.to_string())
+    }
+
+    /// Create a new unauthorized error
+    pub fn unauthorized<T: ToString>(msg: T) -> Self {
+        Self::Unauthorized(msg.to_string())
+    }
 }
 
 impl warp::reject::Reject for AuthServerError {}
+
+impl From<AuthServerError> for ApiError {
+    fn from(err: AuthServerError) -> Self {
+        match err {
+            AuthServerError::ApiKeyInactive | AuthServerError::Unauthorized(_) => {
+                ApiError::Unauthorized
+            },
+            _ => ApiError::InternalError(err.to_string()),
+        }
+    }
+}

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -19,7 +19,7 @@ mod server;
 
 use auth_server_api::{API_KEYS_PATH, DEACTIVATE_API_KEY_PATH};
 use clap::Parser;
-use renegade_utils::telemetry::configure_telemetry;
+use renegade_util::telemetry::configure_telemetry;
 use reqwest::StatusCode;
 use serde_json::json;
 use std::net::SocketAddr;
@@ -75,6 +75,9 @@ pub enum ApiError {
     /// A bad request error
     #[error("Bad request: {0}")]
     BadRequest(String),
+    /// An unauthorized error
+    #[error("Unauthorized")]
+    Unauthorized,
 }
 
 // Implement warp::reject::Reject for ApiError
@@ -159,6 +162,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Rejection> {
                 (StatusCode::INTERNAL_SERVER_ERROR, DEFAULT_INTERNAL_SERVER_ERROR_MESSAGE)
             },
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.as_str()),
+            ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized"),
         };
 
         Ok(json_error(message, code))

--- a/auth/auth-server/src/models.rs
+++ b/auth/auth-server/src/models.rs
@@ -1,17 +1,21 @@
 //! DB model types for the auth server
 #![allow(missing_docs, clippy::missing_docs_in_private_items)]
+#![allow(trivial_bounds)]
+
+use std::time::SystemTime;
 
 use crate::schema::api_keys;
 use diesel::prelude::*;
-use diesel::sql_types::Timestamp;
 use uuid::Uuid;
 
-#[derive(Queryable)]
+#[derive(Queryable, Selectable, Clone)]
+#[diesel(table_name = api_keys)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ApiKey {
     pub id: Uuid,
     pub encrypted_key: String,
     pub description: String,
-    pub created_at: Timestamp,
+    pub created_at: SystemTime,
     pub is_active: bool,
 }
 

--- a/auth/auth-server/src/server/handle_proxy.rs
+++ b/auth/auth-server/src/server/handle_proxy.rs
@@ -3,14 +3,18 @@
 //! At a high level the server must first authenticate the request, then forward
 //! it to the relayer with admin authentication
 
+use auth_server_api::RENEGADE_API_KEY_HEADER;
 use bytes::Bytes;
-use http::Method;
+use http::{HeaderMap, Method};
+use renegade_api::auth::validate_expiring_auth;
+use renegade_common::types::wallet::keychain::HmacKey;
 use tracing::error;
+use uuid::Uuid;
 use warp::{reject::Rejection, reply::Reply};
 
-use crate::ApiError;
+use crate::{error::AuthServerError, ApiError};
 
-use super::Server;
+use super::{helpers::aes_decrypt, Server};
 
 /// Handle a proxied request
 impl Server {
@@ -19,9 +23,13 @@ impl Server {
         &self,
         path: warp::path::FullPath,
         method: Method,
-        headers: warp::hyper::HeaderMap,
+        mut headers: warp::hyper::HeaderMap,
         body: Bytes,
     ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        self.authorize_request(path.as_str(), &mut headers, &body).await?;
+
+        // Forward the request to the relayer
         let url = format!("{}{}", self.relayer_url, path.as_str());
         let req = self.client.request(method, &url).headers(headers).body(body);
 
@@ -47,5 +55,50 @@ impl Server {
                 Err(warp::reject::custom(ApiError::InternalError(e.to_string())))
             },
         }
+    }
+
+    /// Authorize a request
+    async fn authorize_request(
+        &self,
+        path: &str,
+        headers: &mut HeaderMap,
+        body: &[u8],
+    ) -> Result<(), ApiError> {
+        // Check API auth
+        let api_key = headers
+            .remove(RENEGADE_API_KEY_HEADER)
+            .and_then(|h| h.to_str().ok().map(String::from)) // Convert to String
+            .and_then(|s| Uuid::parse_str(&s).ok()) // Use &s to parse
+            .ok_or(AuthServerError::unauthorized("Invalid or missing Renegade API key"))?;
+
+        self.check_api_key_auth(api_key, path, headers, body).await?;
+        Ok(())
+    }
+
+    /// Check that a request is authorized with a given API key and an HMAC of
+    /// the request using the API secret
+    async fn check_api_key_auth(
+        &self,
+        api_key: Uuid,
+        path: &str,
+        headers: &HeaderMap,
+        body: &[u8],
+    ) -> Result<(), AuthServerError> {
+        let api_secret = self.get_api_secret(api_key).await?;
+        let key = HmacKey::from_base64_string(&api_secret).map_err(AuthServerError::serde)?;
+
+        validate_expiring_auth(path, headers, body, &key).map_err(AuthServerError::unauthorized)
+    }
+
+    /// Get the API secret for a given API key
+    async fn get_api_secret(&self, api_key: Uuid) -> Result<String, AuthServerError> {
+        // Fetch the API key entry then decrypt the API secret
+        let entry = self.get_api_key_entry(api_key).await?;
+        let decrypted = aes_decrypt(&entry.encrypted_key, &self.encryption_key)?;
+        if !entry.is_active {
+            return Err(AuthServerError::ApiKeyInactive);
+        }
+
+        Ok(decrypted)
     }
 }

--- a/auth/auth-server/src/server/queries.rs
+++ b/auth/auth-server/src/server/queries.rs
@@ -4,11 +4,30 @@ use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
 
-use crate::{models::NewApiKey, schema::api_keys};
+use crate::{
+    models::{ApiKey, NewApiKey},
+    schema::api_keys,
+};
 
 use super::{AuthServerError, Server};
 
 impl Server {
+    // --- Getters --- //
+
+    /// Get the API key entry for a given key
+    pub async fn get_api_key_entry(&self, api_key: Uuid) -> Result<ApiKey, AuthServerError> {
+        let mut conn = self.get_db_conn().await?;
+        api_keys::table
+            .filter(api_keys::id.eq(api_key))
+            .limit(1)
+            .load::<ApiKey>(&mut conn)
+            .await
+            .map_err(AuthServerError::db)
+            .map(|res| res[0].clone())
+    }
+
+    // --- Setters --- //
+
     /// Add a new API key to the database
     pub async fn add_key_query(&self, new_key: NewApiKey) -> Result<(), AuthServerError> {
         let mut conn = self.get_db_conn().await?;


### PR DESCRIPTION
### Purpose
This PR uses the allocated API keys to authenticate an proxy request to the auth server. Specifically the flow is:
- Retrieve the user's encrypted API secret from the database using their API key as a key
- Decrypt the API secret using the server's decryption key
- Check an expiring HMAC on the request using the decrypted API secret
- If this passes, forward the request to the relayer

### Todo
- Check the path to ensure it's an allowed path
- Attach admin auth to the request

### Testing
- Built a client and allocated an API key for the client, verified that the client was able to call relayer methods through the auth server