### PR TITLE
auth server: record settlement metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ name = "auth-server"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "alloy-sol-types",
  "arbitrum-client",
  "auth-server-api",
  "base64 0.22.1",
@@ -735,8 +736,11 @@ dependencies = [
  "clap",
  "common",
  "config",
+ "constants",
+ "contracts-common",
  "diesel",
  "diesel-async",
+ "ethers",
  "external-api",
  "futures-util",
  "http 0.2.12",

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -22,13 +22,17 @@ native-tls = "0.2"
 
 # === Cryptography === #
 aes-gcm = "0.10.1"
+alloy-sol-types = "=0.7.7"
+ethers = "2"
 rand = "0.8.5"
 
 # === Renegade Dependencies === #
 auth-server-api = { path = "../auth-server-api" }
-renegade-arbitrum-client = { package = "arbitrum-client", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-arbitrum-client = { package = "arbitrum-client", git = "https://github.com/renegade-fi/renegade.git", features = ["rand"]}
 renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }
+contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
 renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -18,6 +18,11 @@ pub const EXTERNAL_MATCH_BASE_VOLUME: &str = "external_match_base_volume";
 /// response
 pub const EXTERNAL_MATCH_QUOTE_VOLUME: &str = "external_match_quote_volume";
 
+/// Metric describing the volume of the base asset in an external match
+pub const EXTERNAL_MATCH_SETTLED_BASE_VOLUME: &str = "external_match_settled_base_volume";
+/// Metric describing the volume of the quote asset in an external match
+pub const EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME: &str = "external_match_settled_quote_volume";
+
 // ---------------
 // | METRIC TAGS |
 // ---------------
@@ -26,3 +31,5 @@ pub const EXTERNAL_MATCH_QUOTE_VOLUME: &str = "external_match_quote_volume";
 pub const ASSET_METRIC_TAG: &str = "asset";
 /// Metric tag for the description of the API key used to make the request
 pub const KEY_DESCRIPTION_METRIC_TAG: &str = "key_description";
+/// Metric tag for the settlement status of an external match
+pub const SETTLEMENT_STATUS_TAG: &str = "did_settle";


### PR DESCRIPTION
### Purpose
This PR records metrics on external match settlement. 

### Testing
Tested locally against locally running auth server and Datadog agent. Example dashboard from this data [here](https://us5.datadoghq.com/dashboard/6j9-i8d-xdq?fromUser=true&refresh_mode=paused&from_ts=1733870660790&to_ts=1733899576032&live=false).
Need to test in testnet stack.