### PR TITLE
auth-server: gas_sponsorship: gas_estimation: core gas estimation logic

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -44,6 +44,9 @@ pub enum AuthServerError {
     /// Price reporter error
     #[error("Price reporter error: {0}")]
     PriceReporter(#[from] PriceReporterError),
+    /// Arbitrum client error
+    #[error("Arbitrum client error: {0}")]
+    ArbitrumClient(String),
 }
 
 impl AuthServerError {
@@ -105,6 +108,12 @@ impl AuthServerError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn custom<T: ToString>(msg: T) -> Self {
         Self::Custom(msg.to_string())
+    }
+
+    /// Create a new arbitrum client error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn arbitrum_client<T: ToString>(msg: T) -> Self {
+        Self::ArbitrumClient(msg.to_string())
     }
 }
 

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/gas_estimation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/gas_estimation.rs
@@ -1,0 +1,74 @@
+//! Gas estimation for gas sponsorship
+
+use alloy_primitives::hex;
+use ethers::{
+    contract::abigen,
+    types::{Address, H160, U256},
+};
+use rand::{thread_rng, RngCore};
+
+use crate::{error::AuthServerError, server::Server};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The estimated gas cost of L2 execution for an external match.
+/// From https://github.com/renegade-fi/renegade/blob/main/workers/api-server/src/http/external_match.rs/#L62
+pub const ESTIMATED_L2_GAS: u64 = 4_000_000; // 4m
+
+/// The approximate size in bytes of the calldata for an external match,
+/// obtained empirically
+const ESTIMATED_CALLDATA_SIZE_BYTES: usize = 8_000;
+
+/// The address of the `NodeInterface` precompile
+const NODE_INTERFACE_ADDRESS: Address = H160(hex!("00000000000000000000000000000000000000c8"));
+
+// -------
+// | ABI |
+// -------
+
+// The ABI for the `NodeInterface` precompile:
+// https://docs.arbitrum.io/build-decentralized-apps/nodeinterface/overview
+abigen!(
+    NodeInterface,
+    r#"[
+        function gasEstimateL1Component(address to, bool contractCreation, bytes calldata data) external payable returns (uint64 gasEstimateForL1, uint256 baseFee, uint256 l1BaseFeeEstimate)
+    ]"#
+);
+
+impl Server {
+    /// Estimate the gas cost, in wei, of an external match.
+    /// This calculation was taken from https://docs.arbitrum.io/build-decentralized-apps/how-to-estimate-gas
+    pub async fn estimate_external_match_gas_cost(&self) -> Result<U256, AuthServerError> {
+        let client = self.arbitrum_client.client();
+
+        // Get the estimate of the L1 gas costs of the transaction.
+        // As per https://github.com/OffchainLabs/nitro-contracts/blob/main/src/node-interface/NodeInterface.sol#L102-L103,
+        // this doesn't actually simulate the transaction, just estimates L1 portion of
+        // gas costs from the calldata size.
+        let node_interface = NodeInterface::new(NODE_INTERFACE_ADDRESS, client.clone());
+
+        // The arguments to the `gasEstimateL1Component` call are largely irrelevant.
+        // Primarily, we're interested in mocking the calldata,
+        // which we do so by constructing `ESTIMATED_CALLDATA_SIZE_BYTES` random bytes,
+        // as a pessimistic assumption of the compressibility of the calldata.
+        let mut data = [0_u8; ESTIMATED_CALLDATA_SIZE_BYTES];
+        thread_rng().fill_bytes(&mut data);
+
+        let (gas_estimate_for_l1, base_fee, _) = node_interface
+            .gas_estimate_l1_component(
+                self.gas_sponsor_address,
+                false, // contract_creation
+                data.into(),
+            )
+            .call()
+            .await
+            .map_err(AuthServerError::arbitrum_client)?;
+
+        let total_gas = U256::from(ESTIMATED_L2_GAS + gas_estimate_for_l1);
+        let total_cost = total_gas * base_fee;
+
+        Ok(total_cost)
+    }
+}

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
@@ -29,6 +29,8 @@ use crate::server::helpers::{
 use crate::telemetry::helpers::record_gas_sponsorship_metrics;
 use crate::{error::AuthServerError, server::helpers::ethers_u256_to_bigdecimal};
 
+pub mod gas_estimation;
+
 // -------
 // | ABI |
 // -------

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -30,7 +30,9 @@ use crate::telemetry::{
 };
 
 mod gas_sponsorship;
-pub use gas_sponsorship::sponsorAtomicMatchSettleWithRefundOptionsCall;
+pub use gas_sponsorship::{
+    gas_estimation::ESTIMATED_L2_GAS, sponsorAtomicMatchSettleWithRefundOptionsCall,
+};
 
 // ---------------
 // | Server Impl |

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -24,10 +24,6 @@ use crate::error::AuthServerError;
 // | Constants |
 // -------------
 
-/// The gas estimation to use if fetching a gas estimation fails
-/// From https://github.com/renegade-fi/renegade/blob/main/workers/api-server/src/http/external_match.rs/#L62
-pub const DEFAULT_GAS_ESTIMATION: u64 = 4_000_000; // 4m
-
 /// The nonce size for AES128-GCM
 const NONCE_SIZE: usize = 12; // 12 bytes, 96 bits
 

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -6,7 +6,7 @@ use renegade_api::http::external_match::AtomicMatchApiBundle;
 use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_common::types::token::Token;
 
-use crate::{error::AuthServerError, server::helpers::DEFAULT_GAS_ESTIMATION};
+use crate::{error::AuthServerError, server::handle_external_match::ESTIMATED_L2_GAS};
 
 /// The name of our quote source
 const RENEGADE_SOURCE_NAME: &str = "renegade";
@@ -98,7 +98,7 @@ impl QuoteResponse {
 /// Converts the `AtomicMatchApiBundle` into a `QuoteResponse`.
 impl From<&AtomicMatchApiBundle> for QuoteResponse {
     fn from(bundle: &AtomicMatchApiBundle) -> Self {
-        let gas = bundle.settlement_tx.gas().map_or(DEFAULT_GAS_ESTIMATION, |gas| gas.as_u64());
+        let gas = bundle.settlement_tx.gas().map_or(ESTIMATED_L2_GAS, |gas| gas.as_u64());
         let fee_take = bundle.fees.total();
         Self {
             quote_mint: bundle.match_result.quote_mint.clone(),


### PR DESCRIPTION
This PR scaffolds the `gas_estimation` module and implements the core gas estimation logic, which for the moment is very simple. We use a constant estimate of both the amount of L2 gas needed to execute the external match, and the calldata size in bytes. We use these values along with a real-time sampling of the L2 basefee and estimated amount of L1 gas used from the [`NodeInterface`](https://docs.arbitrum.io/build-decentralized-apps/nodeinterface/overview) precompile to compute an estimated gas cost according to the instructions [here](https://docs.arbitrum.io/build-decentralized-apps/how-to-estimate-gas).

This functionality is not yet used so clippy lints are expected.