### PR TITLE
auth: server: handle_external_match: gas_sponsorship: only redirect tx through gas sponsor when requested

### DIFF
--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -40,9 +40,9 @@ pub struct CreateApiKeyRequest {
     pub description: String,
 }
 
-/// An external match response from the auth server
+/// A sponsored match response from the auth server
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExternalMatchResponse {
+pub struct SponsoredMatchResponse {
     /// The external match bundle
     pub match_bundle: AtomicMatchApiBundle,
     /// Whether or not the match was sponsored

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
@@ -5,7 +5,7 @@
 
 use alloy_primitives::Address;
 use alloy_sol_types::{sol, SolCall};
-use auth_server_api::ExternalMatchResponse;
+use auth_server_api::SponsoredMatchResponse;
 use bytes::Bytes;
 use ethers::contract::abigen;
 use ethers::types::{transaction::eip2718::TypedTransaction, TxHash, U256};
@@ -17,7 +17,7 @@ use renegade_arbitrum_client::abi::{
 };
 use tracing::{info, warn};
 
-use renegade_api::http::external_match::ExternalMatchResponse as RelayerExternalMatchResponse;
+use renegade_api::http::external_match::ExternalMatchResponse;
 
 use super::Server;
 use crate::error::AuthServerError;
@@ -55,7 +55,7 @@ impl Server {
         is_sponsored: bool,
         refund_address: Address,
     ) -> Result<(), AuthServerError> {
-        let mut relayer_external_match_resp: RelayerExternalMatchResponse =
+        let mut relayer_external_match_resp: ExternalMatchResponse =
             serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
 
         relayer_external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
@@ -70,7 +70,7 @@ impl Server {
             relayer_external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
         }
 
-        let external_match_resp = ExternalMatchResponse {
+        let external_match_resp = SponsoredMatchResponse {
             match_bundle: relayer_external_match_resp.match_bundle,
             is_sponsored,
         };
@@ -87,7 +87,7 @@ impl Server {
     /// Generate the calldata for sponsoring the given match via the gas sponsor
     fn generate_gas_sponsor_calldata(
         &self,
-        external_match_resp: &RelayerExternalMatchResponse,
+        external_match_resp: &ExternalMatchResponse,
         refund_address: Address,
     ) -> Result<Bytes, AuthServerError> {
         let calldata = external_match_resp
@@ -220,7 +220,7 @@ impl Server {
     /// match
     pub async fn record_settled_match_sponsorship(
         &self,
-        match_resp: &ExternalMatchResponse,
+        match_resp: &SponsoredMatchResponse,
         key: String,
         request_id: String,
     ) -> Result<(), AuthServerError> {


### PR DESCRIPTION
This PR tweaks the external match & quote assembly endpoints to only redirect a bundle through the gas sponsor contract if sponsorship has been explicitly requested by the client. In this case, the bundle will be directed to the gas sponsor regardless of whether the user is rate-limited. This way, users that opt into sponsorship can always expect the same contract address to be used, users that opt out can continue expecting the darkpool to be used and don't have to do new token approvals.

Additionally, this change results in the API response type only including the `is_sponsored` field if sponsorship was explicitly requested. This way, users opting out of sponsorship can expect no changes to the response type.