### PR TITLE
auth-server: gas_estimation: make gas estimation constants more accurate

### DIFF
--- a/auth/auth-server/src/server/gas_estimation/constants.rs
+++ b/auth/auth-server/src/server/gas_estimation/constants.rs
@@ -6,12 +6,19 @@ use alloy_primitives::hex;
 use ethers::types::{Address, H160};
 
 /// A pessimistic overestimate of the gas cost of L2 execution for an external
-/// match, rounded up to the nearest million.
-pub const ESTIMATED_L2_GAS: u64 = 4_000_000; // 4m
+/// match, rounded up to the nearest 100k.
+
+// In the future, we can consider sampling execution gas costs from a recent
+// external match
+pub const ESTIMATED_L2_GAS: u64 = 3_600_000; // 3.6m
 
 /// The approximate size in bytes of the calldata for an external match,
-/// obtained empirically
-pub const ESTIMATED_CALLDATA_SIZE_BYTES: usize = 8_000;
+/// accounting for an expected compression ratio.
+/// Concretely, our calldata is ~8kb, and we expect a compression ratio
+/// of ~75%. Both of these values were obtained empirically.
+
+// In the future, we can consider sampling calldata from a recent external match
+pub const ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES: usize = 6_000;
 
 /// The address of the `NodeInterface` precompile
 pub const NODE_INTERFACE_ADDRESS: Address = H160(hex!("00000000000000000000000000000000000000c8"));

--- a/auth/auth-server/src/server/gas_estimation/gas_cost_sampler.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_cost_sampler.rs
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 use crate::error::AuthServerError;
 
 use super::constants::{
-    ESTIMATED_CALLDATA_SIZE_BYTES, ESTIMATED_L2_GAS, GAS_COST_SAMPLING_INTERVAL,
+    ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES, ESTIMATED_L2_GAS, GAS_COST_SAMPLING_INTERVAL,
     NODE_INTERFACE_ADDRESS,
 };
 
@@ -94,9 +94,9 @@ impl GasCostSampler {
 
         // The arguments to the `gasEstimateL1Component` call are largely irrelevant.
         // Primarily, we're interested in mocking the calldata,
-        // which we do so by constructing `ESTIMATED_CALLDATA_SIZE_BYTES` random bytes,
-        // as a pessimistic assumption of the compressibility of the calldata.
-        let mut data = [0_u8; ESTIMATED_CALLDATA_SIZE_BYTES];
+        // which we do so by constructing `ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES`
+        // random bytes
+        let mut data = [0_u8; ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES];
         thread_rng().fill_bytes(&mut data);
 
         let (gas_estimate_for_l1, base_fee, _) = node_interface


### PR DESCRIPTION
This PR tweaks the constants used in gas estimation to be more accurate. We tune down the `ESTIMATED_L2_GAS` to 3.6M, and use `ESTIMATED_CALLDATA_SIZE_BYTES * 0.75` as an approximation of the compressibility of our calldata. We also make a couple misc tweaks: skipping fetching a conversion rate for WETH, and adding some useful tags to quote / bundle logs.

### Testing
- [x] Test native ETH refunds
- [x] Test in-kind refunds