### PR TITLE
auth-server: server: rate-limiter: Implement bundle rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "native-tls",
  "postgres-native-tls",
  "rand 0.8.5",
+ "ratelimit",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -1809,6 +1810,17 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "clocksource"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129026dd5a8a9592d96916258f3a5379589e513ea5e86aeb0bd2530286e44e9e"
+dependencies = [
+ "libc",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "cobs"
@@ -6194,6 +6206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "ratelimit"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea961700fd7260e7fa3701c8287d901b2172c51f9c1421fa0f21d7f7e184b7"
+dependencies = [
+ "clocksource",
+ "parking_lot",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 clap = { version = "4.0", features = ["derive", "env"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["full"] }
+ratelimit = "0.10"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -126,6 +126,9 @@ pub enum ApiError {
     /// A bad request error
     #[error("Bad request: {0}")]
     BadRequest(String),
+    /// A rate limit exceeded error
+    #[error("Rate limit exceeded")]
+    TooManyRequests,
     /// An unauthorized error
     #[error("Unauthorized")]
     Unauthorized,
@@ -294,6 +297,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Rejection> {
                 (StatusCode::INTERNAL_SERVER_ERROR, DEFAULT_INTERNAL_SERVER_ERROR_MESSAGE)
             },
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.as_str()),
+            ApiError::TooManyRequests => (StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
             ApiError::Unauthorized => (StatusCode::UNAUTHORIZED, "Unauthorized"),
         };
 

--- a/auth/auth-server/src/server/rate_limiter.rs
+++ b/auth/auth-server/src/server/rate_limiter.rs
@@ -1,0 +1,70 @@
+//! A rate limiter for the server
+//!
+//! The unit which we rate limit is number of inflight bundles. Therefore, there
+//! are two ways for the token bucket to refill:
+//!     - Wait for the next refill
+//!     - Settle a bundle on-chain
+//!
+//! The latter is measured by waiting for nullifier spend events on-chain
+
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use ratelimit::Ratelimiter;
+use tokio::sync::Mutex;
+
+/// A type alias for a per-user rate limiter
+type BucketMap = HashMap<String, Ratelimiter>;
+
+/// The number of bundles allowed per minute
+const BUNDLES_LIMIT_PER_MINUTE: u64 = 4;
+/// One minute duration
+const ONE_MINUTE: Duration = Duration::from_secs(60);
+
+/// The bundle rate limiter
+#[derive(Clone)]
+pub struct BundleRateLimiter {
+    /// A per-user rate limiter
+    bucket_map: Arc<Mutex<BucketMap>>,
+}
+
+impl BundleRateLimiter {
+    /// Create a new bundle rate limiter
+    pub fn new() -> Self {
+        Self { bucket_map: Arc::new(Mutex::new(HashMap::new())) }
+    }
+
+    /// Create a new rate limiter
+    fn new_rate_limiter() -> Ratelimiter {
+        Ratelimiter::builder(BUNDLES_LIMIT_PER_MINUTE, ONE_MINUTE)
+            .initial_available(BUNDLES_LIMIT_PER_MINUTE)
+            .max_tokens(BUNDLES_LIMIT_PER_MINUTE)
+            .build()
+            .expect("invalid rate limit configuration")
+    }
+
+    /// Consume a token from bucket if available
+    ///
+    /// If no token is available (rate limit reached), this method returns
+    /// false, otherwise true
+    pub async fn check(&self, user_id: String) -> bool {
+        let mut map = self.bucket_map.lock().await;
+        let entry = map.entry(user_id).or_insert_with(Self::new_rate_limiter);
+
+        let available = entry.available();
+        entry.set_available(available.saturating_sub(1)).expect("rate limit range should be valid");
+        available >= 1
+    }
+
+    /// Increment the number of tokens available to a given user
+    #[allow(unused_must_use)]
+    pub async fn add_token(&self, user_id: String) {
+        let mut map = self.bucket_map.lock().await;
+        let entry = map.entry(user_id).or_insert_with(Self::new_rate_limiter);
+
+        // Set the available tokens
+        // The underlying rate limiter will error if this exceeds the configured
+        // maximum, we ignore this error
+        let available = entry.available();
+        entry.set_available(available + 1);
+    }
+}


### PR DESCRIPTION
### Purpose
This PR implements bundle rate limits for the auth server. Specifically, we rate limit the number of inflight, unsettled bundles per client. So, a client may accrue new API tokens by either:
- Waiting for their token bucket to refill
- Settling a match

### Testing
- [ ] Test in testnet