### PR TITLE
auth-server: handle_external_match: mutate calldata for gas sponsorship

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ target/
 
 .vscode/
 /.gitattributes
+
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ name = "auth-server"
 version = "0.1.0"
 dependencies = [
  "aes-gcm",
+ "alloy-primitives",
  "alloy-sol-types",
  "arbitrum-client",
  "auth-server-api",
@@ -755,6 +756,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "thiserror 1.0.69",
  "tokio",
  "tokio-postgres",
@@ -3704,6 +3706,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -37,3 +37,12 @@ pub struct CreateApiKeyRequest {
     /// A description of the API key's purpose
     pub description: String,
 }
+
+/// The query parameters accepted by the external quote assembly endpoint
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ExternalQuoteAssemblyQueryParams {
+    /// Whether to use gas sponsorship for the assembled quote
+    pub use_gas_sponsorship: Option<bool>,
+    /// The address to refund gas to
+    pub refund_address: Option<String>,
+}

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -24,6 +24,7 @@ native-tls = "0.2"
 # === Cryptography === #
 aes-gcm = "0.10.1"
 alloy-sol-types = "=0.7.7"
+alloy-primitives = { version = "=0.7.7", features = ["serde", "k256"] }
 ethers = "2"
 rand = "0.8.5"
 
@@ -48,6 +49,7 @@ futures-util = "0.3"
 metrics = "=0.22.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_urlencoded = "0.7"
 thiserror = "1.0"
 tracing = "0.1"
 uuid = { version = "1.0", features = ["serde", "v4"] }

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -31,6 +31,12 @@ pub enum AuthServerError {
     /// An error executing an HTTP request
     #[error("Http: {0}")]
     Http(String),
+    /// An error mutating calldata for gas sponsorship
+    #[error("Calldata mutation error: {0}")]
+    CalldataMutation(String),
+    /// An error signing a message
+    #[error("Signing error: {0}")]
+    Signing(String),
     /// A miscellaneous error
     #[error("Error: {0}")]
     Custom(String),
@@ -71,6 +77,18 @@ impl AuthServerError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn unauthorized<T: ToString>(msg: T) -> Self {
         Self::Unauthorized(msg.to_string())
+    }
+
+    /// Create a new calldata mutation error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn calldata_mutation<T: ToString>(msg: T) -> Self {
+        Self::CalldataMutation(msg.to_string())
+    }
+
+    /// Create a new signing error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn signing<T: ToString>(msg: T) -> Self {
+        Self::Signing(msg.to_string())
     }
 }
 

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -4,8 +4,11 @@ use aes_gcm::{
     aead::{Aead, KeyInit},
     AeadCore, Aes128Gcm,
 };
+use alloy_primitives::{Address, Bytes, Parity, Signature, U256};
 use base64::{engine::general_purpose, Engine as _};
-use rand::thread_rng;
+use contracts_common::constants::NUM_BYTES_SIGNATURE;
+use ethers::{core::k256::ecdsa::SigningKey, utils::keccak256};
+use rand::{thread_rng, Rng};
 use serde_json::json;
 use warp::reply::Reply;
 
@@ -48,6 +51,54 @@ pub fn aes_decrypt(value: &str, key: &[u8]) -> Result<String, AuthServerError> {
         cipher.decrypt(nonce.into(), ciphertext).map_err(AuthServerError::decryption)?;
     let plaintext = String::from_utf8(plaintext_bytes).map_err(AuthServerError::decryption)?;
     Ok(plaintext)
+}
+
+/// Generate a random nonce for gas sponsorship, signing it and the provided
+/// refund address
+pub fn gen_signed_sponsorship_nonce(
+    refund_address: Address,
+    gas_sponsor_auth_key: &SigningKey,
+) -> Result<(U256, Bytes), AuthServerError> {
+    // Generate a random sponsorship nonce
+    let mut nonce_bytes = [0u8; U256::BYTES];
+    thread_rng().fill(&mut nonce_bytes);
+
+    // Generate a signature over the nonce + refund address using the gas sponsor
+    // key
+    let mut message = [0_u8; U256::BYTES + Address::len_bytes()];
+    message[..U256::BYTES].copy_from_slice(&nonce_bytes);
+    message[U256::BYTES..].copy_from_slice(refund_address.as_ref());
+
+    let signature = sign_message(&message, gas_sponsor_auth_key)?.into();
+    let nonce = U256::from_be_bytes(nonce_bytes);
+
+    Ok((nonce, signature))
+}
+
+/// Sign a message using a secp256k1 key, serializing the signature to bytes
+pub fn sign_message(
+    message: &[u8],
+    key: &SigningKey,
+) -> Result<[u8; NUM_BYTES_SIGNATURE], AuthServerError> {
+    let message_hash = keccak256(message);
+    let (k256_sig, recid) =
+        key.sign_prehash_recoverable(&message_hash).map_err(AuthServerError::signing)?;
+
+    let parity = Parity::Eip155(recid.to_byte() as u64);
+
+    let signature =
+        Signature::from_signature_and_parity(k256_sig, parity).map_err(AuthServerError::signing)?;
+
+    Ok(signature.as_bytes())
+}
+
+/// Get the function selector from calldata
+pub fn get_selector(calldata: &[u8]) -> Result<[u8; 4], AuthServerError> {
+    calldata
+        .get(0..4)
+        .ok_or(AuthServerError::serde("expected selector"))?
+        .try_into()
+        .map_err(AuthServerError::serde)
 }
 
 #[cfg(test)]

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -7,9 +7,8 @@ use renegade_api::http::external_match::AtomicMatchApiBundle;
 use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_common::types::token::Token;
 
-/// The gas estimation to use if fetching a gas estimation fails
-/// From https://github.com/renegade-fi/renegade/blob/main/workers/api-server/src/http/external_match.rs/#L62
-const DEFAULT_GAS_ESTIMATION: u64 = 4_000_000; // 4m
+use crate::server::handle_external_match::DEFAULT_GAS_ESTIMATION;
+
 /// The name of our quote source
 const RENEGADE_SOURCE_NAME: &str = "renegade";
 


### PR DESCRIPTION
This PR adds the ability to redirect the transaction in assembled quotes to a configured gas sponsorship context by specifying the `use_gas_sponsorship` (and optionally `refund_address`) query params.

### Testing
I tested this by invoking external matches on a locally-running auth server pointed against the testnet stack, trying buys/sells on both normal ERC20s and native ETH. I asserted that the gas sponsorship contract was being invoked as expected and refunding w/in 15k gas worth of ETH to the desired address. I tested w/ and w/o a refund address set, as well.

### TODO
- Add gas sponsorship to the direct match bundle route
- Gas sponsorship rate limiting
- Telemetry/monitoring around gas sponsorship