### PR TITLE
auth-server: telemetry: gracefully handle quote comparison errors

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -37,6 +37,9 @@ pub enum AuthServerError {
     /// An error signing a message
     #[error("Signing error: {0}")]
     Signing(String),
+    /// An error comparing quotes
+    #[error("Quote comparison error: {0}")]
+    QuoteComparison(String),
     /// A miscellaneous error
     #[error("Error: {0}")]
     Custom(String),
@@ -89,6 +92,12 @@ impl AuthServerError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn signing<T: ToString>(msg: T) -> Self {
         Self::Signing(msg.to_string())
+    }
+
+    /// Create a new quote comparison error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn quote_comparison<T: ToString>(msg: T) -> Self {
+        Self::QuoteComparison(msg.to_string())
     }
 
     /// Create a new custom error

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -247,7 +247,8 @@ impl Server {
         }
 
         // Record metrics
-        record_external_match_metrics(&order, match_resp.match_bundle, &labels, did_settle).await?;
+        record_external_match_metrics(&order, &match_resp.match_bundle, &labels, did_settle)
+            .await?;
 
         Ok(())
     }

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -244,12 +244,12 @@ pub(crate) fn record_fill_ratio(
 /// Records all metrics related to an external match request and response
 pub(crate) async fn record_external_match_metrics(
     order: &ExternalOrder,
-    match_bundle: AtomicMatchApiBundle,
+    match_bundle: &AtomicMatchApiBundle,
     labels: &[(String, String)],
     did_settle: bool,
 ) -> Result<(), AuthServerError> {
     // Get decimal-corrected price
-    let price = calculate_implied_price(&match_bundle, true /* decimal_correct */)?;
+    let price = calculate_implied_price(match_bundle, true /* decimal_correct */)?;
 
     // Record request metrics
     if let Err(e) = record_external_match_request_metrics(order, price, labels) {
@@ -264,11 +264,11 @@ pub(crate) async fn record_external_match_metrics(
     }
 
     // Record response metrics
-    if let Err(e) = record_external_match_response_metrics(&match_bundle, labels) {
+    if let Err(e) = record_external_match_response_metrics(match_bundle, labels) {
         warn!("Error recording response metrics: {e}");
     }
 
-    if let Err(e) = record_external_match_settlement_metrics(&match_bundle, did_settle, labels) {
+    if let Err(e) = record_external_match_settlement_metrics(match_bundle, did_settle, labels) {
         warn!("Error recording settlement metrics: {e}");
     }
 

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -7,7 +7,7 @@ use renegade_api::http::external_match::AtomicMatchApiBundle;
 use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_common::types::token::Token;
 
-use crate::server::helpers::DEFAULT_GAS_ESTIMATION;
+use crate::{error::AuthServerError, server::helpers::DEFAULT_GAS_ESTIMATION};
 
 /// The name of our quote source
 const RENEGADE_SOURCE_NAME: &str = "renegade";
@@ -129,11 +129,12 @@ impl QuoteSource {
         quote_token: Token,
         side: OrderSide,
         amount: u128,
-    ) -> QuoteResponse {
+    ) -> Result<QuoteResponse, AuthServerError> {
         match self {
-            QuoteSource::Odos(source) => {
-                source.get_quote(base_token, quote_token, side, amount).await
-            },
+            QuoteSource::Odos(source) => source
+                .get_quote(base_token, quote_token, side, amount)
+                .await
+                .map_err(AuthServerError::quote_comparison),
         }
     }
 }

--- a/auth/auth-server/src/telemetry/sources/odos/error.rs
+++ b/auth/auth-server/src/telemetry/sources/odos/error.rs
@@ -8,4 +8,15 @@ pub enum OdosError {
     /// An error with the input
     #[error("Invalid input: {0}")]
     Input(String),
+    /// An error with the Odos API
+    #[error("Odos API error: {0}")]
+    Api(String),
+}
+
+impl OdosError {
+    /// Create a new API error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn api<T: ToString>(msg: T) -> Self {
+        Self::Api(msg.to_string())
+    }
 }


### PR DESCRIPTION
This PR ensures that we  gracefully handle errors in quote comparison recording so that we don't panic the thread.