### PR TITLE
auth-server: gas_sponsorship: use exact refund amount

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -118,6 +118,12 @@ impl AuthServerError {
     pub fn arbitrum_client<T: ToString>(msg: T) -> Self {
         Self::ArbitrumClient(msg.to_string())
     }
+
+    /// Create a new gas cost sampler error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn gas_cost_sampler<T: ToString>(msg: T) -> Self {
+        Self::GasCostSampler(msg.to_string())
+    }
 }
 
 impl warp::reject::Reject for AuthServerError {}

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -31,6 +31,7 @@ use renegade_arbitrum_client::{
     constants::Chain,
 };
 use renegade_config::setup_token_remaps;
+use renegade_system_clock::SystemClock;
 use renegade_util::err_str;
 use renegade_util::telemetry::configure_telemetry;
 use reqwest::StatusCode;
@@ -227,8 +228,12 @@ async fn main() {
     .await
     .unwrap();
 
+    let system_clock = SystemClock::new().await;
+
     // Create the server
-    let server = Server::new(args, arbitrum_client).await.expect("Failed to create server");
+    let server =
+        Server::new(args, arbitrum_client, &system_clock).await.expect("Failed to create server");
+
     let server = Arc::new(server);
 
     // --- Management Routes --- //

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
@@ -13,14 +13,16 @@ use ethers::{
     types::{transaction::eip2718::TypedTransaction, Address, TxHash, U256},
     utils::WEI_IN_ETHER,
 };
-use http::{header::CONTENT_LENGTH, Response};
 use renegade_arbitrum_client::abi::{
     processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
 };
+use renegade_circuit_types::order::OrderSide;
 use renegade_constants::NATIVE_ASSET_ADDRESS;
 use tracing::{info, warn};
 
-use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalMatchResponse};
+use renegade_api::http::external_match::{
+    ApiExternalMatchResult, AtomicMatchApiBundle, ExternalMatchResponse,
+};
 
 use super::Server;
 use crate::server::helpers::{
@@ -30,13 +32,22 @@ use crate::server::helpers::{
 use crate::telemetry::helpers::record_gas_sponsorship_metrics;
 use crate::{error::AuthServerError, server::helpers::ethers_u256_to_bigdecimal};
 
+// -------------
+// | Constants |
+// -------------
+
+/// The number of Wei in 1 ETH, as an `AlloyU256`.
+/// Concretely, this is 10^18
+const ALLOY_WEI_IN_ETHER: AlloyU256 =
+    AlloyU256::from_limbs([1_000_000_000_000_000_000_u64, 0, 0, 0]);
+
 // -------
 // | ABI |
 // -------
 
 // The ABI for gas sponsorship functions
 sol! {
-    function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bool refund_native_eth, uint256 sponsorship_amount, bytes signature) external payable;
+    function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bool refund_native_eth, uint256 refund_amount, bytes signature) external payable;
 }
 
 // The ABI for gas sponsorship events
@@ -55,7 +66,7 @@ impl sponsorAtomicMatchSettleWithRefundOptionsCall {
         refund_address: AlloyAddress,
         nonce: AlloyU256,
         refund_native_eth: bool,
-        sponsorship_amount: AlloyU256,
+        refund_amount: AlloyU256,
         signature: AlloyBytes,
     ) -> Result<Self, AuthServerError> {
         let processAtomicMatchSettleCall {
@@ -77,7 +88,7 @@ impl sponsorAtomicMatchSettleWithRefundOptionsCall {
             refund_address,
             nonce,
             refund_native_eth,
-            sponsorship_amount,
+            refund_amount,
             signature,
         })
     }
@@ -89,7 +100,7 @@ impl sponsorAtomicMatchSettleWithRefundOptionsCall {
         refund_address: AlloyAddress,
         nonce: AlloyU256,
         refund_native_eth: bool,
-        sponsorship_amount: AlloyU256,
+        refund_amount: AlloyU256,
         signature: AlloyBytes,
     ) -> Result<Self, AuthServerError> {
         let processAtomicMatchSettleWithReceiverCall {
@@ -112,7 +123,7 @@ impl sponsorAtomicMatchSettleWithRefundOptionsCall {
             refund_address,
             nonce,
             refund_native_eth,
-            sponsorship_amount,
+            refund_amount,
             signature,
         })
     }
@@ -124,59 +135,58 @@ impl sponsorAtomicMatchSettleWithRefundOptionsCall {
 
 /// Handle a proxied request
 impl Server {
-    /// Mutate a quote assembly response to invoke gas sponsorship
-    pub(crate) async fn mutate_response_for_gas_sponsorship(
+    /// Construct a sponsored match response from an external match response
+    pub(crate) fn construct_sponsored_match_response(
         &self,
-        resp: &mut Response<Bytes>,
-        is_sponsored: bool,
+        mut external_match_resp: ExternalMatchResponse,
         refund_address: AlloyAddress,
         refund_native_eth: bool,
-    ) -> Result<(), AuthServerError> {
-        let mut relayer_external_match_resp: ExternalMatchResponse =
-            serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
+        refund_amount: Option<AlloyU256>,
+    ) -> Result<SponsoredMatchResponse, AuthServerError> {
+        external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
 
-        relayer_external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
-
+        let is_sponsored = refund_amount.is_some();
         if is_sponsored {
             info!("Sponsoring match bundle via gas sponsor");
 
-            let conversion_rate = self
-                .maybe_fetch_conversion_rate(&relayer_external_match_resp, refund_native_eth)
-                .await?;
-
-            let estimated_gas_cost = ethers_u256_to_alloy_u256(self.get_gas_cost_estimate().await);
-
-            let sponsorship_amount = if let Some(conversion_rate) = conversion_rate {
-                let wei_in_eth = ethers_u256_to_alloy_u256(WEI_IN_ETHER);
-                (estimated_gas_cost / wei_in_eth) * conversion_rate
-            } else {
-                estimated_gas_cost
-            };
-
             let gas_sponsor_calldata = self
                 .generate_gas_sponsor_calldata(
-                    &relayer_external_match_resp,
+                    &external_match_resp,
                     refund_address,
                     refund_native_eth,
-                    sponsorship_amount,
+                    refund_amount.unwrap(),
                 )?
                 .into();
 
-            relayer_external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
+            external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
         }
 
-        let external_match_resp = SponsoredMatchResponse {
-            match_bundle: relayer_external_match_resp.match_bundle,
-            is_sponsored,
+        Ok(SponsoredMatchResponse { match_bundle: external_match_resp.match_bundle, is_sponsored })
+    }
+
+    /// Get the amount to refund for a given match result
+    pub async fn get_refund_amount(
+        &self,
+        gas_sponsorship_rate_limited: bool,
+        match_result: &ApiExternalMatchResult,
+        refund_native_eth: bool,
+    ) -> Result<Option<AlloyU256>, AuthServerError> {
+        if gas_sponsorship_rate_limited {
+            return Ok(None);
+        }
+
+        let conversion_rate =
+            self.maybe_fetch_conversion_rate(match_result, refund_native_eth).await?;
+
+        let estimated_gas_cost = ethers_u256_to_alloy_u256(self.get_gas_cost_estimate().await);
+
+        let refund_amount = if let Some(conversion_rate) = conversion_rate {
+            (estimated_gas_cost / ALLOY_WEI_IN_ETHER) * conversion_rate
+        } else {
+            estimated_gas_cost
         };
 
-        let body =
-            Bytes::from(serde_json::to_vec(&external_match_resp).map_err(AuthServerError::serde)?);
-
-        resp.headers_mut().insert(CONTENT_LENGTH, body.len().into());
-        *resp.body_mut() = body;
-
-        Ok(())
+        Ok(Some(refund_amount))
     }
 
     /// Fetch the conversion rate from ETH to the buy-side token in the trade
@@ -185,10 +195,13 @@ impl Server {
     #[allow(clippy::unused_async)]
     async fn maybe_fetch_conversion_rate(
         &self,
-        external_match_resp: &ExternalMatchResponse,
+        match_result: &ApiExternalMatchResult,
         refund_native_eth: bool,
     ) -> Result<Option<AlloyU256>, AuthServerError> {
-        let buy_mint = &external_match_resp.match_bundle.receive.mint;
+        let buy_mint = match match_result.direction {
+            OrderSide::Buy => &match_result.base_mint,
+            OrderSide::Sell => &match_result.quote_mint,
+        };
         let native_eth_buy = buy_mint.to_lowercase() == NATIVE_ASSET_ADDRESS.to_lowercase();
 
         // If we're deliberately refunding via native ETH, or the buy-side token
@@ -202,7 +215,7 @@ impl Server {
         let eth_price = BigDecimal::from_f64(eth_price_f64)
             .ok_or(AuthServerError::gas_sponsorship("failed to convert ETH price to BigDecimal"))?;
 
-        let buy_token_price = get_nominal_buy_token_price(&external_match_resp.match_bundle)?;
+        let buy_token_price = get_nominal_buy_token_price(buy_mint, match_result)?;
 
         // Compute conversion rate of nominal units of TOKEN per whole ETH
         let conversion_rate = eth_price / buy_token_price;
@@ -224,11 +237,11 @@ impl Server {
         external_match_resp: &ExternalMatchResponse,
         refund_address: AlloyAddress,
         refund_native_eth: bool,
-        sponsorship_amount: AlloyU256,
+        refund_amount: AlloyU256,
     ) -> Result<Bytes, AuthServerError> {
         let (nonce, signature) = gen_signed_sponsorship_nonce(
             refund_address,
-            sponsorship_amount,
+            refund_amount,
             &self.gas_sponsor_auth_key,
         )?;
 
@@ -247,7 +260,7 @@ impl Server {
                     refund_address,
                     nonce,
                     refund_native_eth,
-                    sponsorship_amount,
+                    refund_amount,
                     signature,
                 )
             },
@@ -257,7 +270,7 @@ impl Server {
                     refund_address,
                     nonce,
                     refund_native_eth,
-                    sponsorship_amount,
+                    refund_amount,
                     signature,
                 )
             },
@@ -271,9 +284,9 @@ impl Server {
         Ok(calldata)
     }
 
-    /// Get the token & amount spent to sponsor the given settlement
+    /// Get the token & amount refunded to sponsor the given settlement
     /// transaction, and the associated transaction hash
-    async fn get_sponsorship_amount_and_tx(
+    async fn get_refunded_amount_and_tx(
         &self,
         settlement_tx: &TypedTransaction,
     ) -> Result<Option<(Address, U256, TxHash)>, AuthServerError> {
@@ -325,7 +338,7 @@ impl Server {
     ) -> Result<(), AuthServerError> {
         if is_sponsored
             && let Some((token_addr, amount, tx_hash)) =
-                self.get_sponsorship_amount_and_tx(&match_bundle.settlement_tx).await?
+                self.get_refunded_amount_and_tx(&match_bundle.settlement_tx).await?
         {
             let nominal_price = if token_addr == Address::zero() {
                 // The zero address indicates that the gas was sponsored via native ETH.
@@ -346,7 +359,7 @@ impl Server {
                 // If we did not refund via native ETH, it must have been through the buy-side
                 // token. Thus we compute the nominal price of the buy-side
                 // token from the match result.
-                get_nominal_buy_token_price(match_bundle)?
+                get_nominal_buy_token_price(&match_bundle.receive.mint, &match_bundle.match_result)?
             };
 
             let nominal_amount = ethers_u256_to_bigdecimal(amount);

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -3,9 +3,11 @@
 //! At a high level the server must first authenticate the request, then forward
 //! it to the relayer with admin authentication
 
+use alloy_primitives::U256 as AlloyU256;
 use auth_server_api::{GasSponsorshipQueryParams, SponsoredMatchResponse};
 use bytes::Bytes;
-use http::{Method, StatusCode};
+use http::header::CONTENT_LENGTH;
+use http::{Method, Response, StatusCode};
 use renegade_api::http::external_match::{
     AssembleExternalMatchRequest, AtomicMatchApiBundle, ExternalMatchRequest,
     ExternalMatchResponse, ExternalOrder, ExternalQuoteResponse,
@@ -87,9 +89,8 @@ impl Server {
         let key_desc = self.authorize_request(&auth_path, &headers, &body).await?;
         self.check_bundle_rate_limit(key_desc.clone()).await?;
 
-        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or(true);
-        let is_sponsored =
-            sponsorship_requested && self.check_gas_sponsorship_rate_limit(key_desc.clone()).await;
+        let gas_sponsorship_rate_limited =
+            !self.check_gas_sponsorship_rate_limit(key_desc.clone()).await;
 
         // Send the request to the relayer, potentially sponsoring the gas costs
 
@@ -102,33 +103,27 @@ impl Server {
             return Ok(resp);
         }
 
-        // We redirect the TX to the gas sponsor contract if the user explicitly
-        // requested sponsorship, regardless of whether they are rate-limited.
-        if sponsorship_requested {
-            let refund_address =
-                query_params.get_refund_address().map_err(AuthServerError::serde)?;
+        let external_match_resp: ExternalMatchResponse =
+            serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
 
-            let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
-
-            self.mutate_response_for_gas_sponsorship(
-                &mut resp,
-                is_sponsored,
-                refund_address,
+        // TODO: Move refund amount calculation to quote request stage, expect amount
+        // in to be re-submitted in the assembly request
+        let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
+        let refund_amount = self
+            .get_refund_amount(
+                gas_sponsorship_rate_limited,
+                &external_match_resp.match_bundle.match_result,
                 refund_native_eth,
             )
             .await?;
-        }
+
+        self.maybe_apply_sponsorship(&mut resp, &query_params, external_match_resp, refund_amount)?;
 
         let resp_clone = resp.body().to_vec();
         let server_clone = self.clone();
         tokio::spawn(async move {
             if let Err(e) = server_clone
-                .handle_quote_assembly_bundle_response(
-                    key_desc,
-                    &body,
-                    &resp_clone,
-                    sponsorship_requested,
-                )
+                .handle_quote_assembly_bundle_response(key_desc, &body, &resp_clone)
                 .await
             {
                 warn!("Error handling bundle: {e}");
@@ -159,9 +154,8 @@ impl Server {
         let key_description = self.authorize_request(&auth_path, &headers, &body).await?;
         self.check_bundle_rate_limit(key_description.clone()).await?;
 
-        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or(true);
-        let is_sponsored = sponsorship_requested
-            && self.check_gas_sponsorship_rate_limit(key_description.clone()).await;
+        let gas_sponsorship_rate_limited =
+            !self.check_gas_sponsorship_rate_limit(key_description.clone()).await;
 
         // Send the request to the relayer, potentially sponsoring the gas costs
 
@@ -174,34 +168,26 @@ impl Server {
             return Ok(resp);
         }
 
-        // We redirect the TX to the gas sponsor contract if the user explicitly
-        // requested sponsorship, regardless of whether they are rate-limited.
-        if sponsorship_requested {
-            let refund_address =
-                query_params.get_refund_address().map_err(AuthServerError::serde)?;
+        let external_match_resp: ExternalMatchResponse =
+            serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
 
-            let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
-
-            self.mutate_response_for_gas_sponsorship(
-                &mut resp,
-                is_sponsored,
-                refund_address,
+        let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
+        let refund_amount = self
+            .get_refund_amount(
+                gas_sponsorship_rate_limited,
+                &external_match_resp.match_bundle.match_result,
                 refund_native_eth,
             )
             .await?;
-        }
+
+        self.maybe_apply_sponsorship(&mut resp, &query_params, external_match_resp, refund_amount)?;
 
         // Watch the bundle for settlement
         let resp_clone = resp.body().to_vec();
         let server_clone = self.clone();
         tokio::spawn(async move {
             if let Err(e) = server_clone
-                .handle_direct_match_bundle_response(
-                    key_description,
-                    &body,
-                    &resp_clone,
-                    sponsorship_requested,
-                )
+                .handle_direct_match_bundle_response(key_description, &body, &resp_clone)
                 .await
             {
                 warn!("Error handling bundle: {e}");
@@ -209,6 +195,49 @@ impl Server {
         });
 
         Ok(resp)
+    }
+
+    /// Potentially apply gas sponsorship of `refund_amount` to the given
+    /// external match, writing the resulting `SponsoredMatchResponse` into
+    /// the response body
+    fn maybe_apply_sponsorship(
+        &self,
+        resp: &mut Response<Bytes>,
+        query_params: &GasSponsorshipQueryParams,
+        external_match_resp: ExternalMatchResponse,
+        refund_amount: Option<AlloyU256>,
+    ) -> Result<(), AuthServerError> {
+        // Whether or not sponsorship was requested, we return a
+        // `SponsoredMatchResponse`. This simply has one extra field,
+        // `is_sponsored`, which we expect clients to ignore if they did not
+        // request sponsorship.
+        let sponsorship_requested = query_params.use_gas_sponsorship.unwrap_or(true);
+        let sponsored_match_resp = if sponsorship_requested {
+            let refund_address =
+                query_params.get_refund_address().map_err(AuthServerError::serde)?;
+
+            let refund_native_eth = query_params.refund_native_eth.unwrap_or_default();
+
+            self.construct_sponsored_match_response(
+                external_match_resp,
+                refund_address,
+                refund_native_eth,
+                refund_amount,
+            )?
+        } else {
+            SponsoredMatchResponse {
+                match_bundle: external_match_resp.match_bundle,
+                is_sponsored: false,
+            }
+        };
+
+        let resp_body =
+            Bytes::from(serde_json::to_vec(&sponsored_match_resp).map_err(AuthServerError::serde)?);
+
+        resp.headers_mut().insert(CONTENT_LENGTH, resp_body.len().into());
+        *resp.body_mut() = resp_body;
+
+        Ok(())
     }
 
     // --- Bundle Tracking --- //
@@ -219,7 +248,6 @@ impl Server {
         key: String,
         req: &[u8],
         resp: &[u8],
-        sponsorship_requested: bool,
     ) -> Result<(), AuthServerError> {
         let req: AssembleExternalMatchRequest =
             serde_json::from_slice(req).map_err(AuthServerError::serde)?;
@@ -232,14 +260,7 @@ impl Server {
             self.log_updated_order(&key, original_order, updated_order, &request_id);
         }
 
-        self.handle_bundle_response(
-            key,
-            updated_order.clone(),
-            resp,
-            Some(request_id),
-            sponsorship_requested,
-        )
-        .await
+        self.handle_bundle_response(key, updated_order.clone(), resp, Some(request_id)).await
     }
 
     /// Handle a bundle response from a direct match request
@@ -248,12 +269,11 @@ impl Server {
         key: String,
         req: &[u8],
         resp: &[u8],
-        sponsorship_requested: bool,
     ) -> Result<(), AuthServerError> {
         let req: ExternalMatchRequest =
             serde_json::from_slice(req).map_err(AuthServerError::serde)?;
         let order = req.external_order;
-        self.handle_bundle_response(key, order, resp, None, sponsorship_requested).await
+        self.handle_bundle_response(key, order, resp, None).await
     }
 
     /// Record and watch a bundle that was forwarded to the client
@@ -265,23 +285,13 @@ impl Server {
         order: ExternalOrder,
         resp: &[u8],
         request_id: Option<String>,
-        sponsorship_requested: bool,
     ) -> Result<(), AuthServerError> {
         // Log the bundle
         let request_id = request_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         // Deserialize the response
-        let (is_sponsored, match_bundle) = if sponsorship_requested {
-            let match_resp: SponsoredMatchResponse =
-                serde_json::from_slice(resp).map_err(AuthServerError::serde)?;
-
-            (match_resp.is_sponsored, match_resp.match_bundle)
-        } else {
-            let match_resp: ExternalMatchResponse =
-                serde_json::from_slice(resp).map_err(AuthServerError::serde)?;
-
-            (false, match_resp.match_bundle)
-        };
+        let SponsoredMatchResponse { match_bundle, is_sponsored } =
+            serde_json::from_slice(resp).map_err(AuthServerError::serde)?;
 
         self.log_bundle(&order, &match_bundle, &key, &request_id)?;
 

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -13,7 +13,7 @@ use bigdecimal::{
 use contracts_common::constants::NUM_BYTES_SIGNATURE;
 use ethers::{core::k256::ecdsa::SigningKey, types::U256, utils::keccak256};
 use rand::{thread_rng, Rng};
-use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_api::http::external_match::ApiExternalMatchResult;
 use renegade_common::types::token::Token;
 use serde_json::json;
 use warp::reply::Reply;
@@ -64,10 +64,10 @@ pub fn aes_decrypt(value: &str, key: &[u8]) -> Result<String, AuthServerError> {
 }
 
 /// Generate a random nonce for gas sponsorship, signing it along with
-/// the provided refund address and the sponsorship amount
+/// the provided refund address and the refund amount
 pub fn gen_signed_sponsorship_nonce(
     refund_address: Address,
-    sponsorship_amount: AlloyU256,
+    refund_amount: AlloyU256,
     gas_sponsor_auth_key: &SigningKey,
 ) -> Result<(AlloyU256, Bytes), AuthServerError> {
     // Generate a random sponsorship nonce
@@ -78,7 +78,7 @@ pub fn gen_signed_sponsorship_nonce(
     let mut message = Vec::new();
     message.extend_from_slice(&nonce_bytes);
     message.extend_from_slice(refund_address.as_ref());
-    message.extend_from_slice(&sponsorship_amount.to_be_bytes::<{ AlloyU256::BYTES }>());
+    message.extend_from_slice(&refund_amount.to_be_bytes::<{ AlloyU256::BYTES }>());
 
     let signature = sign_message(&message, gas_sponsor_auth_key)?.into();
     let nonce = AlloyU256::from_be_bytes(nonce_bytes);
@@ -130,10 +130,10 @@ pub fn ethers_u256_to_bigdecimal(value: U256) -> BigDecimal {
 /// Get the nominal price of the buy token in USDC,
 /// i.e. whole units of USDC per nominal unit of TOKEN
 pub fn get_nominal_buy_token_price(
-    match_bundle: &AtomicMatchApiBundle,
+    buy_mint: &str,
+    match_result: &ApiExternalMatchResult,
 ) -> Result<BigDecimal, AuthServerError> {
-    let buy_mint = &match_bundle.receive.mint;
-    let quote_mint = &match_bundle.match_result.quote_mint;
+    let quote_mint = &match_result.quote_mint;
     let buying_quote = buy_mint.to_lowercase() == quote_mint.to_lowercase();
 
     // Compute TOKEN price from match result, in nominal terms
@@ -142,8 +142,8 @@ pub fn get_nominal_buy_token_price(
         // The quote token is always USDC, so price is 1
         BigDecimal::one()
     } else {
-        let base_amount = BigDecimal::from(match_bundle.match_result.base_amount);
-        let quote_amount = BigDecimal::from(match_bundle.match_result.quote_amount);
+        let base_amount = BigDecimal::from(match_result.base_amount);
+        let quote_amount = BigDecimal::from(match_result.quote_amount);
         quote_amount / base_amount
     };
 


### PR DESCRIPTION
This PR lays the groundwork for sponsoring gas using exact token amounts. Namely, the changes here are:
1. Preempt contract interface changes: we now expect the contracts to directly receive a `refund_amount` for gas sponsorship
2. Use the new `gas_estimation` module combined with the existing conversion logic to compute the refund amount in the appropriate token
3. Configure abstraction boundaries to lift computation of the refund amount out of the calldata construction code path. This will be necessary for computing the amount during the "quote" stage of the "quote-assemble" flow, the changes for which will come in a later PR

### Testing
- [x] Assert that gas estimation module is correctly estimating gas prices on the expected interval while the server runs