### PR TITLE
auth-server: record quote comparison metrics

### DIFF
--- a/auth/auth-server/src/server/handle_external_match.rs
+++ b/auth/auth-server/src/server/handle_external_match.rs
@@ -241,6 +241,9 @@ impl Server {
         let base_token = Token::from_addr_biguint(&req.external_order.base_mint);
         record_endpoint_metrics(&base_token.addr, EXTERNAL_MATCH_QUOTE_REQUEST_COUNT, &labels);
 
+        // Record quote comparison metrics
+        self.quote_metrics.record_quote_comparison(&quote_resp, labels.as_slice());
+
         Ok(())
     }
 }

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -29,6 +29,9 @@ pub const EXTERNAL_MATCH_SETTLED_BASE_VOLUME: &str = "external_match_settled_bas
 /// Metric describing the volume of the quote asset in an external match
 pub const EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME: &str = "external_match_settled_quote_volume";
 
+/// Consolidated metric for quote comparison analysis with all data as tags
+pub const QUOTE_PRICE_DIFF_BPS_METRIC: &str = "quote.price_diff_bps";
+
 // ---------------
 // | METRIC TAGS |
 // ---------------
@@ -46,3 +49,15 @@ pub const REQUEST_ID_METRIC_TAG: &str = "request_id";
 pub const BASE_ASSET_METRIC_TAG: &str = "base_asset";
 /// Metric tag to indicate data was recorded post decimal correction fix
 pub const DECIMAL_CORRECTION_FIXED_METRIC_TAG: &str = "post_decimal_fix";
+
+/// Metric tag for identifying the source of a quote (our server or competitor)
+pub const SOURCE_NAME_TAG: &str = "source_name";
+
+/// Metric tag for identifying the order side (buy/sell)
+pub const SIDE_TAG: &str = "side";
+
+/// Metric tag for our quoted price
+pub const OUR_PRICE_TAG: &str = "our_price";
+
+/// Metric tag for the comparison source's price
+pub const SOURCE_PRICE_TAG: &str = "source_price";

--- a/auth/auth-server/src/telemetry/mod.rs
+++ b/auth/auth-server/src/telemetry/mod.rs
@@ -1,3 +1,5 @@
 //! Defines helpers for recording metrics
 pub mod helpers;
 pub mod labels;
+pub mod quote_comparison;
+pub mod sources;

--- a/auth/auth-server/src/telemetry/quote_comparison.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison.rs
@@ -1,0 +1,70 @@
+use renegade_circuit_types::order::OrderSide;
+use renegade_common::types::{token::Token, TimestampedPrice};
+
+use super::{
+    helpers::{
+        calculate_price_diff_bps, extend_labels_with_base_asset, record_comparison,
+        reverse_decimal_correction,
+    },
+    labels::SIDE_TAG,
+    sources::MockQuoteSource,
+};
+use renegade_api::http::external_match::ExternalQuoteResponse;
+
+/// Represents a single quote comparison between quotes from different sources
+pub struct QuoteComparison {
+    pub our_price: f64,
+    pub source_price: f64,
+    pub source_name: String,
+    pub price_diff_bips: i32,
+}
+
+/// Records metrics comparing quotes from different sources
+#[derive(Clone)]
+pub struct QuoteComparisonHandler {
+    sources: Vec<MockQuoteSource>,
+}
+
+impl QuoteComparisonHandler {
+    /// Create a new QuoteComparisonHandler with the given sources
+    pub fn new(sources: Vec<MockQuoteSource>) -> Self {
+        Self { sources }
+    }
+
+    /// Records metrics comparing quotes from different sources
+    pub fn record_quote_comparison(
+        &self,
+        quote_resp: &ExternalQuoteResponse,
+        extra_labels: &[(String, String)],
+    ) {
+        let base_token = Token::from_addr_biguint(&quote_resp.signed_quote.quote.order.base_mint);
+        let quote_token = Token::from_addr_biguint(&quote_resp.signed_quote.quote.order.quote_mint);
+
+        let ts_price: TimestampedPrice = quote_resp.signed_quote.quote.price.clone().into();
+        let our_price = reverse_decimal_correction(ts_price.price, &base_token, &quote_token)
+            .expect("Price correction should not fail");
+
+        let is_sell = quote_resp.signed_quote.quote.order.side == OrderSide::Sell;
+        let side_label = if is_sell { "sell" } else { "buy" };
+
+        let mut labels = vec![(SIDE_TAG.to_string(), side_label.to_string())];
+        labels.extend(extra_labels.iter().cloned());
+        labels = extend_labels_with_base_asset(&base_token.get_addr(), labels);
+
+        // Compare with each source
+        for source in &self.sources {
+            let other_quote = source.get_quote(base_token.clone(), quote_token.clone(), our_price);
+            // See calculate_price_diff_bps for detailed comparison logic
+            let price_diff_bips = calculate_price_diff_bps(our_price, other_quote.price, is_sell);
+
+            let comparison = QuoteComparison {
+                our_price,
+                source_price: other_quote.price,
+                source_name: source.name().to_string(),
+                price_diff_bips,
+            };
+
+            record_comparison(&comparison, &labels);
+        }
+    }
+}

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -1,0 +1,39 @@
+//! Mock quote source for price comparison metrics
+
+use rand::Rng;
+use renegade_common::types::token::Token;
+
+/// A quote response containing price data
+#[derive(Debug, Clone)]
+pub struct QuoteResponse {
+    pub base_token: Token,
+    pub quote_token: Token,
+    pub price: f64,
+}
+
+/// A mock quote source that generates random prices within 2% of the input
+/// price
+#[derive(Clone)]
+pub struct MockQuoteSource {
+    name: &'static str,
+}
+
+impl MockQuoteSource {
+    pub fn new(name: &'static str) -> Self {
+        Self { name }
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn get_quote(
+        &self,
+        base_token: Token,
+        quote_token: Token,
+        our_price: f64,
+    ) -> QuoteResponse {
+        let price_diff_percent = rand::thread_rng().gen_range(-0.02..=0.02);
+        QuoteResponse { base_token, quote_token, price: our_price * (1.0 + price_diff_percent) }
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds quote comparison metrics to track how our prices compare to other sources. It introduces:

- A new QuoteComparisonMetrics struct that records price differences in basis points
- Mock quote sources (Binance, Coinbase) that generate random prices within 2% of our quotes

The metrics will help us monitor our price competitiveness vs other venues. Real quote sources will be added in future PRs - this initial implementation with mock sources allows us to test the metrics infrastructure and finalize the tags/fields needed for an initial Datadog quote comparison widget.

### Testing
- [x] Tested locally
- [ ] Tested in testnet