### PR TITLE
auth-server: server: handel_external_match: use gas sponsorship rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,8 @@ dependencies = [
 name = "auth-server-api"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
+ "external-api",
  "serde",
  "uuid 1.12.0",
 ]

--- a/auth/auth-server-api/Cargo.toml
+++ b/auth/auth-server-api/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 uuid = "1.0"
+renegade-api = { workspace = true }
+alloy-primitives = { version = "=0.7.7" }

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -6,6 +6,8 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![feature(trivial_bounds)]
 
+use alloy_primitives::Address;
+use renegade_api::http::external_match::AtomicMatchApiBundle;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -38,6 +40,15 @@ pub struct CreateApiKeyRequest {
     pub description: String,
 }
 
+/// An external match response from the auth server
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalMatchResponse {
+    /// The external match bundle
+    pub match_bundle: AtomicMatchApiBundle,
+    /// Whether or not the match was sponsored
+    pub is_sponsored: bool,
+}
+
 /// The query parameters used for gas sponsorship
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GasSponsorshipQueryParams {
@@ -45,4 +56,15 @@ pub struct GasSponsorshipQueryParams {
     pub use_gas_sponsorship: Option<bool>,
     /// The address to refund gas to
     pub refund_address: Option<String>,
+}
+
+impl GasSponsorshipQueryParams {
+    /// Get the refund address, or the default zero address if not provided
+    pub fn get_refund_address(&self) -> Result<Address, String> {
+        self.refund_address
+            .as_ref()
+            .map(|s| s.parse())
+            .unwrap_or(Ok(Address::ZERO))
+            .map_err(|_| "invalid refund address".to_string())
+    }
 }

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -31,9 +31,9 @@ pub enum AuthServerError {
     /// An error executing an HTTP request
     #[error("Http: {0}")]
     Http(String),
-    /// An error mutating calldata for gas sponsorship
-    #[error("Calldata mutation error: {0}")]
-    CalldataMutation(String),
+    /// Gas sponsorship error
+    #[error("Gas sponsorship error: {0}")]
+    GasSponsorship(String),
     /// An error signing a message
     #[error("Signing error: {0}")]
     Signing(String),
@@ -79,16 +79,22 @@ impl AuthServerError {
         Self::Unauthorized(msg.to_string())
     }
 
-    /// Create a new calldata mutation error
+    /// Create a new gas sponsorship error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn calldata_mutation<T: ToString>(msg: T) -> Self {
-        Self::CalldataMutation(msg.to_string())
+    pub fn gas_sponsorship<T: ToString>(msg: T) -> Self {
+        Self::GasSponsorship(msg.to_string())
     }
 
     /// Create a new signing error
     #[allow(clippy::needless_pass_by_value)]
     pub fn signing<T: ToString>(msg: T) -> Self {
         Self::Signing(msg.to_string())
+    }
+
+    /// Create a new custom error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom<T: ToString>(msg: T) -> Self {
+        Self::Custom(msg.to_string())
     }
 }
 

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -12,6 +12,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::unused_async)]
 #![feature(trivial_bounds)]
+#![feature(let_chains)]
 #![feature(duration_constructors)]
 
 pub(crate) mod error;

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
@@ -1,0 +1,270 @@
+//! Handler code for proxied relayer requests
+//!
+//! At a high level the server must first authenticate the request, then forward
+//! it to the relayer with admin authentication
+
+use alloy_primitives::Address;
+use alloy_sol_types::{sol, SolCall};
+use auth_server_api::ExternalMatchResponse;
+use bytes::Bytes;
+use ethers::contract::abigen;
+use ethers::types::{transaction::eip2718::TypedTransaction, TxHash, U256};
+use ethers::utils::format_ether;
+use http::header::CONTENT_LENGTH;
+use http::Response;
+use renegade_arbitrum_client::abi::{
+    processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+};
+use tracing::info;
+
+use renegade_api::http::external_match::ExternalMatchResponse as RelayerExternalMatchResponse;
+
+use super::Server;
+use crate::error::AuthServerError;
+use crate::server::helpers::{gen_signed_sponsorship_nonce, get_selector};
+use crate::telemetry::helpers::record_gas_sponsorship_metrics;
+
+// -------
+// | ABI |
+// -------
+
+// The ABI for gas sponsorship functions
+sol! {
+    function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
+    function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
+}
+
+// The ABI for gas sponsorship events
+abigen!(
+    GasSponsorContract,
+    r#"[
+        event AmountSponsored(uint256 indexed amount, uint256 indexed nonce)
+    ]"#
+);
+
+// ---------------
+// | Server Impl |
+// ---------------
+
+/// Handle a proxied request
+impl Server {
+    /// Mutate a quote assembly response to invoke gas sponsorship
+    pub(crate) fn mutate_response_for_gas_sponsorship(
+        &self,
+        resp: &mut Response<Bytes>,
+        is_sponsored: bool,
+        refund_address: Address,
+    ) -> Result<(), AuthServerError> {
+        let mut relayer_external_match_resp: RelayerExternalMatchResponse =
+            serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
+
+        relayer_external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
+
+        if is_sponsored {
+            info!("Sponsoring match bundle via gas sponsor");
+
+            let gas_sponsor_calldata = self
+                .generate_gas_sponsor_calldata(&relayer_external_match_resp, refund_address)?
+                .into();
+
+            relayer_external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
+        }
+
+        let external_match_resp = ExternalMatchResponse {
+            match_bundle: relayer_external_match_resp.match_bundle,
+            is_sponsored,
+        };
+
+        let body =
+            Bytes::from(serde_json::to_vec(&external_match_resp).map_err(AuthServerError::serde)?);
+
+        resp.headers_mut().insert(CONTENT_LENGTH, body.len().into());
+        *resp.body_mut() = body;
+
+        Ok(())
+    }
+
+    /// Generate the calldata for sponsoring the given match via the gas sponsor
+    fn generate_gas_sponsor_calldata(
+        &self,
+        external_match_resp: &RelayerExternalMatchResponse,
+        refund_address: Address,
+    ) -> Result<Bytes, AuthServerError> {
+        let calldata = external_match_resp
+            .match_bundle
+            .settlement_tx
+            .data()
+            .ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
+
+        let selector = get_selector(calldata)?;
+
+        let gas_sponsor_calldata = match selector {
+            processAtomicMatchSettleCall::SELECTOR => {
+                self.sponsor_atomic_match_settle_call(calldata, refund_address)
+            },
+            processAtomicMatchSettleWithReceiverCall::SELECTOR => {
+                self.sponsor_atomic_match_settle_with_receiver_call(calldata, refund_address)
+            },
+            _ => {
+                return Err(AuthServerError::gas_sponsorship("invalid selector"));
+            },
+        }?;
+
+        Ok(gas_sponsor_calldata)
+    }
+
+    /// Create a `sponsorAtomicMatchSettle` call from `processAtomicMatchSettle`
+    /// calldata
+    fn sponsor_atomic_match_settle_call(
+        &self,
+        calldata: &[u8],
+        refund_address: Address,
+    ) -> Result<Bytes, AuthServerError> {
+        let call = processAtomicMatchSettleCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        let (nonce, signature) =
+            gen_signed_sponsorship_nonce(refund_address, &self.gas_sponsor_auth_key)?;
+
+        let sponsored_call = sponsorAtomicMatchSettleCall {
+            internal_party_match_payload: call.internal_party_match_payload,
+            valid_match_settle_atomic_statement: call.valid_match_settle_atomic_statement,
+            match_proofs: call.match_proofs,
+            match_linking_proofs: call.match_linking_proofs,
+            refund_address,
+            nonce,
+            signature,
+        };
+
+        Ok(sponsored_call.abi_encode().into())
+    }
+
+    /// Create a `sponsorAtomicMatchSettleWithReceiver` call from
+    /// `processAtomicMatchSettleWithReceiver` calldata
+    fn sponsor_atomic_match_settle_with_receiver_call(
+        &self,
+        calldata: &[u8],
+        refund_address: Address,
+    ) -> Result<Bytes, AuthServerError> {
+        let call = processAtomicMatchSettleWithReceiverCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        let (nonce, signature) =
+            gen_signed_sponsorship_nonce(refund_address, &self.gas_sponsor_auth_key)?;
+
+        let sponsored_call = sponsorAtomicMatchSettleWithReceiverCall {
+            receiver: call.receiver,
+            internal_party_match_payload: call.internal_party_match_payload,
+            valid_match_settle_atomic_statement: call.valid_match_settle_atomic_statement,
+            match_proofs: call.match_proofs,
+            match_linking_proofs: call.match_linking_proofs,
+            refund_address,
+            nonce,
+            signature,
+        };
+
+        Ok(sponsored_call.abi_encode().into())
+    }
+
+    /// Get the amount of Ether spent to sponsor the given settlement
+    /// transaction, and the associated transaction hash
+    async fn get_sponsorship_amount_and_tx(
+        &self,
+        settlement_tx: &TypedTransaction,
+    ) -> Result<Option<(U256, TxHash)>, AuthServerError> {
+        // Parse the nonce from the TX calldata
+        let calldata =
+            settlement_tx.data().ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
+
+        let selector = get_selector(calldata)?;
+
+        let nonce = match selector {
+            sponsorAtomicMatchSettleCall::SELECTOR => {
+                Self::get_nonce_from_sponsor_atomic_match_calldata(calldata)?
+            },
+            sponsorAtomicMatchSettleWithReceiverCall::SELECTOR => {
+                Self::get_nonce_from_sponsor_atomic_match_with_receiver_calldata(calldata)?
+            },
+            _ => {
+                return Err(AuthServerError::gas_sponsorship("invalid selector"));
+            },
+        };
+
+        // Search for the `AmountSponsored` event for the given nonce
+        let filter =
+            GasSponsorContract::new(self.gas_sponsor_address, self.arbitrum_client.client())
+                .event::<AmountSponsoredFilter>()
+                .address(self.gas_sponsor_address.into())
+                .topic2(nonce)
+                .from_block(self.start_block_num);
+
+        let events = filter.query_with_meta().await.map_err(AuthServerError::gas_sponsorship)?;
+
+        // If no event was found, we assume that gas was not sponsored for this nonce.
+        // This could be the case if the gas sponsor was underfunded or paused.
+        let amount_sponsored_with_tx =
+            events.last().map(|(event, meta)| (event.amount, meta.transaction_hash));
+
+        Ok(amount_sponsored_with_tx)
+    }
+
+    /// Record the gas sponsorship rate limit & metrics for a given settled
+    /// match
+    pub async fn record_settled_match_sponsorship(
+        &self,
+        match_resp: &ExternalMatchResponse,
+        key: String,
+        request_id: String,
+    ) -> Result<(), AuthServerError> {
+        if match_resp.is_sponsored
+            && let Some((gas_cost, tx_hash)) =
+                self.get_sponsorship_amount_and_tx(&match_resp.match_bundle.settlement_tx).await?
+        {
+            // Convert wei to ether using format_ether, then parse to f64
+            let gas_cost_eth: f64 =
+                format_ether(gas_cost).parse().map_err(AuthServerError::custom)?;
+
+            let eth_price: f64 = self
+                .price_reporter_client
+                .get_eth_price()
+                .await
+                .map_err(AuthServerError::custom)?;
+
+            let gas_sponsorship_value = eth_price * gas_cost_eth;
+
+            self.rate_limiter.record_gas_sponsorship(key, gas_sponsorship_value).await;
+
+            record_gas_sponsorship_metrics(gas_sponsorship_value, tx_hash, request_id);
+        }
+
+        Ok(())
+    }
+
+    /// Get the nonce from `sponsorAtomicMatchSettle` calldata
+    fn get_nonce_from_sponsor_atomic_match_calldata(
+        calldata: &[u8],
+    ) -> Result<U256, AuthServerError> {
+        let call = sponsorAtomicMatchSettleCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(U256::from_big_endian(&call.nonce.to_be_bytes_vec()))
+    }
+
+    /// Get the nonce from `sponsorAtomicMatchSettleWithReceiver` calldata
+    fn get_nonce_from_sponsor_atomic_match_with_receiver_calldata(
+        calldata: &[u8],
+    ) -> Result<U256, AuthServerError> {
+        let call = sponsorAtomicMatchSettleWithReceiverCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(U256::from_big_endian(&call.nonce.to_be_bytes_vec()))
+    }
+}

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -14,6 +14,14 @@ use warp::reply::Reply;
 
 use crate::error::AuthServerError;
 
+// -------------
+// | Constants |
+// -------------
+
+/// The gas estimation to use if fetching a gas estimation fails
+/// From https://github.com/renegade-fi/renegade/blob/main/workers/api-server/src/http/external_match.rs/#L62
+pub const DEFAULT_GAS_ESTIMATION: u64 = 4_000_000; // 4m
+
 /// The nonce size for AES128-GCM
 const NONCE_SIZE: usize = 12; // 12 bytes, 96 bits
 

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -4,7 +4,7 @@
 mod api_auth;
 pub(crate) mod handle_external_match;
 mod handle_key_management;
-mod helpers;
+pub(crate) mod helpers;
 mod queries;
 mod rate_limiter;
 
@@ -28,12 +28,7 @@ use diesel_async::{
     pooled_connection::{AsyncDieselConnectionManager, ManagerConfig},
     AsyncPgConnection,
 };
-use ethers::{
-    abi::Address,
-    core::k256::ecdsa::SigningKey,
-    types::{BlockNumber, U256},
-    utils::{format_ether, hex},
-};
+use ethers::{abi::Address, core::k256::ecdsa::SigningKey, types::BlockNumber, utils::hex};
 use http::{HeaderMap, Method, Response};
 use native_tls::TlsConnector;
 use postgres_native_tls::MakeTlsConnector;
@@ -251,23 +246,6 @@ impl Server {
             return false;
         }
         true
-    }
-
-    /// Record a gas sponsorship value for a given user
-    pub async fn record_gas_sponsorship(
-        &self,
-        key_description: String,
-        gas_cost: U256,
-    ) -> Result<(), AuthServerError> {
-        // Convert wei to ether using format_ether, then parse to f64
-        let gas_cost_eth: f64 = format_ether(gas_cost).parse().map_err(AuthServerError::custom)?;
-
-        let eth_price: f64 =
-            self.price_reporter_client.get_eth_price().await.map_err(AuthServerError::custom)?;
-
-        let gas_sponsorship_value = eth_price * gas_cost_eth;
-        self.rate_limiter.record_gas_sponsorship(key_description, gas_sponsorship_value).await;
-        Ok(())
     }
 
     // --- Caching --- //

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use alloy_sol_types::SolCall;
 use contracts_common::types::MatchPayload;
+use ethers::types::TxHash;
 use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalOrder};
 use renegade_arbitrum_client::{
     abi::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
@@ -35,7 +36,10 @@ use crate::{
     },
 };
 
-use super::{labels::SIDE_TAG, quote_comparison::QuoteComparison};
+use super::{
+    labels::{GAS_SPONSORSHIP_VALUE, REQUEST_ID_METRIC_TAG, SIDE_TAG, TX_HASH_METRIC_TAG},
+    quote_comparison::QuoteComparison,
+};
 
 // --- Constants --- //
 
@@ -269,6 +273,19 @@ pub(crate) async fn record_external_match_metrics(
     }
 
     Ok(())
+}
+
+/// Record the dollar value of sponsored gas for a given settled match
+pub(crate) fn record_gas_sponsorship_metrics(
+    gas_sponsorship_value: f64,
+    tx_hash: TxHash,
+    request_id: String,
+) {
+    let labels = vec![
+        (REQUEST_ID_METRIC_TAG.to_string(), request_id),
+        (TX_HASH_METRIC_TAG.to_string(), format!("{:#x}", tx_hash)),
+    ];
+    metrics::gauge!(GAS_SPONSORSHIP_VALUE, &labels).set(gas_sponsorship_value);
 }
 
 // --- Settlement Processing --- //

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -42,6 +42,9 @@ pub const QUOTE_OUTPUT_NET_OF_FEE_DIFF_BPS_METRIC: &str = "quote.output_net_of_f
 /// our quote and the source quote, in basis points
 pub const QUOTE_NET_OUTPUT_DIFF_BPS_METRIC: &str = "quote.net_output_diff_bps";
 
+/// Metric describing the value of gas sponsorship for a given request
+pub const GAS_SPONSORSHIP_VALUE: &str = "gas_sponsorship_value";
+
 // ---------------
 // | METRIC TAGS |
 // ---------------
@@ -80,3 +83,8 @@ pub const SOURCE_OUTPUT_NET_OF_FEE_TAG: &str = "source_output_net_of_fee";
 pub const OUR_NET_OUTPUT_TAG: &str = "our_net_output";
 /// Metric tag for the comparison source's output net of gas and fee
 pub const SOURCE_NET_OUTPUT_TAG: &str = "source_net_output";
+
+/// Metric tag to indicate that a match had its gas costs sponsored
+pub const GAS_SPONSORED_METRIC_TAG: &str = "gas_sponsored";
+/// Metric tag for a transaction hash
+pub const TX_HASH_METRIC_TAG: &str = "tx_hash";

--- a/auth/auth-server/src/telemetry/sources/http_utils.rs
+++ b/auth/auth-server/src/telemetry/sources/http_utils.rs
@@ -15,6 +15,18 @@ pub enum HttpError {
     /// An API error
     #[error("API error: {0}")]
     Api(String),
+
+    /// A response parsing error
+    #[error("Response parsing error: {0}")]
+    Parsing(String),
+}
+
+impl HttpError {
+    /// Create a new parsing error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn parsing<T: ToString>(msg: T) -> Self {
+        Self::Parsing(msg.to_string())
+    }
 }
 
 /// Sends a basic GET request

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -7,7 +7,7 @@ use renegade_api::http::external_match::AtomicMatchApiBundle;
 use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_common::types::token::Token;
 
-use crate::server::handle_external_match::DEFAULT_GAS_ESTIMATION;
+use crate::server::helpers::DEFAULT_GAS_ESTIMATION;
 
 /// The name of our quote source
 const RENEGADE_SOURCE_NAME: &str = "renegade";

--- a/funds-manager/funds-manager-api/src/types/gas.rs
+++ b/funds-manager/funds-manager-api/src/types/gas.rs
@@ -13,6 +13,8 @@ pub const REFILL_GAS_ROUTE: &str = "refill-gas";
 pub const REGISTER_GAS_WALLET_ROUTE: &str = "register-gas-wallet";
 /// The route to report active peers
 pub const REPORT_ACTIVE_PEERS_ROUTE: &str = "report-active-peers";
+/// The route to refill the gas sponsor contract
+pub const REFILL_GAS_SPONSOR_ROUTE: &str = "refill-gas-sponsor";
 
 // -------------
 // | Api Types |
@@ -66,4 +68,11 @@ pub struct RegisterGasWalletResponse {
 pub struct ReportActivePeersRequest {
     /// The list of active peers
     pub peers: Vec<String>,
+}
+
+/// The request body for refilling gas for the gas sponsor contract
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RefillGasSponsorRequest {
+    /// The amount of gas to top up the gas sponsor contract to
+    pub amount: f64,
 }

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -1,0 +1,120 @@
+//! Handlers for gas sponsor operations
+
+use alloy_sol_types::SolCall;
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::Middleware,
+    signers::{LocalWallet, Signer},
+    types::{BlockNumber, TransactionRequest},
+    utils::parse_ether,
+};
+use tracing::info;
+
+use crate::error::FundsManagerError;
+
+use super::{CustodyClient, DepositWithdrawSource};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The threshold beneath which we skip refilling gas for the gas sponsor
+///
+/// I.e. if the contract's balance is within this amount of the desired fill, we
+/// skip refilling
+pub const GAS_SPONSOR_REFILL_TOLERANCE: f64 = 0.001; // ETH
+
+// -------
+// | ABI |
+// -------
+
+// The ABI for gas sponsorship functions
+#[allow(clippy::missing_docs_in_private_items)]
+mod sol {
+    use alloy_sol_types::sol;
+
+    sol! {
+        function receiveEth() external payable;
+    }
+}
+
+impl CustodyClient {
+    // ------------
+    // | Handlers |
+    // ------------
+
+    /// Refill the gas sponsor
+    pub(crate) async fn refill_gas_sponsor(&self, fill_to: f64) -> Result<(), FundsManagerError> {
+        let gas_sponsor_address = format!("{:#x}", self.gas_sponsor_address);
+        let bal = self.get_ether_balance(&gas_sponsor_address).await?;
+        if bal + GAS_SPONSOR_REFILL_TOLERANCE < fill_to {
+            self.send_eth_to_gas_sponsor(fill_to - bal).await?;
+            info!("Refilled gas sponsor to {fill_to} ETH");
+        }
+
+        Ok(())
+    }
+
+    /// Send ETH to the gas sponsor contract
+    async fn send_eth_to_gas_sponsor(&self, amount: f64) -> Result<(), FundsManagerError> {
+        // Get the gas hot wallet's private key
+        let source = DepositWithdrawSource::Gas.vault_name();
+        let gas_wallet = self.get_hot_wallet_by_vault(source).await?;
+        let signer = self.get_hot_wallet_private_key(&gas_wallet.address).await?;
+
+        // Check that the gas wallet has enough ETH to cover the refill
+        let my_balance = self.get_ether_balance(&gas_wallet.address).await?;
+        if my_balance < amount {
+            return Err(FundsManagerError::custom(
+                "gas wallet does not have enough ETH to cover the refill",
+            ));
+        }
+
+        // Invoke the `receiveEth` function on the gas sponsor contract
+        self.send_receive_eth_tx(amount, signer).await
+    }
+
+    /// Send a transaction to the gas sponsor contract to invoke the
+    /// `receiveEth` function
+    async fn send_receive_eth_tx(
+        &self,
+        amount: f64,
+        signer: LocalWallet,
+    ) -> Result<(), FundsManagerError> {
+        let wallet = signer.with_chain_id(self.chain_id);
+        let provider = self.get_rpc_provider()?;
+        let client = SignerMiddleware::new(provider, wallet);
+
+        let calldata = sol::receiveEthCall {}.abi_encode();
+
+        let amount_units = parse_ether(amount.to_string()).map_err(FundsManagerError::parse)?;
+
+        let latest_block = client
+            .get_block(BlockNumber::Latest)
+            .await
+            .map_err(FundsManagerError::arbitrum)?
+            .ok_or(FundsManagerError::arbitrum("No latest block found".to_string()))?;
+
+        let latest_basefee = latest_block
+            .base_fee_per_gas
+            .ok_or(FundsManagerError::arbitrum("No basefee found".to_string()))?;
+
+        let tx = TransactionRequest::new()
+            .data(calldata)
+            .to(self.gas_sponsor_address)
+            .value(amount_units)
+            .gas_price(latest_basefee * 2);
+
+        info!("Sending {amount} ETH to the gas sponsor contract");
+
+        let pending_tx =
+            client.send_transaction(tx, None).await.map_err(FundsManagerError::arbitrum)?;
+
+        pending_tx
+            .await
+            .map_err(FundsManagerError::arbitrum)?
+            .ok_or_else(|| FundsManagerError::arbitrum("Transaction failed".to_string()))?;
+
+        Ok(())
+    }
+}

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -1,5 +1,6 @@
 //! Manages the custody backend for the funds manager
 pub mod deposit;
+pub mod gas_sponsor;
 pub mod gas_wallets;
 mod hot_wallets;
 mod queries;
@@ -74,6 +75,8 @@ pub struct CustodyClient {
     db_pool: Arc<DbPool>,
     /// The AWS config
     aws_config: AwsConfig,
+    /// The gas sponsor contract address
+    gas_sponsor_address: Address,
 }
 
 impl CustodyClient {
@@ -86,6 +89,7 @@ impl CustodyClient {
         arbitrum_rpc_url: String,
         db_pool: Arc<DbPool>,
         aws_config: AwsConfig,
+        gas_sponsor_address: Address,
     ) -> Self {
         let fireblocks_api_secret = fireblocks_api_secret.as_bytes().to_vec();
         Self {
@@ -95,6 +99,7 @@ impl CustodyClient {
             arbitrum_rpc_url,
             db_pool,
             aws_config,
+            gas_sponsor_address,
         }
     }
 

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -6,8 +6,8 @@ use crate::Server;
 use bytes::Bytes;
 use funds_manager_api::fees::{FeeWalletsResponse, WithdrawFeeBalanceRequest};
 use funds_manager_api::gas::{
-    CreateGasWalletResponse, RefillGasRequest, RegisterGasWalletRequest, RegisterGasWalletResponse,
-    ReportActivePeersRequest, WithdrawGasRequest,
+    CreateGasWalletResponse, RefillGasRequest, RefillGasSponsorRequest, RegisterGasWalletRequest,
+    RegisterGasWalletResponse, ReportActivePeersRequest, WithdrawGasRequest,
 };
 use funds_manager_api::hot_wallets::{
     CreateHotWalletRequest, CreateHotWalletResponse, HotWalletBalancesResponse,
@@ -32,6 +32,8 @@ pub const GAS_ASSET_NAME: &str = "ETH";
 pub const MAX_GAS_WITHDRAWAL_AMOUNT: f64 = 1.; // ETH
 /// The maximum amount that a request may refill gas to
 pub const MAX_GAS_REFILL_AMOUNT: f64 = 0.1; // ETH
+/// The maximum amount of ETH that a request may refill the gas sponsor to
+pub const MAX_GAS_SPONSOR_REFILL_AMOUNT: f64 = 0.5; // ETH
 /// The maximum value of a quoter withdrawal that can be processed in a single
 /// request
 pub const MAX_WITHDRAWAL_VALUE: f64 = 50_000.; // USD
@@ -255,6 +257,24 @@ pub(crate) async fn report_active_peers_handler(
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
+    let resp = json!({});
+    Ok(warp::reply::json(&resp))
+}
+
+/// Handler for refilling gas for the gas sponsor contract
+pub(crate) async fn refill_gas_sponsor_handler(
+    req: RefillGasSponsorRequest,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    // Check that the refill amount is less than the max
+    if req.amount > MAX_GAS_SPONSOR_REFILL_AMOUNT {
+        return Err(warp::reject::custom(ApiError::BadRequest(format!(
+            "Requested amount {} ETH exceeds maximum allowed refill of {} ETH",
+            req.amount, MAX_GAS_SPONSOR_REFILL_AMOUNT
+        ))));
+    }
+
+    server.custody_client.refill_gas_sponsor(req.amount).await?;
     let resp = json!({});
     Ok(warp::reply::json(&resp))
 }

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -4,7 +4,7 @@
 use std::{error::Error, str::FromStr, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region, SdkConfig};
-use ethers::signers::LocalWallet;
+use ethers::{signers::LocalWallet, types::Address};
 use renegade_arbitrum_client::{
     client::{ArbitrumClient, ArbitrumClientConfig},
     constants::Chain,
@@ -97,6 +97,8 @@ impl Server {
         let db_pool = create_db_pool(&args.db_url).await?;
         let arc_pool = Arc::new(db_pool);
 
+        let gas_sponsor_address = Address::from_str(&args.gas_sponsor_address)?;
+
         let custody_client = CustodyClient::new(
             chain_id,
             args.fireblocks_api_key,
@@ -104,6 +106,7 @@ impl Server {
             args.rpc_url.clone(),
             arc_pool.clone(),
             config.clone(),
+            gas_sponsor_address,
         );
 
         let execution_client = ExecutionClient::new(


### PR DESCRIPTION
This PR integrates usage of the gas sponsorship rate limiter into the external match paths in the auth server. We do this by checking the rate limit when a request for a sponsored match comes in, and consuming the user's gas sponsorship budget if they settle the bundle by fetching the ETH price and the amount of gas sponsored for the request.

### Testing
- [x] Tested w/ local auth server against testnet using a low rate limit, confirmed that rate limit was exceeded & refilled accordingly