### PR TITLE
auth-server: record fill ratio metrics

### DIFF
--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -5,9 +5,11 @@
 // ----------------
 
 /// Metric describing the ratio of matched quote amount to requested quote
-/// amount
+/// amount for quotes and matches
 pub const EXTERNAL_MATCH_FILL_RATIO: &str = "external_match.fill_ratio";
 
+/// Metric describing the number of external quote requests
+pub const EXTERNAL_MATCH_QUOTE_REQUEST_COUNT: &str = "num_external_match_quote_requests";
 /// Metric describing the number of external matches requested
 pub const NUM_EXTERNAL_MATCH_REQUESTS: &str = "num_external_match_requests";
 

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -4,6 +4,10 @@
 // | METRIC NAMES |
 // ----------------
 
+/// Metric describing the ratio of matched quote amount to requested quote
+/// amount
+pub const EXTERNAL_MATCH_FILL_RATIO: &str = "external_match.fill_ratio";
+
 /// Metric describing the number of external matches requested
 pub const NUM_EXTERNAL_MATCH_REQUESTS: &str = "num_external_match_requests";
 


### PR DESCRIPTION
### Purpose
This PR records fill ratios of quote requests and external match requests (to be deprecated) for display as histograms on a Datadog dashboard. Also records number of quote requests per key.

### Testing
- [x] Tested locally
- [ ] Tested in testnet