### PR TITLE
auth-server: rate-limiter: Configure rate limit from command line

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -84,6 +84,9 @@ pub struct Cli {
     /// The chain that the relayer settles to
     #[arg(long, env = "CHAIN_ID")]
     pub chain_id: Chain,
+    /// The bundle rate limit in bundles per minute
+    #[arg(long, env = "BUNDLE_RATE_LIMIT", default_value = "4")]
+    pub bundle_rate_limit: u64,
     /// The path to the file containing token remaps for the given chain
     ///
     /// See https://github.com/renegade-fi/token-mappings for more information on the format of this file

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -80,6 +80,8 @@ impl Server {
         let relayer_admin_key =
             HmacKey::from_base64_string(&args.relayer_admin_key).map_err(AuthServerError::setup)?;
 
+        let rate_limiter = BundleRateLimiter::new(args.bundle_rate_limit);
+
         Ok(Self {
             db_pool: Arc::new(db_pool),
             relayer_url: args.relayer_url,
@@ -89,7 +91,7 @@ impl Server {
             api_key_cache: Arc::new(RwLock::new(UnboundCache::new())),
             client: Client::new(),
             arbitrum_client,
-            rate_limiter: BundleRateLimiter::new(),
+            rate_limiter,
         })
     }
 


### PR DESCRIPTION
### Purpose
This PR accepts the bundle rate limit as a CLI argument

### Testing
- [x] Test in testnet