### PR TITLE
auth-server: remove unnecessary flag in Dockerfile

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -53,4 +53,3 @@ RUN apt-get update && \
 COPY --from=builder /build/target/release/auth-server /bin/auth-server
 
 ENTRYPOINT ["/bin/auth-server"]
-CMD ["--datadog-logging"]


### PR DESCRIPTION
This PR removes the `--datadog-logging` flag from the Dockerfile since the flag name has been changed and is now defined in Terraform. 