### PR TITLE
price-reporter: routes: add admin token mapping refresh route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0822426598f95e45dd1ea32a738dac057529a709ee645fcc516ffa4cbde08f"
+checksum = "f542548a609dca89fcd72b3b9f355928cf844d4363c5eed9c5273a3dd225e097"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69371e34337c4c984bbe322360c2547210bf632eb2814bbe78a6e87a2935bd2b"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.22"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24c1b4099818523236a8ca881d2b45db98dadfb4625cf6608c12069fcbbde1"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1798,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cobs"
@@ -3851,7 +3851,7 @@ dependencies = [
  "rustls 0.23.19",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
 ]
 
@@ -7908,20 +7908,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls 0.23.19",
- "rustls-pki-types",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ lto = true
 renegade-arbitrum-client = { package = "arbitrum-client", git = "https://github.com/renegade-fi/renegade.git", features = [
     "rand",
 ] }
-renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
+    "auth",
+] }
 renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }

--- a/price-reporter/src/errors.rs
+++ b/price-reporter/src/errors.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use renegade_price_reporter::errors::ExchangeConnectionError;
-use serde_json::Error as SerdeError;
 
 /// An error that can occur in the price reporter server.
 #[derive(Debug)]
@@ -29,9 +28,13 @@ pub enum ServerError {
     /// An error receiving a message over a websocket
     WebsocketReceive(String),
     /// An error during de/serialization
-    Serde(SerdeError),
+    Serde(String),
     /// An error in the HTTP server execution
     HttpServer(String),
+    /// An error in the authorization of an HTTP request
+    Unauthorized(String),
+    /// An error indicating that the admin key was not provided
+    NoAdminKey,
 }
 
 impl Display for ServerError {

--- a/price-reporter/src/http_server/routes.rs
+++ b/price-reporter/src/http_server/routes.rs
@@ -1,12 +1,17 @@
 //! The routes for the HTTP server
 
 use async_trait::async_trait;
-use hyper::{Body, Request, Response, StatusCode};
-use renegade_common::types::Price;
+use hyper::{body::to_bytes, Body, Request, Response, StatusCode};
+use renegade_api::auth::validate_expiring_auth;
+use renegade_arbitrum_client::constants::Chain;
+use renegade_common::types::{wallet::keychain::HmacKey, Price};
+use renegade_config::setup_token_remaps;
 use renegade_price_reporter::worker::ExchangeConnectionsConfig;
+use renegade_util::err_str;
 
 use crate::{
     errors::ServerError,
+    init_default_price_streams,
     utils::{parse_pair_info_from_topic, UrlParams},
     ws_server::GlobalPriceStreams,
 };
@@ -91,6 +96,94 @@ impl Handler for PriceHandler {
                 .status(StatusCode::OK)
                 .body(Body::from(price.to_string()))
                 .unwrap(),
+            Err(e) => Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::from(e.to_string()))
+                .unwrap(),
+        }
+    }
+}
+
+// -------------------------------
+// | REFRESH TOKEN MAPPING ROUTE |
+// -------------------------------
+
+/// The route for the token mapping refresh endpoint
+pub const REFRESH_TOKEN_MAPPING_ROUTE: &str = "/refresh-token-mapping";
+
+/// The handler for the token mapping refresh endpoint
+#[derive(Clone)]
+pub struct RefreshTokenMappingHandler {
+    /// The HMAC key for the admin API
+    admin_key: Option<HmacKey>,
+    /// The path to the token remap file
+    token_remap_path: Option<String>,
+    /// The chain to use for the token remap
+    remap_chain: Chain,
+    /// The global price streams
+    price_streams: GlobalPriceStreams,
+    /// The configuration for the exchange connections
+    config: ExchangeConnectionsConfig,
+}
+
+impl RefreshTokenMappingHandler {
+    /// Create a new token mapping refresh handler
+    pub fn new(
+        admin_key: Option<HmacKey>,
+        token_remap_path: Option<String>,
+        remap_chain: Chain,
+        price_streams: GlobalPriceStreams,
+        config: ExchangeConnectionsConfig,
+    ) -> Self {
+        Self { admin_key, token_remap_path, remap_chain, price_streams, config }
+    }
+
+    /// Authenticate a token mapping refresh request using the admin HMAC key.
+    async fn authenticate_request(&self, req: &mut Request<Body>) -> Result<(), ServerError> {
+        if self.admin_key.is_none() {
+            return Err(ServerError::NoAdminKey);
+        }
+
+        let req_body = to_bytes(req.body_mut()).await.map_err(err_str!(ServerError::Serde))?;
+        let path = req.uri().path();
+        let headers = req.headers();
+        validate_expiring_auth(path, headers, &req_body, &self.admin_key.unwrap())
+            .map_err(err_str!(ServerError::Unauthorized))
+    }
+
+    /// Refresh the token mapping from the remote source
+    pub async fn refresh_token_mapping(&self) -> Result<(), ServerError> {
+        let token_remap_path = self.token_remap_path.clone();
+        let remap_chain = self.remap_chain;
+        tokio::task::spawn_blocking(move || setup_token_remaps(token_remap_path, remap_chain))
+            .await
+            .map_err(err_str!(ServerError::TokenRemap))
+            .and_then(|res| res.map_err(err_str!(ServerError::TokenRemap)))?;
+
+        // Re-initialize the default price streams after refreshing the token mapping
+        init_default_price_streams(&self.price_streams, &self.config)
+    }
+}
+
+#[async_trait]
+impl Handler for RefreshTokenMappingHandler {
+    async fn handle(&self, mut req: Request<Body>, _: UrlParams) -> Response<Body> {
+        if self.admin_key.is_none() {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from("Admin API disabled".to_string()))
+                .unwrap();
+        }
+
+        if let Err(e) = self.authenticate_request(&mut req).await {
+            return Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(Body::from(e.to_string()))
+                .unwrap();
+        }
+
+        match self.refresh_token_mapping().await {
+            Ok(_) => Response::builder().status(StatusCode::OK).body(Body::empty()).unwrap(),
             Err(e) => Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(Body::from(e.to_string()))

--- a/price-reporter/src/ws_server.rs
+++ b/price-reporter/src/ws_server.rs
@@ -264,7 +264,7 @@ pub async fn handle_connection(
                 // meaning the stream lagged receiving price updates. We can safely ignore this.
                 let topic = get_pair_info_topic(&pair_info);
                 let message = PriceMessage { topic, price };
-                let message_ser = serde_json::to_string(&message).map_err(ServerError::Serde)?;
+                let message_ser = serde_json::to_string(&message).map_err(err_str!(ServerError::Serde))?;
                 write_stream
                     .send(Message::Text(message_ser))
                     .await
@@ -328,7 +328,7 @@ async fn handle_ws_message(
                 )
                 .await
                 {
-                    Ok(res) => serde_json::to_string(&res).map_err(ServerError::Serde)?,
+                    Ok(res) => serde_json::to_string(&res).map_err(err_str!(ServerError::Serde))?,
                     Err(e) => e.to_string(),
                 };
 


### PR DESCRIPTION
This PR adds an authenticated route to the price reporter for refreshing the token mapping. The authentication scheme is inherited from the relayer, and in accordance with this the price reporter now accepts an HMAC key in its configuration.

After the token mapping is refreshed, price streams are reinitialized. This is a no-op for existing price streams but will start streams for any newly-added tokens. Note that in the case of tokens being _removed_ from the mapping, the price streams will not be closed - but practically this is not a concern.

This was tested locally, with authentication disabled and using a local token mapping file instead of modifying the actual repo. This will be tested end-to-end in testnet shortly.