### PR TITLE
auth-server: sample quote endpoint metrics

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -117,6 +117,9 @@ pub struct Cli {
     /// Whether or not to enable quote comparison functionality
     #[arg(long, env = "ENABLE_QUOTE_COMPARISON", default_value = "false")]
     pub enable_quote_comparison: bool,
+    /// Rate at which to sample metrics (0.0 to 1.0)
+    #[arg(long, env = "METRICS_SAMPLING_RATE")]
+    pub metrics_sampling_rate: Option<f64>,
 }
 
 // -------------

--- a/auth/auth-server/src/server/handle_external_match.rs
+++ b/auth/auth-server/src/server/handle_external_match.rs
@@ -229,6 +229,11 @@ impl Server {
         // Log the quote parameters
         self.log_quote(resp)?;
 
+        // Only proceed with metrics recording if sampled
+        if !self.should_sample_metrics() {
+            return Ok(());
+        }
+
         // Parse request and response for metrics
         let req: ExternalMatchRequest =
             serde_json::from_slice(req).map_err(AuthServerError::serde)?;


### PR DESCRIPTION
### Purpose
This PR implements a helper to sample metrics.

According to our Usage page in Datadog, quote metrics are recorded ~25k/per hour. This is resulting in widgets erroring with `Query Response Size Exceeded` and increased costs.

In a future PR, we can migrate metrics for `num_external_match_quote_requests` to be log-based if we don't want to sample those metrics but still want to save on costs.

### Testing
- [x] Tested locally
- [ ] Tested in testnet