### PR TITLE
price-reporter: add disabled exchanges config option

### DIFF
--- a/price-reporter/src/http_server.rs
+++ b/price-reporter/src/http_server.rs
@@ -61,6 +61,7 @@ impl HttpServer {
                     config.remap_chain,
                     price_streams,
                     config.exchange_conn_config.clone(),
+                    config.disabled_exchanges.clone(),
                 )),
             )
             .unwrap();


### PR DESCRIPTION
This PR adds a `DISABLED_EXCHANGES` environment variable to the price reporter config which can be used to disable the initialization of price streams for the specified exchanges. This can be useful when the exchange APIs themselves are experiencing downtime, which would force downtime upon our own price reporter due to the self-shutdown logic invoked when reconnection retries are exhausted.