### PR TITLE
auth-server: Use admin auth to proxy relayer requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
+checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -137,7 +137,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -149,11 +149,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -169,7 +169,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
  "syn-solidity",
 ]
 
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "approx"
@@ -276,17 +276,17 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types",
+ "circuits",
+ "common",
+ "constants",
  "contracts-common",
  "ethers",
  "itertools 0.12.1",
@@ -296,13 +296,14 @@ dependencies = [
  "num-traits",
  "postcard",
  "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "renegade-crypto",
  "renegade-metrics",
  "ruint",
  "serde",
  "serde_with",
+ "tokio",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
 ]
 
 [[package]]
@@ -671,7 +672,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -723,13 +724,13 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "common",
  "diesel",
  "diesel-async",
- "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "external-api",
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "native-tls",
  "postgres-native-tls",
  "rand 0.8.5",
@@ -740,8 +741,8 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "uuid 1.10.0",
+ "util",
+ "uuid 1.11.0",
  "warp",
 ]
 
@@ -750,7 +751,7 @@ name = "auth-server-api"
 version = "0.1.0"
 dependencies = [
  "serde",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -761,7 +762,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -772,9 +773,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.7"
+version = "1.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8191fb3091fa0561d1379ef80333c3c7191c6f0435d986e85821bcf7acbd1126"
+checksum = "7198e6f03240fdceba36656d8be440297b6b82270325908c7381f37d826a74f6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -834,14 +835,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.48.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f0ed64c48d8d703d93791e5315f9c12789f7280e8ee7c2c8fe8c1bc5d91907"
+checksum = "05a5d3faceba815f3a81039e0c6952e7afad1467c0e2378d28f642c2a5fb299b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -862,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b90cfe6504115e13c41d3ea90286ede5aa14da294f3fe077027a6e83850843c"
+checksum = "0dc2faec3205d496c7e57eff685dd944203df7ce16a4116d0281c44021788a7b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -884,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.45.0"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167c0fad1f212952084137308359e8e4c4724d1c643038ce163f06de9662c1d0"
+checksum = "c93c241f52bc5e0476e259c953234dab7e2a35ee207ee202e86c0095ec4951dc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -906,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.44.0"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb5f98188ec1435b68097daa2a37d74b9d17c9caa799466338a8d1544e71b9d"
+checksum = "b259429be94a3459fa1b00c5684faee118d74f9577cc50aebadc36e507c63b5f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1002,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce695746394772e7000b39fe073095db6d45a862d0767dd5ad0ac0d7f8eb87"
+checksum = "a065c0fe6fdbdf9f11817eb68582b2ab4aff9e9c39e986ae48f7ec576c6322db"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1017,7 +1018,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body 1.0.1",
  "httparse",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "once_cell",
  "pin-project-lite",
@@ -1106,7 +1107,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "itoa",
  "matchit",
  "memchr",
@@ -1201,9 +1202,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bb8"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
+checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -1393,7 +1394,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
  "syn_derive",
 ]
 
@@ -1477,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -1489,9 +1490,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1570,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.24"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812acba72f0a070b003d3697490d2b55b837230ae7c6c6497f05cc2ddbb8d938"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1644,18 +1645,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
-dependencies = [
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "circuit-macros"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1666,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1676,8 +1666,8 @@ dependencies = [
  "async-trait",
  "bigdecimal 0.3.1",
  "byteorder",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuit-macros",
+ "constants",
  "futures",
  "hex 0.4.3",
  "itertools 0.10.5",
@@ -1689,38 +1679,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "circuit-types"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "ark-serialize 0.4.2",
- "async-trait",
- "bigdecimal 0.3.1",
- "byteorder",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "futures",
- "hex 0.4.3",
- "itertools 0.10.5",
- "jf-primitives",
- "k256",
- "lazy_static",
- "mpc-plonk",
- "mpc-relation",
- "num-bigint",
- "num-integer",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "renegade-crypto",
  "serde",
  "serde_json",
 ]
@@ -1728,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -1736,9 +1695,9 @@ dependencies = [
  "ark-mpc",
  "bigdecimal 0.3.1",
  "bitvec 1.0.1",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuit-macros",
+ "circuit-types",
+ "constants",
  "futures",
  "itertools 0.10.5",
  "jf-primitives",
@@ -1748,48 +1707,18 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
-]
-
-[[package]]
-name = "circuits"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
-dependencies = [
- "ark-crypto-primitives",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "bigdecimal 0.3.1",
- "bitvec 1.0.1",
- "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "futures",
- "itertools 0.10.5",
- "jf-primitives",
- "lazy_static",
- "mpc-plonk",
- "mpc-relation",
- "num-bigint",
- "num-integer",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
- "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1797,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1816,7 +1745,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -1902,22 +1831,22 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-mpc",
  "async-trait",
  "base64 0.22.1",
  "bimap",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuit-types",
+ "circuits",
+ "constants",
  "contracts-common",
  "crossbeam",
  "derivative",
  "ed25519-dalek 1.0.1",
  "ethers",
  "hmac",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itertools 0.10.5",
  "k256",
  "lazy_static",
@@ -1927,7 +1856,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "renegade-crypto",
  "renegade-dealer-api 0.1.0 (git+https://github.com/renegade-fi/renegade-dealer.git)",
  "serde",
  "serde_json",
@@ -1935,48 +1864,8 @@ dependencies = [
  "signature 2.2.0",
  "tokio",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "uuid 1.10.0",
-]
-
-[[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
-dependencies = [
- "ark-mpc",
- "async-trait",
- "base64 0.13.1",
- "bimap",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "contracts-common",
- "crossbeam",
- "derivative",
- "ed25519-dalek 1.0.1",
- "ethers",
- "hmac",
- "indexmap 2.5.0",
- "itertools 0.10.5",
- "k256",
- "lazy_static",
- "libp2p",
- "libp2p-identity",
- "metrics",
- "num-bigint",
- "num-traits",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "renegade-dealer-api 0.1.0 (git+https://github.com/renegade-fi/renegade-dealer.git)",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "signature 2.2.0",
- "tokio",
- "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.10.0",
+ "util",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -2000,23 +1889,23 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
  "warp",
 ]
 
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
  "bimap",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types",
  "clap",
  "colored",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common",
+ "constants",
  "ed25519-dalek 1.0.1",
  "ethers",
  "json",
@@ -2028,7 +1917,7 @@ dependencies = [
  "toml 0.5.11",
  "tracing",
  "url",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
 ]
 
 [[package]]
@@ -2059,18 +1948,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ed-on-bn254",
- "ark-mpc",
-]
-
-[[package]]
-name = "constants"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2081,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "contracts-common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-contracts.git#d5e33f3e66145e693dbb0b18e26b7f5794d9503b"
+source = "git+https://github.com/renegade-fi/renegade-contracts.git#f7b7dced3fae359185690dff7e63c356b7d6effb"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2160,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "critical-section"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -2307,7 +2185,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2331,7 +2209,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2342,7 +2220,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2412,7 +2290,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2432,7 +2310,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
  "unicode-xid",
 ]
 
@@ -2453,7 +2331,7 @@ dependencies = [
  "num-traits",
  "pq-sys",
  "r2d2",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -2480,7 +2358,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2489,7 +2367,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2572,7 +2450,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2941,7 +2819,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.83",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -2959,7 +2837,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -2985,7 +2863,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.79",
+ "syn 2.0.83",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3126,42 +3004,23 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "base64 0.22.1",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuit-types",
+ "common",
+ "constants",
  "ethers",
  "hex 0.4.3",
  "http 0.2.12",
  "itertools 0.10.5",
  "num-bigint",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "thiserror",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "uuid 1.10.0",
-]
-
-[[package]]
-name = "external-api"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
-dependencies = [
- "base64 0.22.1",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "hex 0.4.3",
- "itertools 0.10.5",
- "num-bigint",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "serde",
- "serde_json",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.10.0",
+ "util",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -3327,15 +3186,15 @@ dependencies = [
  "bb8",
  "bigdecimal 0.4.5",
  "bytes",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types",
+ "circuits",
  "clap",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common",
+ "constants",
  "diesel",
  "diesel-async",
  "ethers",
- "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "external-api",
  "fireblocks-sdk",
  "funds-manager-api",
  "futures",
@@ -3347,15 +3206,15 @@ dependencies = [
  "num-bigint",
  "postgres-native-tls",
  "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "renegade-crypto",
  "reqwest 0.12.8",
  "serde",
  "serde_json",
  "tokio",
  "tokio-postgres",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.10.0",
+ "util",
+ "uuid 1.11.0",
  "warp",
 ]
 
@@ -3364,7 +3223,7 @@ name = "funds-manager-api"
 version = "0.1.0"
 dependencies = [
  "ethers",
- "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "external-api",
  "hex 0.4.3",
  "hmac",
  "http 0.2.12",
@@ -3373,7 +3232,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -3390,9 +3249,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3405,9 +3264,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3415,15 +3274,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3433,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-locks"
@@ -3449,26 +3308,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -3482,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3563,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -3588,11 +3447,11 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "bincode",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types",
+ "common",
  "hmac",
  "libp2p",
  "openraft",
@@ -3600,8 +3459,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.10.0",
+ "util",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -3627,7 +3486,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util 0.7.12",
@@ -3646,7 +3505,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util 0.7.12",
@@ -3688,6 +3547,12 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hashers"
@@ -3866,9 +3731,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3890,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3916,7 +3781,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs",
@@ -3932,9 +3797,9 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3947,7 +3812,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -3960,7 +3825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -3974,7 +3839,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3993,7 +3858,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -4126,12 +3991,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -4155,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -4270,20 +4135,21 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-mpc",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "circuits 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types",
+ "circuits",
+ "common",
+ "constants",
  "crossbeam",
+ "external-api",
  "gossip-api",
  "libp2p",
  "libp2p-core",
  "tokio",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "uuid 1.10.0",
+ "util",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -4297,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4435,9 +4301,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -4701,7 +4567,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb791d015f8947acf5a7f62bd28d00f289bb7ea98cfbe3ffec1d061eee12df12"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -4722,7 +4588,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -5069,26 +4935,23 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -5129,9 +4992,9 @@ dependencies = [
 
 [[package]]
 name = "openraft"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f04a57ce93dda863229cc4ec5598f5c6d7e97cf71464c14e8488f763e0bcbb6"
+checksum = "c99ea08834a7786c6b19a6a40163291d55933889079af2caed24230358d4467a"
 dependencies = [
  "anyerror",
  "byte-unit",
@@ -5151,22 +5014,22 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.9.16"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1762f82298d483bc8201671faa584838391cc9a25b8f0c9db0ba04d2e909e939"
+checksum = "226ce477d851088815fdbd05a35921960edeb8767427b2369b424fa57e303ae5"
 dependencies = [
  "chrono",
  "proc-macro2",
  "quote",
  "semver 1.0.23",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -5185,7 +5048,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -5196,9 +5059,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -5214,7 +5077,7 @@ checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
  "futures-core",
  "futures-sink",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -5230,7 +5093,7 @@ checksum = "3e09667367cb509f10d7cf5960a83f9c4d96e93715f750b164b4b98d46c3cbf4"
 dependencies = [
  "futures-core",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itertools 0.11.0",
  "once_cell",
  "opentelemetry",
@@ -5324,9 +5187,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -5490,9 +5353,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.13"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -5506,7 +5369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -5549,7 +5412,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -5572,22 +5435,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -5734,25 +5597,25 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common",
+ "constants",
  "create2",
- "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "external-api",
  "futures",
  "futures-util",
  "hex 0.3.2",
@@ -5771,7 +5634,7 @@ dependencies = [
  "tracing",
  "tungstenite 0.18.0",
  "url",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
  "web3",
 ]
 
@@ -5847,9 +5710,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6131,9 +5994,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.1.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -6258,32 +6121,13 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal 0.3.1",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "ethers-core",
- "itertools 0.10.5",
- "lazy_static",
- "num-bigint",
- "rand 0.8.5",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "renegade-crypto"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-mpc",
- "bigdecimal 0.3.1",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "constants",
  "ethers-core",
  "itertools 0.10.5",
  "lazy_static",
@@ -6308,7 +6152,7 @@ dependencies = [
  "renegade-dealer-api 0.1.0",
  "serde_json",
  "tokio",
- "uuid 1.10.0",
+ "uuid 1.11.0",
  "warp",
 ]
 
@@ -6322,7 +6166,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -6335,22 +6179,22 @@ dependencies = [
  "k256",
  "serde",
  "serde_json",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "atomic_float 1.1.0",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "circuit-types",
+ "common",
  "lazy_static",
  "metrics",
  "num-bigint",
  "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
 ]
 
 [[package]]
@@ -6359,11 +6203,11 @@ version = "0.1.0"
 dependencies = [
  "arbitrum-client",
  "async-trait",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common",
  "config",
- "external-api 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "external-api",
  "futures-util",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "matchit",
  "price-reporter",
  "serde",
@@ -6374,7 +6218,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber 0.3.18",
  "tungstenite 0.18.0",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "util",
 ]
 
 [[package]]
@@ -6391,7 +6235,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -6438,7 +6282,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-tls 0.6.0",
  "hyper-util",
@@ -6530,7 +6374,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.10.0",
+ "uuid 1.11.0",
 ]
 
 [[package]]
@@ -6698,9 +6542,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -6741,9 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -6768,9 +6612,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "rusty-fork"
@@ -6830,21 +6674,21 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "22760a375f81a31817aeaf6f5081e9ccb7ffd7f2da1809a6e3fc82b6656f10d5"
 dependencies = [
  "cfg-if",
- "derive_more 0.99.18",
+ "derive_more 1.0.0",
  "parity-scale-codec 3.6.12",
  "scale-info-derive",
 ]
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "abc61ebe25a5c410c0e245028fc9934bf8fa4817199ef5a24a68092edfd34614"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -6854,9 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -6872,12 +6716,11 @@ dependencies = [
 
 [[package]]
 name = "scoped-futures"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+checksum = "1b24aae2d0636530f359e9d5ef0c04669d11c5e756699b27a6a6d845d8329091"
 dependencies = [
- "cfg-if",
- "pin-utils",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -7040,14 +6883,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -7078,15 +6921,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9720086b3357bcb44fce40117d769a4d068c70ecfa190850a980a71755f66fcc"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex 0.4.3",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7096,14 +6939,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1abbfe725f27678f4663bcacb75a83e829fd464c25d78dd038a3a29e307cec"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -7488,7 +7331,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -7530,9 +7373,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "01680f5d178a369f817f43f3d399650272873a8e7588a7872f7e90edc71d60a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7548,7 +7391,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -7560,7 +7403,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -7593,10 +7436,10 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "bus",
- "common 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "common",
  "futures",
  "serde",
  "tokio",
@@ -7702,22 +7545,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -7787,9 +7630,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7821,7 +7664,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -7876,7 +7719,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -8000,7 +7843,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -8022,7 +7865,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -8087,7 +7930,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -8276,18 +8119,15 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -8382,13 +8222,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim#02c66fd929ac076598a8d53227444e77edd79831"
+source = "git+https://github.com/renegade-fi/renegade.git#e46651ebd6e4031852f3ce28a8e7063d2f0a217d"
 dependencies = [
  "ark-ec",
  "ark-serialize 0.4.2",
  "chrono",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
+ "circuit-types",
+ "constants",
  "crossbeam",
  "eyre",
  "futures",
@@ -8407,45 +8247,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?branch=joey/auth-v2-shim)",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-opentelemetry",
- "tracing-serde",
- "tracing-subscriber 0.3.18",
-]
-
-[[package]]
-name = "util"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#99cc160e9db51ade72d0310b44cf3e1a9b7d9da8"
-dependencies = [
- "ark-ec",
- "ark-serialize 0.4.2",
- "chrono",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
- "crossbeam",
- "eyre",
- "futures",
- "hex 0.4.3",
- "json",
- "libp2p",
- "metrics",
- "metrics-exporter-statsd",
- "metrics-tracing-context",
- "metrics-util",
- "num-bigint",
- "num-traits",
- "opentelemetry",
- "opentelemetry-datadog",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "rand 0.8.5",
- "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "renegade-crypto",
  "serde",
  "serde_json",
  "tokio",
@@ -8467,9 +8269,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
@@ -8553,7 +8355,7 @@ dependencies = [
  "futures-util",
  "headers",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "mime",
  "mime_guess",
@@ -8591,9 +8393,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8604,24 +8406,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -8631,9 +8433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8641,22 +8443,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
@@ -8673,9 +8475,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9143,7 +8945,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]
@@ -9163,7 +8965,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.83",
 ]
 
 [[package]]

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -23,7 +23,7 @@ pub const API_KEYS_PATH: &str = "api-keys";
 /// The path to mark an API key as inactive
 ///
 /// POST /api-keys/{id}/deactivate
-pub const DEACTIVATE_API_KEY_PATH: &str = "deactivate";
+pub const DEACTIVATE_API_KEY_PATH: &str = "/api-keys/{id}/deactivate";
 
 /// A request to create a new API key
 #[derive(Debug, Deserialize)]

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -22,6 +22,9 @@ pub enum AuthServerError {
     /// Error serializing or deserializing a stored value
     #[error("Error serializing/deserializing a stored value: {0}")]
     Serde(String),
+    /// Error setting up the auth server
+    #[error("Error setting up the auth server: {0}")]
+    Setup(String),
     /// Unauthorized
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
@@ -29,26 +32,37 @@ pub enum AuthServerError {
 
 impl AuthServerError {
     /// Create a new database connection error
+    #[allow(clippy::needless_pass_by_value)]
     pub fn db<T: ToString>(msg: T) -> Self {
         Self::DatabaseConnection(msg.to_string())
     }
 
     /// Create a new encryption error
+    #[allow(clippy::needless_pass_by_value)]
     pub fn encryption<T: ToString>(msg: T) -> Self {
         Self::Encryption(msg.to_string())
     }
 
     /// Create a new decryption error
+    #[allow(clippy::needless_pass_by_value)]
     pub fn decryption<T: ToString>(msg: T) -> Self {
         Self::Decryption(msg.to_string())
     }
 
     /// Create a new serde error
+    #[allow(clippy::needless_pass_by_value)]
     pub fn serde<T: ToString>(msg: T) -> Self {
         Self::Serde(msg.to_string())
     }
 
+    /// Create a new setup error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn setup<T: ToString>(msg: T) -> Self {
+        Self::Setup(msg.to_string())
+    }
+
     /// Create a new unauthorized error
+    #[allow(clippy::needless_pass_by_value)]
     pub fn unauthorized<T: ToString>(msg: T) -> Self {
         Self::Unauthorized(msg.to_string())
     }

--- a/auth/auth-server/src/server/api_auth.rs
+++ b/auth/auth-server/src/server/api_auth.rs
@@ -1,64 +1,18 @@
-//! Handler code for proxied relayer requests
-//!
-//! At a high level the server must first authenticate the request, then forward
-//! it to the relayer with admin authentication
+//! Handles API authentication
 
 use auth_server_api::RENEGADE_API_KEY_HEADER;
-use bytes::Bytes;
-use http::{HeaderMap, Method};
+use http::HeaderMap;
 use renegade_api::auth::validate_expiring_auth;
 use renegade_common::types::wallet::keychain::HmacKey;
-use tracing::error;
 use uuid::Uuid;
-use warp::{reject::Rejection, reply::Reply};
 
 use crate::{error::AuthServerError, ApiError};
 
 use super::{helpers::aes_decrypt, Server};
 
-/// Handle a proxied request
 impl Server {
-    /// Handle a request meant to be authenticated and proxied to the relayer
-    pub async fn handle_proxy_request(
-        &self,
-        path: warp::path::FullPath,
-        method: Method,
-        mut headers: warp::hyper::HeaderMap,
-        body: Bytes,
-    ) -> Result<impl Reply, Rejection> {
-        // Authorize the request
-        self.authorize_request(path.as_str(), &mut headers, &body).await?;
-
-        // Forward the request to the relayer
-        let url = format!("{}{}", self.relayer_url, path.as_str());
-        let req = self.client.request(method, &url).headers(headers).body(body);
-
-        // TODO: Add admin auth here
-        match req.send().await {
-            Ok(resp) => {
-                let status = resp.status();
-                let headers = resp.headers().clone();
-                let body = resp.bytes().await.map_err(|e| {
-                    warp::reject::custom(ApiError::InternalError(format!(
-                        "Failed to read response body: {e}"
-                    )))
-                })?;
-
-                let mut response = warp::http::Response::new(body);
-                *response.status_mut() = status;
-                *response.headers_mut() = headers;
-
-                Ok(response)
-            },
-            Err(e) => {
-                error!("Error proxying request: {}", e);
-                Err(warp::reject::custom(ApiError::InternalError(e.to_string())))
-            },
-        }
-    }
-
     /// Authorize a request
-    async fn authorize_request(
+    pub(crate) async fn authorize_request(
         &self,
         path: &str,
         headers: &mut HeaderMap,

--- a/auth/auth-server/src/server/handle_external_match.rs
+++ b/auth/auth-server/src/server/handle_external_match.rs
@@ -1,0 +1,28 @@
+//! Handler code for proxied relayer requests
+//!
+//! At a high level the server must first authenticate the request, then forward
+//! it to the relayer with admin authentication
+
+use bytes::Bytes;
+use http::Method;
+use warp::{reject::Rejection, reply::Reply};
+
+use super::Server;
+
+/// Handle a proxied request
+impl Server {
+    /// Handle an external match request
+    pub async fn handle_external_match_request(
+        &self,
+        path: warp::path::FullPath,
+        mut headers: warp::hyper::HeaderMap,
+        body: Bytes,
+    ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        self.authorize_request(path.as_str(), &mut headers, &body).await?;
+
+        // Send the request to the relayer
+        let resp = self.send_admin_request(Method::POST, path.as_str(), headers, body).await?;
+        Ok(resp)
+    }
+}

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -65,4 +65,12 @@ mod tests {
         let decrypted = aes_decrypt(&encrypted, &key).unwrap();
         assert_eq!(value, decrypted);
     }
+
+    /// Generate an encryption key, base64 encode it, and print it
+    #[test]
+    pub fn generate_encryption_key() {
+        let key = Aes128Gcm::generate_key(&mut thread_rng());
+        let encoded = general_purpose::STANDARD.encode(&key);
+        println!("{}", encoded);
+    }
 }


### PR DESCRIPTION
### Purpose
This PR uses the relayer admin key to authorize proxied requests from the auth server. I also setup a non-generic router to limit the routes that the proxy may be used to access.

### Testing
- Generated and submitted an atomic match through the auth API with an API key