### PR TITLE
auth-server: tag counter matric as post fix

### DIFF
--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -199,7 +199,10 @@ fn record_endpoint_metrics(
     extra_labels: &[(String, String)],
 ) {
     let (asset, _) = get_asset_and_volume(mint, 0);
-    let mut labels = vec![(ASSET_METRIC_TAG.to_string(), asset)];
+    let mut labels = vec![
+        (ASSET_METRIC_TAG.to_string(), asset),
+        (DECIMAL_CORRECTION_FIXED_METRIC_TAG.to_string(), "true".to_string()),
+    ];
     labels.extend(extra_labels.iter().cloned());
     metrics::counter!(metric_name, &labels).increment(1);
 }

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -39,4 +39,4 @@ pub const REQUEST_ID_METRIC_TAG: &str = "request_id";
 /// Metric tag for the base asset of an external order or match
 pub const BASE_ASSET_METRIC_TAG: &str = "base_asset";
 /// Metric tag to indicate data was recorded post decimal correction fix
-pub const DECIMAL_CORRECTION_FIXED_METRIC_TAG: &str = "post_decimal_correction_fix";
+pub const DECIMAL_CORRECTION_FIXED_METRIC_TAG: &str = "post_decimal_fix";


### PR DESCRIPTION
### Purpose
This PR adds the post fix tag to the request counter metric. Also changes the tag name so that data is aligned when filtered.

### Testing
- [ ] Tested locally
- [ ] Tested in testnet