### PR TITLE
auth-server: organize quote comparison structs

### DIFF
--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -11,7 +11,9 @@ mod rate_limiter;
 use crate::{
     error::AuthServerError,
     models::ApiKey,
-    telemetry::{quote_comparison::QuoteComparisonHandler, sources::odos::OdosQuoteSource},
+    telemetry::{
+        quote_comparison::handler::QuoteComparisonHandler, sources::odos::OdosQuoteSource,
+    },
     ApiError, Cli,
 };
 use base64::{engine::general_purpose, Engine};

--- a/auth/auth-server/src/telemetry/quote_comparison/handler.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/handler.rs
@@ -2,23 +2,14 @@ use futures_util::future::join_all;
 use renegade_circuit_types::order::OrderSide;
 use renegade_common::types::token::Token;
 
-use super::{
-    helpers::{
-        calculate_implied_price, calculate_price_diff_bps, extend_labels_with_base_asset,
-        record_comparison,
-    },
-    labels::SIDE_TAG,
-    sources::QuoteSource,
-};
 use renegade_api::http::external_match::AtomicMatchApiBundle;
 
-/// Represents a single quote comparison between quotes from different sources
-pub struct QuoteComparison {
-    pub our_price: f64,
-    pub source_price: f64,
-    pub source_name: String,
-    pub price_diff_bips: i32,
-}
+use crate::telemetry::{
+    helpers::record_comparison,
+    sources::{QuoteResponse, QuoteSource},
+};
+
+use super::QuoteComparison;
 
 /// Records metrics comparing quotes from different sources
 pub struct QuoteComparisonHandler {
@@ -34,7 +25,7 @@ impl QuoteComparisonHandler {
     /// Records a comparison for a single source
     async fn record_comparison_for_source(
         source: QuoteSource,
-        our_price: f64,
+        our_quote: &QuoteResponse,
         base_token: Token,
         quote_token: Token,
         side: OrderSide,
@@ -42,14 +33,10 @@ impl QuoteComparisonHandler {
         labels: Vec<(String, String)>,
     ) {
         let quote = source.get_quote(base_token, quote_token, side, amount).await;
-        let price_diff_bips = calculate_price_diff_bps(our_price, quote.price, side);
-        let comparison = QuoteComparison {
-            our_price,
-            source_price: quote.price,
-            source_name: source.name().to_string(),
-            price_diff_bips,
-        };
-        record_comparison(&comparison, &labels);
+        let comparison =
+            QuoteComparison { our_quote, source_quote: &quote, source_name: source.name() };
+
+        record_comparison(&comparison, side, &labels);
     }
 
     /// Records metrics comparing quotes from different sources
@@ -61,17 +48,9 @@ impl QuoteComparisonHandler {
         let base_token = Token::from_addr(&match_bundle.match_result.base_mint);
         let quote_token = Token::from_addr(&match_bundle.match_result.quote_mint);
 
-        let our_price = calculate_implied_price(match_bundle, false)
-            .expect("Price calculation should not fail");
+        let our_quote: QuoteResponse = match_bundle.into();
 
-        let is_sell = match_bundle.match_result.direction == OrderSide::Sell;
-        let side_label = if is_sell { "sell" } else { "buy" };
-
-        let mut labels = vec![(SIDE_TAG.to_string(), side_label.to_string())];
-        labels.extend(extra_labels.iter().cloned());
-        labels = extend_labels_with_base_asset(&base_token.get_addr(), labels);
-
-        let amount = if is_sell {
+        let amount = if match_bundle.match_result.direction == OrderSide::Sell {
             match_bundle.match_result.base_amount
         } else {
             match_bundle.match_result.quote_amount
@@ -81,12 +60,12 @@ impl QuoteComparisonHandler {
         for source in &self.sources {
             futures.push(Self::record_comparison_for_source(
                 source.clone(),
-                our_price,
+                &our_quote,
                 base_token.clone(),
                 quote_token.clone(),
                 match_bundle.match_result.direction,
                 amount,
-                labels.clone(),
+                extra_labels.to_vec(),
             ));
         }
 

--- a/auth/auth-server/src/telemetry/quote_comparison/mod.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/mod.rs
@@ -1,0 +1,33 @@
+//! Defines the quote comparison struct and handler
+pub mod handler;
+
+use renegade_circuit_types::order::OrderSide;
+
+use super::sources::QuoteResponse;
+
+/// Multiplier to convert decimal to basis points (1 basis point = 0.01%)
+const DECIMAL_TO_BPS: f64 = 10_000.0;
+
+/// Represents a single quote comparison between quotes from different sources
+pub struct QuoteComparison<'a> {
+    pub our_quote: &'a QuoteResponse,
+    pub source_quote: &'a QuoteResponse,
+    pub source_name: &'a str,
+}
+
+impl<'a> QuoteComparison<'a> {
+    /// Calculate the price difference in basis points (bps).
+    /// Positive bps indicates a better quote for the given side:
+    /// - Sell: our price > source price
+    /// - Buy: source price > our price
+    pub fn price_diff_bps(&self, side: OrderSide) -> i32 {
+        let our_price = self.our_quote.price();
+        let source_price = self.source_quote.price();
+        let price_diff_ratio = match side {
+            OrderSide::Sell => (our_price - source_price) / source_price,
+            OrderSide::Buy => (source_price - our_price) / our_price,
+        };
+
+        (price_diff_ratio * DECIMAL_TO_BPS) as i32
+    }
+}

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -3,28 +3,65 @@
 mod http_utils;
 pub mod odos;
 
-use renegade_circuit_types::order::OrderSide;
+use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_common::types::token::Token;
 
 /// A quote response containing price data
 #[derive(Debug)]
 pub struct QuoteResponse {
-    pub price: f64,
+    /// The mint of the quote token in the matched asset pair
+    pub quote_mint: String,
+    /// The mint of the base token in the matched asset pair
+    pub base_mint: String,
+    /// The amount of the quote token exchanged by the match
+    pub quote_amount: Amount,
+    /// The amount of the base token exchanged by the match
+    pub base_amount: Amount,
+}
+
+/// Converts the `AtomicMatchApiBundle` into a `QuoteResponse`.
+impl From<&AtomicMatchApiBundle> for QuoteResponse {
+    fn from(bundle: &AtomicMatchApiBundle) -> Self {
+        Self {
+            quote_mint: bundle.match_result.quote_mint.clone(),
+            base_mint: bundle.match_result.base_mint.clone(),
+            quote_amount: bundle.match_result.quote_amount,
+            base_amount: bundle.match_result.base_amount,
+        }
+    }
+}
+
+impl QuoteResponse {
+    /// Calculates the price from the quote and base amounts.
+    pub fn price(&self) -> f64 {
+        let base_token = Token::from_addr(&self.base_mint);
+        let quote_token = Token::from_addr(&self.quote_mint);
+
+        let base_amt = base_token.convert_to_decimal(self.base_amount);
+        let quote_amt = quote_token.convert_to_decimal(self.quote_amount);
+
+        quote_amt / base_amt
+    }
 }
 
 /// Enum representing different types of quote sources
 #[derive(Clone)]
 pub enum QuoteSource {
+    /// The quote source for the Odos API
     Odos(odos::OdosQuoteSource),
 }
 
 impl QuoteSource {
+    /// Returns the name of the quote source.
     pub fn name(&self) -> &'static str {
         match self {
             QuoteSource::Odos(source) => source.name(),
         }
     }
 
+    /// Asynchronously retrieves a quote for the given base and quote tokens,
+    /// order side, and amount.
     pub async fn get_quote(
         &self,
         base_token: Token,

--- a/auth/auth-server/src/telemetry/sources/odos/types.rs
+++ b/auth/auth-server/src/telemetry/sources/odos/types.rs
@@ -40,6 +40,8 @@ pub(crate) struct OutputToken {
 }
 
 impl OdosQuoteRequest {
+    /// Creates a new `OdosQuoteRequest` with the given configuration and
+    /// tokens.
     pub fn new(
         config: &OdosConfig,
         input_token: String,
@@ -76,5 +78,21 @@ impl OdosQuoteResponse {
             .ok_or_else(|| OdosError::Input("No output amount available".to_string()))?
             .parse()
             .map_err(|e| OdosError::Input(format!("Failed to parse output amount: {}", e)))
+    }
+
+    /// Gets the input token from the first token in the quote.
+    pub fn get_in_token(&self) -> Result<String, OdosError> {
+        self.in_tokens
+            .first()
+            .ok_or_else(|| OdosError::Input("No input token available".to_string()))
+            .map(|token| token.to_string())
+    }
+
+    /// Gets the output token from the first token in the quote.
+    pub fn get_out_token(&self) -> Result<String, OdosError> {
+        self.out_tokens
+            .first()
+            .ok_or_else(|| OdosError::Input("No output token available".to_string()))
+            .map(|token| token.to_string())
     }
 }


### PR DESCRIPTION
### Purpose

This PR makes better use of the `QuoteComparison` and `QuoteSource` structs to make metric recording code more readable and extensible. Future PRs will build upon these changes to colocate helpers to get price net of fees, price net of gas, etc.

### Testing
- [x] Tested locally
- [ ] Tested in testnet