### PR TITLE
funds-manager: custody_client: gas_sponsor: add gas sponsor refill route

### DIFF
--- a/funds-manager/funds-manager-api/src/types/gas.rs
+++ b/funds-manager/funds-manager-api/src/types/gas.rs
@@ -13,6 +13,8 @@ pub const REFILL_GAS_ROUTE: &str = "refill-gas";
 pub const REGISTER_GAS_WALLET_ROUTE: &str = "register-gas-wallet";
 /// The route to report active peers
 pub const REPORT_ACTIVE_PEERS_ROUTE: &str = "report-active-peers";
+/// The route to refill the gas sponsor contract
+pub const REFILL_GAS_SPONSOR_ROUTE: &str = "refill-gas-sponsor";
 
 // -------------
 // | Api Types |
@@ -66,4 +68,11 @@ pub struct RegisterGasWalletResponse {
 pub struct ReportActivePeersRequest {
     /// The list of active peers
     pub peers: Vec<String>,
+}
+
+/// The request body for refilling gas for the gas sponsor contract
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RefillGasSponsorRequest {
+    /// The amount of gas to top up the gas sponsor contract to
+    pub amount: f64,
 }

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -1,0 +1,120 @@
+//! Handlers for gas sponsor operations
+
+use alloy_sol_types::SolCall;
+use ethers::{
+    middleware::SignerMiddleware,
+    providers::Middleware,
+    signers::{LocalWallet, Signer},
+    types::{BlockNumber, TransactionRequest},
+    utils::parse_ether,
+};
+use tracing::info;
+
+use crate::error::FundsManagerError;
+
+use super::{CustodyClient, DepositWithdrawSource};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The threshold beneath which we skip refilling gas for the gas sponsor
+///
+/// I.e. if the contract's balance is within this amount of the desired fill, we
+/// skip refilling
+pub const GAS_SPONSOR_REFILL_TOLERANCE: f64 = 0.001; // ETH
+
+// -------
+// | ABI |
+// -------
+
+// The ABI for gas sponsorship functions
+#[allow(clippy::missing_docs_in_private_items)]
+mod sol {
+    use alloy_sol_types::sol;
+
+    sol! {
+        function receiveEth() external payable;
+    }
+}
+
+impl CustodyClient {
+    // ------------
+    // | Handlers |
+    // ------------
+
+    /// Refill the gas sponsor
+    pub(crate) async fn refill_gas_sponsor(&self, fill_to: f64) -> Result<(), FundsManagerError> {
+        let gas_sponsor_address = format!("{:#x}", self.gas_sponsor_address);
+        let bal = self.get_ether_balance(&gas_sponsor_address).await?;
+        if bal + GAS_SPONSOR_REFILL_TOLERANCE < fill_to {
+            self.send_eth_to_gas_sponsor(fill_to - bal).await?;
+            info!("Refilled gas sponsor to {fill_to} ETH");
+        }
+
+        Ok(())
+    }
+
+    /// Send ETH to the gas sponsor contract
+    async fn send_eth_to_gas_sponsor(&self, amount: f64) -> Result<(), FundsManagerError> {
+        // Get the gas hot wallet's private key
+        let source = DepositWithdrawSource::Gas.vault_name();
+        let gas_wallet = self.get_hot_wallet_by_vault(source).await?;
+        let signer = self.get_hot_wallet_private_key(&gas_wallet.address).await?;
+
+        // Check that the gas wallet has enough ETH to cover the refill
+        let my_balance = self.get_ether_balance(&gas_wallet.address).await?;
+        if my_balance < amount {
+            return Err(FundsManagerError::custom(
+                "gas wallet does not have enough ETH to cover the refill",
+            ));
+        }
+
+        // Invoke the `receiveEth` function on the gas sponsor contract
+        self.send_receive_eth_tx(amount, signer).await
+    }
+
+    /// Send a transaction to the gas sponsor contract to invoke the
+    /// `receiveEth` function
+    async fn send_receive_eth_tx(
+        &self,
+        amount: f64,
+        signer: LocalWallet,
+    ) -> Result<(), FundsManagerError> {
+        let wallet = signer.with_chain_id(self.chain_id);
+        let provider = self.get_rpc_provider()?;
+        let client = SignerMiddleware::new(provider, wallet);
+
+        let calldata = sol::receiveEthCall {}.abi_encode();
+
+        let amount_units = parse_ether(amount.to_string()).map_err(FundsManagerError::parse)?;
+
+        let latest_block = client
+            .get_block(BlockNumber::Latest)
+            .await
+            .map_err(FundsManagerError::arbitrum)?
+            .ok_or(FundsManagerError::arbitrum("No latest block found".to_string()))?;
+
+        let latest_basefee = latest_block
+            .base_fee_per_gas
+            .ok_or(FundsManagerError::arbitrum("No basefee found".to_string()))?;
+
+        let tx = TransactionRequest::new()
+            .data(calldata)
+            .to(self.gas_sponsor_address)
+            .value(amount_units)
+            .gas_price(latest_basefee * 2);
+
+        info!("Sending {amount} ETH to the gas sponsor contract");
+
+        let pending_tx =
+            client.send_transaction(tx, None).await.map_err(FundsManagerError::arbitrum)?;
+
+        pending_tx
+            .await
+            .map_err(FundsManagerError::arbitrum)?
+            .ok_or_else(|| FundsManagerError::arbitrum("Transaction failed".to_string()))?;
+
+        Ok(())
+    }
+}

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -1,5 +1,6 @@
 //! Manages the custody backend for the funds manager
 pub mod deposit;
+pub mod gas_sponsor;
 pub mod gas_wallets;
 mod hot_wallets;
 mod queries;
@@ -74,6 +75,8 @@ pub struct CustodyClient {
     db_pool: Arc<DbPool>,
     /// The AWS config
     aws_config: AwsConfig,
+    /// The gas sponsor contract address
+    gas_sponsor_address: Address,
 }
 
 impl CustodyClient {
@@ -86,6 +89,7 @@ impl CustodyClient {
         arbitrum_rpc_url: String,
         db_pool: Arc<DbPool>,
         aws_config: AwsConfig,
+        gas_sponsor_address: Address,
     ) -> Self {
         let fireblocks_api_secret = fireblocks_api_secret.as_bytes().to_vec();
         Self {
@@ -95,6 +99,7 @@ impl CustodyClient {
             arbitrum_rpc_url,
             db_pool,
             aws_config,
+            gas_sponsor_address,
         }
     }
 

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -6,8 +6,8 @@ use crate::Server;
 use bytes::Bytes;
 use funds_manager_api::fees::{FeeWalletsResponse, WithdrawFeeBalanceRequest};
 use funds_manager_api::gas::{
-    CreateGasWalletResponse, RefillGasRequest, RegisterGasWalletRequest, RegisterGasWalletResponse,
-    ReportActivePeersRequest, WithdrawGasRequest,
+    CreateGasWalletResponse, RefillGasRequest, RefillGasSponsorRequest, RegisterGasWalletRequest,
+    RegisterGasWalletResponse, ReportActivePeersRequest, WithdrawGasRequest,
 };
 use funds_manager_api::hot_wallets::{
     CreateHotWalletRequest, CreateHotWalletResponse, HotWalletBalancesResponse,
@@ -32,6 +32,8 @@ pub const GAS_ASSET_NAME: &str = "ETH";
 pub const MAX_GAS_WITHDRAWAL_AMOUNT: f64 = 1.; // ETH
 /// The maximum amount that a request may refill gas to
 pub const MAX_GAS_REFILL_AMOUNT: f64 = 0.1; // ETH
+/// The maximum amount of ETH that a request may refill the gas sponsor to
+pub const MAX_GAS_SPONSOR_REFILL_AMOUNT: f64 = 0.5; // ETH
 /// The maximum value of a quoter withdrawal that can be processed in a single
 /// request
 pub const MAX_WITHDRAWAL_VALUE: f64 = 50_000.; // USD
@@ -255,6 +257,24 @@ pub(crate) async fn report_active_peers_handler(
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
+    let resp = json!({});
+    Ok(warp::reply::json(&resp))
+}
+
+/// Handler for refilling gas for the gas sponsor contract
+pub(crate) async fn refill_gas_sponsor_handler(
+    req: RefillGasSponsorRequest,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    // Check that the refill amount is less than the max
+    if req.amount > MAX_GAS_SPONSOR_REFILL_AMOUNT {
+        return Err(warp::reject::custom(ApiError::BadRequest(format!(
+            "Requested amount {} ETH exceeds maximum allowed refill of {} ETH",
+            req.amount, MAX_GAS_SPONSOR_REFILL_AMOUNT
+        ))));
+    }
+
+    server.custody_client.refill_gas_sponsor(req.amount).await?;
     let resp = json!({});
     Ok(warp::reply::json(&resp))
 }

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -4,7 +4,7 @@
 use std::{error::Error, str::FromStr, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region, SdkConfig};
-use ethers::signers::LocalWallet;
+use ethers::{signers::LocalWallet, types::Address};
 use renegade_arbitrum_client::{
     client::{ArbitrumClient, ArbitrumClientConfig},
     constants::Chain,
@@ -97,6 +97,8 @@ impl Server {
         let db_pool = create_db_pool(&args.db_url).await?;
         let arc_pool = Arc::new(db_pool);
 
+        let gas_sponsor_address = Address::from_str(&args.gas_sponsor_address)?;
+
         let custody_client = CustodyClient::new(
             chain_id,
             args.fireblocks_api_key,
@@ -104,6 +106,7 @@ impl Server {
             args.rpc_url.clone(),
             arc_pool.clone(),
             config.clone(),
+            gas_sponsor_address,
         );
 
         let execution_client = ExecutionClient::new(


### PR DESCRIPTION
This PR adds the `/custody/gas/refill-gas-sponsor` route to the funds manager, used to refill the gas sponsor's ETH balance. This is necessary, i.e. the `/custody/gas/withdraw-gas` route can't be used, since the `receiveEth` method on the gas sponsor must be invoked.

### Testing
This was tested by running a local funds manager against the testnet stack & invoking the endpoint.