### PR TITLE
auth-server: handle_external_match: gas_sponsorship: compute conversion rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "auth-server-api",
  "base64 0.22.1",
  "bb8",
+ "bigdecimal 0.4.7",
  "bytes",
  "cached",
  "chrono",

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -52,12 +52,16 @@ pub struct SponsoredMatchResponse {
 /// The query parameters used for gas sponsorship
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GasSponsorshipQueryParams {
-    /// Whether to use gas sponsorship for the external match
-    pub use_gas_sponsorship: Option<bool>,
-    /// The address to refund gas to
+    /// Whether to omit gas sponsorship for the external match.
+    /// Defaults to `false`, meaning gas sponsorship is used.
+    pub omit_sponsorship: Option<bool>,
+    /// The address to refund gas to.
+    /// In the case of a native ETH refund, defaults to `tx::origin`.
+    /// In the case of an in-kind refund, defaults to the receiver.
     pub refund_address: Option<String>,
     /// Whether to provide the gas refund in terms of native ETH,
-    /// as opposed to the buy-side token
+    /// as opposed to the buy-side token.
+    /// Defaults to `false`, meaning the buy-side token is used.
     pub refund_native_eth: Option<bool>,
 }
 

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -56,6 +56,9 @@ pub struct GasSponsorshipQueryParams {
     pub use_gas_sponsorship: Option<bool>,
     /// The address to refund gas to
     pub refund_address: Option<String>,
+    /// Whether to provide the gas refund in terms of native ETH,
+    /// as opposed to the buy-side token
+    pub refund_native_eth: Option<bool>,
 }
 
 impl GasSponsorshipQueryParams {

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -42,6 +42,7 @@ renegade-api = { workspace = true }
 
 # === Misc Dependencies === #
 base64 = "0.22.1"
+bigdecimal = "0.4"
 bytes = "1.0"
 cached = "0.53"
 chrono = { version = "0.4", features = ["serde"] }

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -2,7 +2,7 @@
 
 use thiserror::Error;
 
-use crate::ApiError;
+use crate::{telemetry::sources::http_utils::HttpError, ApiError};
 
 /// Custom error type for server errors
 #[derive(Error, Debug)]
@@ -30,7 +30,7 @@ pub enum AuthServerError {
     Unauthorized(String),
     /// An error executing an HTTP request
     #[error("Http: {0}")]
-    Http(String),
+    Http(HttpError),
     /// Gas sponsorship error
     #[error("Gas sponsorship error: {0}")]
     GasSponsorship(String),
@@ -108,6 +108,12 @@ impl AuthServerError {
 }
 
 impl warp::reject::Reject for AuthServerError {}
+
+impl From<HttpError> for AuthServerError {
+    fn from(err: HttpError) -> Self {
+        Self::Http(err)
+    }
+}
 
 impl From<AuthServerError> for ApiError {
     fn from(err: AuthServerError) -> Self {

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship.rs
@@ -3,9 +3,10 @@
 //! At a high level the server must first authenticate the request, then forward
 //! it to the relayer with admin authentication
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, Bytes as AlloyBytes, U256 as AlloyU256};
 use alloy_sol_types::{sol, SolCall};
 use auth_server_api::SponsoredMatchResponse;
+use bigdecimal::{num_bigint::BigInt, BigDecimal, FromPrimitive};
 use bytes::Bytes;
 use ethers::contract::abigen;
 use ethers::types::{transaction::eip2718::TypedTransaction, TxHash, U256};
@@ -15,6 +16,8 @@ use http::Response;
 use renegade_arbitrum_client::abi::{
     processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
 };
+use renegade_common::types::token::Token;
+use renegade_constants::NATIVE_ASSET_ADDRESS;
 use tracing::{info, warn};
 
 use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalMatchResponse};
@@ -30,8 +33,9 @@ use crate::telemetry::helpers::record_gas_sponsorship_metrics;
 
 // The ABI for gas sponsorship functions
 sol! {
-    function sponsorAtomicMatchSettle(bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
-    function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes memory internal_party_match_payload, bytes memory valid_match_settle_atomic_statement, bytes memory match_proofs, bytes memory match_linking_proofs, address memory refund_address, uint256 memory nonce, bytes memory signature) external payable;
+    function sponsorAtomicMatchSettle(bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bytes signature) external payable;
+    function sponsorAtomicMatchSettleWithReceiver(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bytes signature) external payable;
+    function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bool refund_native_eth, uint256 conversion_rate, bytes signature) external payable;
 }
 
 // The ABI for gas sponsorship events
@@ -42,6 +46,77 @@ abigen!(
     ]"#
 );
 
+impl sponsorAtomicMatchSettleWithRefundOptionsCall {
+    /// Create a `sponsorAtomicMatchSettleWithRefundOptions` call from
+    /// `processAtomicMatchSettle` calldata
+    pub fn from_process_atomic_match_settle_calldata(
+        calldata: &[u8],
+        refund_address: Address,
+        nonce: AlloyU256,
+        refund_native_eth: bool,
+        conversion_rate: AlloyU256,
+        signature: AlloyBytes,
+    ) -> Result<Self, AuthServerError> {
+        let processAtomicMatchSettleCall {
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+        } = processAtomicMatchSettleCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(sponsorAtomicMatchSettleWithRefundOptionsCall {
+            receiver: Address::ZERO,
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+            refund_address,
+            nonce,
+            refund_native_eth,
+            conversion_rate,
+            signature,
+        })
+    }
+
+    /// Create a `sponsorAtomicMatchSettleWithRefundOptions` call from
+    /// `processAtomicMatchSettleWithReceiver` calldata
+    pub fn from_process_atomic_match_settle_with_receiver_calldata(
+        calldata: &[u8],
+        refund_address: Address,
+        nonce: AlloyU256,
+        refund_native_eth: bool,
+        conversion_rate: AlloyU256,
+        signature: AlloyBytes,
+    ) -> Result<Self, AuthServerError> {
+        let processAtomicMatchSettleWithReceiverCall {
+            receiver,
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+        } = processAtomicMatchSettleWithReceiverCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(sponsorAtomicMatchSettleWithRefundOptionsCall {
+            receiver,
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+            refund_address,
+            nonce,
+            refund_native_eth,
+            conversion_rate,
+            signature,
+        })
+    }
+}
+
 // ---------------
 // | Server Impl |
 // ---------------
@@ -49,11 +124,12 @@ abigen!(
 /// Handle a proxied request
 impl Server {
     /// Mutate a quote assembly response to invoke gas sponsorship
-    pub(crate) fn mutate_response_for_gas_sponsorship(
+    pub(crate) async fn mutate_response_for_gas_sponsorship(
         &self,
         resp: &mut Response<Bytes>,
         is_sponsored: bool,
         refund_address: Address,
+        refund_native_eth: bool,
     ) -> Result<(), AuthServerError> {
         let mut relayer_external_match_resp: ExternalMatchResponse =
             serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
@@ -63,8 +139,17 @@ impl Server {
         if is_sponsored {
             info!("Sponsoring match bundle via gas sponsor");
 
+            let conversion_rate = self
+                .maybe_fetch_conversion_rate(&relayer_external_match_resp, refund_native_eth)
+                .await?;
+
             let gas_sponsor_calldata = self
-                .generate_gas_sponsor_calldata(&relayer_external_match_resp, refund_address)?
+                .generate_gas_sponsor_calldata(
+                    &relayer_external_match_resp,
+                    refund_address,
+                    refund_native_eth,
+                    conversion_rate,
+                )?
                 .into();
 
             relayer_external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
@@ -84,12 +169,94 @@ impl Server {
         Ok(())
     }
 
+    /// Fetch the conversion rate from ETH to the buy-side token in the trade
+    /// from the price reporter, if necessary.
+    /// The conversion rate is in units of
+    /// `token/wei * 10^CONVERSION_RATE_SCALE`
+    #[allow(clippy::unused_async)]
+    async fn maybe_fetch_conversion_rate(
+        &self,
+        external_match_resp: &ExternalMatchResponse,
+        refund_native_eth: bool,
+    ) -> Result<Option<AlloyU256>, AuthServerError> {
+        let buy_mint = &external_match_resp.match_bundle.receive.mint;
+        let native_eth_buy = buy_mint.to_lowercase() == NATIVE_ASSET_ADDRESS.to_lowercase();
+
+        // If we're deliberately refunding via native ETH, or the buy-side token
+        // is native ETH, we don't need to get a conversion rate
+        if refund_native_eth || native_eth_buy {
+            return Ok(None);
+        }
+
+        // Get ETH price
+        let eth_price_f64 = self.price_reporter_client.get_eth_price().await?;
+
+        // Get TOKEN price
+        let buy_token_price_f64 = self.price_reporter_client.get_binance_price(buy_mint).await?;
+
+        // Get the number of decimals for the buy-side token
+        let buy_token_decimals: u32 = Token::from_addr(buy_mint)
+            .get_decimals()
+            .ok_or(AuthServerError::gas_sponsorship("buy-side token does not have known decimals"))?
+            .into();
+
+        // Compute the conversion rate
+        let conversion_rate =
+            Self::compute_conversion_rate(eth_price_f64, buy_token_price_f64, buy_token_decimals)?;
+
+        Ok(Some(conversion_rate))
+    }
+
+    /// Given the price of ETH and the buy-side token,
+    /// compute the conversion rate in units of
+    /// `token/wei * 10^CONVERSION_RATE_SCALE`
+    fn compute_conversion_rate(
+        eth_price: f64,
+        buy_token_price: f64,
+        buy_token_decimals: u32,
+    ) -> Result<AlloyU256, AuthServerError> {
+        // USDT per ETH
+        let eth_price = BigDecimal::from_f64(eth_price)
+            .ok_or(AuthServerError::gas_sponsorship("failed to convert ETH price to BigDecimal"))?;
+
+        // USDT per TOKEN
+        let buy_token_price =
+            BigDecimal::from_f64(buy_token_price).ok_or(AuthServerError::gas_sponsorship(
+                "failed to convert buy-side token price to BigDecimal",
+            ))?;
+
+        // Compute conversion rate of TOKEN per ETH
+        let conversion_rate = eth_price / buy_token_price;
+
+        // Decimal-adjust the rate to represent (smallest-denomination) *units* of TOKEN
+        // per ETH
+        let adjustment: BigDecimal = BigInt::from(10).pow(buy_token_decimals).into();
+        let conversion_rate_adjusted = conversion_rate * adjustment;
+
+        // Convert the scaled rate to a U256. We can use the `BigInt` component of the
+        // `BigDecimal` directly because we round to 0 digits after the decimal.
+        let (conversion_rate_bigint, _) =
+            conversion_rate_adjusted.round(0 /* round_digits */).into_bigint_and_scale();
+
+        AlloyU256::try_from(conversion_rate_bigint).map_err(AuthServerError::gas_sponsorship)
+    }
+
     /// Generate the calldata for sponsoring the given match via the gas sponsor
     fn generate_gas_sponsor_calldata(
         &self,
         external_match_resp: &ExternalMatchResponse,
         refund_address: Address,
+        refund_native_eth: bool,
+        conversion_rate: Option<AlloyU256>,
     ) -> Result<Bytes, AuthServerError> {
+        let (nonce, signature) = gen_signed_sponsorship_nonce(
+            refund_address,
+            conversion_rate,
+            &self.gas_sponsor_auth_key,
+        )?;
+
+        let conversion_rate = conversion_rate.unwrap_or_default();
+
         let calldata = external_match_resp
             .match_bundle
             .settlement_tx
@@ -98,76 +265,35 @@ impl Server {
 
         let selector = get_selector(calldata)?;
 
-        let gas_sponsor_calldata = match selector {
+        let gas_sponsor_call = match selector {
             processAtomicMatchSettleCall::SELECTOR => {
-                self.sponsor_atomic_match_settle_call(calldata, refund_address)
+                sponsorAtomicMatchSettleWithRefundOptionsCall::from_process_atomic_match_settle_calldata(
+                    calldata,
+                    refund_address,
+                    nonce,
+                    refund_native_eth,
+                    conversion_rate,
+                    signature,
+                )
             },
             processAtomicMatchSettleWithReceiverCall::SELECTOR => {
-                self.sponsor_atomic_match_settle_with_receiver_call(calldata, refund_address)
+                sponsorAtomicMatchSettleWithRefundOptionsCall::from_process_atomic_match_settle_with_receiver_calldata(
+                    calldata,
+                    refund_address,
+                    nonce,
+                    refund_native_eth,
+                    conversion_rate,
+                    signature,
+                )
             },
             _ => {
                 return Err(AuthServerError::gas_sponsorship("invalid selector"));
             },
         }?;
 
-        Ok(gas_sponsor_calldata)
-    }
+        let calldata = gas_sponsor_call.abi_encode().into();
 
-    /// Create a `sponsorAtomicMatchSettle` call from `processAtomicMatchSettle`
-    /// calldata
-    fn sponsor_atomic_match_settle_call(
-        &self,
-        calldata: &[u8],
-        refund_address: Address,
-    ) -> Result<Bytes, AuthServerError> {
-        let call = processAtomicMatchSettleCall::abi_decode(
-            calldata, true, // validate
-        )
-        .map_err(AuthServerError::gas_sponsorship)?;
-
-        let (nonce, signature) =
-            gen_signed_sponsorship_nonce(refund_address, &self.gas_sponsor_auth_key)?;
-
-        let sponsored_call = sponsorAtomicMatchSettleCall {
-            internal_party_match_payload: call.internal_party_match_payload,
-            valid_match_settle_atomic_statement: call.valid_match_settle_atomic_statement,
-            match_proofs: call.match_proofs,
-            match_linking_proofs: call.match_linking_proofs,
-            refund_address,
-            nonce,
-            signature,
-        };
-
-        Ok(sponsored_call.abi_encode().into())
-    }
-
-    /// Create a `sponsorAtomicMatchSettleWithReceiver` call from
-    /// `processAtomicMatchSettleWithReceiver` calldata
-    fn sponsor_atomic_match_settle_with_receiver_call(
-        &self,
-        calldata: &[u8],
-        refund_address: Address,
-    ) -> Result<Bytes, AuthServerError> {
-        let call = processAtomicMatchSettleWithReceiverCall::abi_decode(
-            calldata, true, // validate
-        )
-        .map_err(AuthServerError::gas_sponsorship)?;
-
-        let (nonce, signature) =
-            gen_signed_sponsorship_nonce(refund_address, &self.gas_sponsor_auth_key)?;
-
-        let sponsored_call = sponsorAtomicMatchSettleWithReceiverCall {
-            receiver: call.receiver,
-            internal_party_match_payload: call.internal_party_match_payload,
-            valid_match_settle_atomic_statement: call.valid_match_settle_atomic_statement,
-            match_proofs: call.match_proofs,
-            match_linking_proofs: call.match_linking_proofs,
-            refund_address,
-            nonce,
-            signature,
-        };
-
-        Ok(sponsored_call.abi_encode().into())
+        Ok(calldata)
     }
 
     /// Get the amount of Ether spent to sponsor the given settlement
@@ -271,5 +397,68 @@ impl Server {
         .map_err(AuthServerError::gas_sponsorship)?;
 
         Ok(U256::from_big_endian(&call.nonce.to_be_bytes_vec()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::{thread_rng, Rng};
+
+    use super::*;
+
+    #[test]
+    fn test_conversion_rate_simple() {
+        let eth_price = 1000.0;
+        let token_price = 1.0;
+        let token_decimals: u32 = 18;
+
+        let expected_conversion_rate = AlloyU256::from(1000 * 10_u128.pow(18));
+        let conversion_rate =
+            Server::compute_conversion_rate(eth_price, token_price, token_decimals).unwrap();
+
+        assert_eq!(conversion_rate, expected_conversion_rate);
+    }
+
+    #[test]
+    fn test_conversion_rate_diff_decimals() {
+        let eth_price = 2_500.0;
+        let token_price = 100_000.0;
+        let token_decimals: u32 = 8;
+
+        let expected_conversion_rate = AlloyU256::from(2_500_000);
+        let conversion_rate =
+            Server::compute_conversion_rate(eth_price, token_price, token_decimals).unwrap();
+
+        assert_eq!(conversion_rate, expected_conversion_rate);
+    }
+
+    #[test]
+    fn test_conversion_rate_random() {
+        let mut rng = thread_rng();
+        let eth_price: f64 = rng.gen();
+        let token_price: f64 = rng.gen();
+        let token_decimals: u32 = rng.gen_range(1..=18);
+
+        let conversion_rate =
+            Server::compute_conversion_rate(eth_price, token_price, token_decimals).unwrap();
+
+        // Simulate converting 1 ETH to TOKEN, and check that the resulting USD value is
+        // the same as 1 ETH worth of USD.
+
+        // This is the amount of nominal units of TOKEN for 1 whole ETH
+        let nominal_token_per_eth: f64 = conversion_rate.into();
+
+        // The token price is the amount of USD for 1 whole TOKEN, not for 1 nominal
+        // unit. As such, this is effectively the derived amount of USD for 1
+        // whole ETH, scaled by a factor of 10^`token_decimals`. We truncate
+        // this result to compare to the original ETH price up to
+        // `token_decimals` digits of precision.
+        // Even this is not guaranteed to be exact, as the conversion from U256 -> f64
+        // above has unspecified precision, so we scale down by one additional decimal
+        // point.
+        let usd_per_eth_scaled = (nominal_token_per_eth * token_price / 10.0).trunc();
+        let eth_price_scaled = (eth_price * 10_f64.powi(token_decimals as i32 - 1)).trunc();
+
+        assert_eq!(usd_per_eth_scaled, eth_price_scaled);
     }
 }

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -86,7 +86,7 @@ impl Server {
         let key_desc = self.authorize_request(&auth_path, &headers, &body).await?;
         self.check_bundle_rate_limit(key_desc.clone()).await?;
 
-        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or(false);
+        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or_default();
         let is_sponsored =
             sponsorship_requested && self.check_gas_sponsorship_rate_limit(key_desc.clone()).await;
 
@@ -107,7 +107,15 @@ impl Server {
             let refund_address =
                 query_params.get_refund_address().map_err(AuthServerError::serde)?;
 
-            self.mutate_response_for_gas_sponsorship(&mut resp, is_sponsored, refund_address)?;
+            let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
+
+            self.mutate_response_for_gas_sponsorship(
+                &mut resp,
+                is_sponsored,
+                refund_address,
+                refund_native_eth,
+            )
+            .await?;
         }
 
         let resp_clone = resp.body().to_vec();
@@ -150,7 +158,7 @@ impl Server {
         let key_description = self.authorize_request(&auth_path, &headers, &body).await?;
         self.check_bundle_rate_limit(key_description.clone()).await?;
 
-        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or(false);
+        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or_default();
         let is_sponsored = sponsorship_requested
             && self.check_gas_sponsorship_rate_limit(key_description.clone()).await;
 
@@ -171,7 +179,15 @@ impl Server {
             let refund_address =
                 query_params.get_refund_address().map_err(AuthServerError::serde)?;
 
-            self.mutate_response_for_gas_sponsorship(&mut resp, is_sponsored, refund_address)?;
+            let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
+
+            self.mutate_response_for_gas_sponsorship(
+                &mut resp,
+                is_sponsored,
+                refund_address,
+                refund_native_eth,
+            )
+            .await?;
         }
 
         // Watch the bundle for settlement

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -86,7 +86,7 @@ impl Server {
         let key_desc = self.authorize_request(&auth_path, &headers, &body).await?;
         self.check_bundle_rate_limit(key_desc.clone()).await?;
 
-        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or_default();
+        let sponsorship_requested = query_params.omit_sponsorship.unwrap_or_default();
         let is_sponsored =
             sponsorship_requested && self.check_gas_sponsorship_rate_limit(key_desc.clone()).await;
 
@@ -158,7 +158,7 @@ impl Server {
         let key_description = self.authorize_request(&auth_path, &headers, &body).await?;
         self.check_bundle_rate_limit(key_description.clone()).await?;
 
-        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or_default();
+        let sponsorship_requested = query_params.omit_sponsorship.unwrap_or_default();
         let is_sponsored = sponsorship_requested
             && self.check_gas_sponsorship_rate_limit(key_description.clone()).await;
 


### PR DESCRIPTION
This PR implements the necessary changes to invoke external matches sponsored in-kind through the gas sponsor. Primarily, this is composed of an additional query parameter `refund_native_eth` - which defaults to `false`, implying that in-kind gas sponsorship is the default - and the logic for computing a conversion rate for in-kind sponsorship.

### TODO
- [x] Rate limiting of in-kind refunds

### Testing
- [x] Conversion rate calculation, unit tests
- [x] Testing against testnet
    - [x] Simple buy w/ in-kind refund
    - [x] Simple sell w/ in-kind refund
    - [x] Native ETH buy w/ in-kind refund
    - [x] Native ETH sell w/ in-kind refund
    - [x] In-kind refund w/ refund address set
    - [x] In-kind refund w/ receiver set
    - [ ] Native ETH refund w/ receiver set (blocked on SDK updates)