### PR TITLE
auth-server: use get-quote-amount helper

### DIFF
--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -120,8 +120,8 @@ fn record_external_match_request_metrics(
     let fixed_point_price = FixedPoint::from_f64_round_down(price);
     let order = req.external_order.to_order_with_price(fixed_point_price);
 
-    // Calculate amount in quote
-    let quote_amount = order.amount * price as u128;
+    // Calculate amount in quote using fixed point arithmetic
+    let quote_amount = req.external_order.get_quote_amount(fixed_point_price);
 
     record_volume_with_tags(&base_mint, order.amount, EXTERNAL_ORDER_BASE_VOLUME, labels);
 


### PR DESCRIPTION
### Purpose
This PR fixes an issue where the `quote_amount` calculation would lose precision when casting from `f64` to `u128`, especially for base tokens with 18 decimals.

Relies on https://github.com/renegade-fi/renegade/pull/862

### Testing
- [x] Tested locally with very small and very large values that were causing issues before (WBTC, WETH, PENDLE)
- [ ] Test in testnet