### PR TITLE
auth-server: record metrics for output net of gas and fees

### DIFF
--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -38,6 +38,9 @@ pub const QUOTE_OUTPUT_NET_OF_GAS_DIFF_BPS_METRIC: &str = "quote.output_net_of_g
 /// Metric describing the difference in output value net of fee between our
 /// quote and the source quote, in basis points
 pub const QUOTE_OUTPUT_NET_OF_FEE_DIFF_BPS_METRIC: &str = "quote.output_net_of_fee_diff_bps";
+/// Metric describing the difference in output value net of gas and fee between
+/// our quote and the source quote, in basis points
+pub const QUOTE_NET_OUTPUT_DIFF_BPS_METRIC: &str = "quote.net_output_diff_bps";
 
 // ---------------
 // | METRIC TAGS |
@@ -73,3 +76,7 @@ pub const SOURCE_OUTPUT_NET_OF_GAS_TAG: &str = "source_output_net_of_gas";
 pub const OUR_OUTPUT_NET_OF_FEE_TAG: &str = "our_output_net_of_fee";
 /// Metric tag for the comparison source's output net of fee
 pub const SOURCE_OUTPUT_NET_OF_FEE_TAG: &str = "source_output_net_of_fee";
+/// Metric tag for our output net of gas and fee
+pub const OUR_NET_OUTPUT_TAG: &str = "our_net_output";
+/// Metric tag for the comparison source's output net of gas and fee
+pub const SOURCE_NET_OUTPUT_TAG: &str = "source_net_output";

--- a/auth/auth-server/src/telemetry/quote_comparison/handler.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/handler.rs
@@ -9,11 +9,13 @@ use renegade_common::types::token::Token;
 
 use renegade_api::http::external_match::AtomicMatchApiBundle;
 
-use crate::telemetry::helpers::record_output_value_net_of_gas_comparison;
 use crate::{
     error::AuthServerError,
     telemetry::{
-        helpers::{record_comparison, record_output_value_net_of_fee_comparison},
+        helpers::{
+            record_net_output_value_comparison, record_output_value_net_of_fee_comparison,
+            record_output_value_net_of_gas_comparison, record_quote_price_comparison,
+        },
         sources::{QuoteResponse, QuoteSource},
     },
 };
@@ -85,9 +87,10 @@ impl QuoteComparisonHandler {
         let usdc_per_gas = self.get_usdc_per_gas().await?;
         let comparison = QuoteComparison { our_quote, source_quote: &quote, usdc_per_gas };
 
-        record_comparison(&comparison, side, &labels);
+        record_quote_price_comparison(&comparison, side, &labels);
         record_output_value_net_of_gas_comparison(&comparison, side, &labels);
         record_output_value_net_of_fee_comparison(&comparison, side, &labels);
+        record_net_output_value_comparison(&comparison, side, &labels);
         Ok(())
     }
 }

--- a/auth/auth-server/src/telemetry/quote_comparison/mod.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/mod.rs
@@ -63,4 +63,13 @@ impl<'a> QuoteComparison<'a> {
 
         calc_bps_diff(our_output_value_net_of_fee, source_output_value_net_of_fee)
     }
+
+    /// Calculate the net output value difference in basis points (bps).
+    /// Positive bps indicates our quote is better.
+    pub fn net_output_value_diff_bps(&self, usdc_per_gas: f64, side: OrderSide) -> f64 {
+        let our_net_output = self.our_quote.output_net_of_gas_and_fee(side, usdc_per_gas);
+        let source_net_output = self.source_quote.output_net_of_gas_and_fee(side, usdc_per_gas);
+
+        calc_bps_diff(our_net_output, source_net_output)
+    }
 }

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -63,6 +63,12 @@ impl QuoteResponse {
         self.deduct_fees(amount, &token)
     }
 
+    /// Calculates output value with gas and fees deducted
+    pub fn output_net_of_gas_and_fee(&self, side: OrderSide, usdc_per_gas: f64) -> f64 {
+        let value = self.output_net_of_fee(side);
+        self.deduct_gas(value, side, usdc_per_gas)
+    }
+
     /// Helper to apply gas cost deduction based on order side
     fn deduct_gas(&self, value: f64, side: OrderSide, usdc_per_gas: f64) -> f64 {
         let gas_cost_usdc = self.gas_cost(usdc_per_gas);


### PR DESCRIPTION
### Purpose
This PR records metrics net of both gas costs and fees.

### Testing
- [x] Tested locally
- [ ] Test in testnet