### PR TITLE
auth-server: add output net of fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ dependencies = [
  "postgres-native-tls",
  "rand 0.8.5",
  "ratelimit",
+ "renegade-crypto",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -35,6 +35,7 @@ renegade-circuit-types = { workspace = true }
 renegade-common = { workspace = true }
 renegade-constants = { workspace = true }
 renegade-config = { workspace = true }
+renegade-crypto = { workspace = true }
 renegade-util = { workspace = true }
 renegade-api = { workspace = true }
 

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -32,9 +32,12 @@ pub const EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME: &str = "external_match_settled_qu
 /// Metric describing the difference in price between our quote and the source
 /// quote, in basis points
 pub const QUOTE_PRICE_DIFF_BPS_METRIC: &str = "quote.price_diff_bps";
-/// Metric describing the difference in net output value between our quote and
-/// the source quote, in basis points
-pub const QUOTE_NET_OUT_VALUE_DIFF_BPS_METRIC: &str = "quote.net_out_value_diff_bps";
+/// Metric describing the difference in output value net of gas between our
+/// quote and the source quote, in basis points
+pub const QUOTE_OUTPUT_NET_OF_GAS_DIFF_BPS_METRIC: &str = "quote.output_net_of_gas_diff_bps";
+/// Metric describing the difference in output value net of fee between our
+/// quote and the source quote, in basis points
+pub const QUOTE_OUTPUT_NET_OF_FEE_DIFF_BPS_METRIC: &str = "quote.output_net_of_fee_diff_bps";
 
 // ---------------
 // | METRIC TAGS |
@@ -66,3 +69,7 @@ pub const SOURCE_PRICE_TAG: &str = "source_price";
 pub const OUR_OUTPUT_NET_OF_GAS_TAG: &str = "our_output_net_of_gas";
 /// Metric tag for the comparison source's output net of gas
 pub const SOURCE_OUTPUT_NET_OF_GAS_TAG: &str = "source_output_net_of_gas";
+/// Metric tag for our output net of fee
+pub const OUR_OUTPUT_NET_OF_FEE_TAG: &str = "our_output_net_of_fee";
+/// Metric tag for the comparison source's output net of fee
+pub const SOURCE_OUTPUT_NET_OF_FEE_TAG: &str = "source_output_net_of_fee";

--- a/auth/auth-server/src/telemetry/quote_comparison/handler.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/handler.rs
@@ -11,7 +11,7 @@ use crate::telemetry::helpers::record_output_value_net_of_gas_comparison;
 use crate::{
     error::AuthServerError,
     telemetry::{
-        helpers::record_comparison,
+        helpers::{record_comparison, record_output_value_net_of_fee_comparison},
         sources::{QuoteResponse, QuoteSource},
     },
 };
@@ -82,6 +82,7 @@ impl QuoteComparisonHandler {
 
         record_comparison(&comparison, side, &labels);
         record_output_value_net_of_gas_comparison(&comparison, side, &labels);
+        record_output_value_net_of_fee_comparison(&comparison, side, &labels);
         Ok(())
     }
 }

--- a/auth/auth-server/src/telemetry/quote_comparison/mod.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/mod.rs
@@ -10,6 +10,17 @@ use super::sources::QuoteResponse;
 /// Multiplier to convert decimal to basis points (1 basis point = 0.01%)
 const DECIMAL_TO_BPS: f64 = 10_000.0;
 
+/// Calculate the difference between two values in basis points.
+///
+/// Formula: ((value - baseline) / baseline) * 10000
+///
+/// Returns the relative difference in basis points. A positive result means
+/// `value` is higher than the `baseline` by that many basis points.
+fn calc_bps_diff(value: f64, baseline: f64) -> f64 {
+    let diff_ratio = (value - baseline) / baseline;
+    diff_ratio * DECIMAL_TO_BPS
+}
+
 /// Represents a single quote comparison between quotes from different sources
 pub struct QuoteComparison<'a> {
     /// Our quote
@@ -25,29 +36,31 @@ impl<'a> QuoteComparison<'a> {
     /// Positive bps indicates a better quote for the given side:
     /// - Sell: our price > source price
     /// - Buy: source price > our price
-    pub fn price_diff_bps(&self, side: OrderSide) -> i32 {
+    pub fn price_diff_bps(&self, side: OrderSide) -> f64 {
         let our_price = self.our_quote.price();
         let source_price = self.source_quote.price();
-        let price_diff_ratio = match side {
-            OrderSide::Sell => (our_price - source_price) / source_price,
-            OrderSide::Buy => (source_price - our_price) / our_price,
-        };
-
-        (price_diff_ratio * DECIMAL_TO_BPS) as i32
+        match side {
+            OrderSide::Sell => calc_bps_diff(our_price, source_price),
+            OrderSide::Buy => calc_bps_diff(source_price, our_price),
+        }
     }
 
     /// Calculate the output value net of gas difference in basis points (bps).
     /// Positive bps indicates our quote is better.
-    pub fn output_value_net_of_gas_diff_bps(&self, usdc_per_gas: f64, side: OrderSide) -> i32 {
-        let our_output_value_net_of_gas =
-            self.our_quote.output_value_net_of_gas(usdc_per_gas, side);
+    pub fn output_value_net_of_gas_diff_bps(&self, usdc_per_gas: f64, side: OrderSide) -> f64 {
+        let our_output_value_net_of_gas = self.our_quote.output_net_of_gas(usdc_per_gas, side);
         let source_output_value_net_of_gas =
-            self.source_quote.output_value_net_of_gas(usdc_per_gas, side);
+            self.source_quote.output_net_of_gas(usdc_per_gas, side);
 
-        let diff_ratio = (our_output_value_net_of_gas - source_output_value_net_of_gas)
-            / source_output_value_net_of_gas;
-        let bps_diff = diff_ratio * DECIMAL_TO_BPS;
+        calc_bps_diff(our_output_value_net_of_gas, source_output_value_net_of_gas)
+    }
 
-        bps_diff as i32
+    /// Calculate the output value net of fee difference in basis points (bps).
+    /// Positive bps indicates our quote is better.
+    pub fn output_value_net_of_fee_diff_bps(&self, side: OrderSide) -> f64 {
+        let our_output_value_net_of_fee = self.our_quote.output_net_of_fee(side);
+        let source_output_value_net_of_fee = self.source_quote.output_net_of_fee(side);
+
+        calc_bps_diff(our_output_value_net_of_fee, source_output_value_net_of_fee)
     }
 }

--- a/auth/auth-server/src/telemetry/sources/odos/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/odos/mod.rs
@@ -3,12 +3,14 @@ mod error;
 mod types;
 
 use super::QuoteResponse;
-use renegade_circuit_types::order::OrderSide;
+use renegade_circuit_types::{fixed_point::FixedPoint, order::OrderSide};
 use renegade_common::types::token::Token;
 
 use client::OdosClient;
 
 pub use client::OdosConfig;
+use renegade_constants::Scalar;
+use renegade_crypto::fields::scalar_to_u128;
 
 // -------------
 // | Constants |
@@ -16,6 +18,11 @@ pub use client::OdosConfig;
 
 /// The name of the Odos quote source
 const SOURCE_NAME: &str = "odos";
+
+/// The fee rate for Odos Simple Swap using "volatile tokens".
+///
+/// This is defined in https://docs.odos.xyz/build/fees#swap-fees
+const ODOS_FEE_RATE: f64 = 0.0025; // 0.25%
 
 // ----------
 // | Source |
@@ -66,6 +73,11 @@ impl OdosQuoteSource {
             OrderSide::Sell => (quote.get_in_amount().unwrap(), quote.get_out_amount().unwrap()),
         };
 
+        // Calculate the fee take
+        let fee_rate = FixedPoint::from_f64_round_down(ODOS_FEE_RATE);
+        let receive_amount = Scalar::from(quote.get_out_amount().unwrap());
+        let fee_take = (fee_rate * receive_amount).floor();
+
         QuoteResponse {
             base_amount,
             base_mint,
@@ -73,6 +85,7 @@ impl OdosQuoteSource {
             quote_mint,
             gas: quote.gas_estimate as u64,
             name: SOURCE_NAME.to_string(),
+            fee_take: scalar_to_u128(&fee_take),
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR takes into account fees when recording quote comparison metrics. We do so by calculating the fee take amount and storing it in the `QuoteResponse` struct.

### Testing
- [x] Tested locally
- [ ] Test in testnet