### PR TITLE
auth-server: telemetry: await nullifier spend on correct selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ target/
 .vscode/
 /.gitattributes
 
-.env
+.env*

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
@@ -17,7 +17,7 @@ use renegade_arbitrum_client::abi::{
 };
 use tracing::{info, warn};
 
-use renegade_api::http::external_match::ExternalMatchResponse;
+use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalMatchResponse};
 
 use super::Server;
 use crate::error::AuthServerError;
@@ -220,13 +220,14 @@ impl Server {
     /// match
     pub async fn record_settled_match_sponsorship(
         &self,
-        match_resp: &SponsoredMatchResponse,
+        match_bundle: &AtomicMatchApiBundle,
+        is_sponsored: bool,
         key: String,
         request_id: String,
     ) -> Result<(), AuthServerError> {
-        if match_resp.is_sponsored
+        if is_sponsored
             && let Some((gas_cost, tx_hash)) =
-                self.get_sponsorship_amount_and_tx(&match_resp.match_bundle.settlement_tx).await?
+                self.get_sponsorship_amount_and_tx(&match_bundle.settlement_tx).await?
         {
             // Convert wei to ether using format_ether, then parse to f64
             let gas_cost_eth: f64 =


### PR DESCRIPTION
This PR ensures that we await a nullifier spend event on the correct selectors, and that we are able to deserialize either a sponsored or unsponsored match response when handling the bundle for telemetry.

### Testing
Tested by running a local auth server against both the testnet and mainnet stacks