### PR TITLE
auth server: add request-level tag

### DIFF
--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -33,3 +33,8 @@ pub const ASSET_METRIC_TAG: &str = "asset";
 pub const KEY_DESCRIPTION_METRIC_TAG: &str = "key_description";
 /// Metric tag for the settlement status of an external match
 pub const SETTLEMENT_STATUS_TAG: &str = "did_settle";
+/// Metric tag that contains a unique identifier for tracking a single request
+/// through its entire lifecycle.
+pub const REQUEST_ID_METRIC_TAG: &str = "request_id";
+/// Metric tag for the base asset of an external order or match
+pub const BASE_ASSET_METRIC_TAG: &str = "base_asset";


### PR DESCRIPTION
### Purpose
This PR adds metric tags to allow for richer queries in DD. Specifically, we want to 
- correlate different components of a request together (order, bundle, settlement)
- indicate base asset on quote volume metrics to group by base asset

### Testing
Tested against locally running auth server and Datadog agent.