### PR TITLE
auth-server: handle_external_match, gas_sponsorship: update external quote w/ sponsorship info

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -276,9 +276,10 @@ async fn main() {
         .and(warp::path::full())
         .and(warp::header::headers_cloned())
         .and(warp::body::bytes())
+        .and(warp::query::<GasSponsorshipQueryParams>())
         .and(with_server(server.clone()))
-        .and_then(|path, headers, body, server: Arc<Server>| async move {
-            server.handle_external_quote_request(path, headers, body).await
+        .and_then(|path, headers, body, query_params, server: Arc<Server>| async move {
+            server.handle_external_quote_request(path, headers, body, query_params).await
         });
 
     let external_quote_assembly_path = warp::path("v0")

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/contract_interaction.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/contract_interaction.rs
@@ -1,0 +1,222 @@
+//! Logic for interacting with the gas sponsor contract
+
+use alloy_primitives::{Address as AlloyAddress, Bytes as AlloyBytes, U256 as AlloyU256};
+use alloy_sol_types::{sol, SolCall};
+use bytes::Bytes;
+use ethers::{
+    contract::abigen,
+    types::{transaction::eip2718::TypedTransaction, Address, TxHash, U256},
+};
+use renegade_api::http::external_match::ExternalMatchResponse;
+use renegade_arbitrum_client::abi::{
+    processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+};
+use tracing::warn;
+
+use crate::{
+    error::AuthServerError,
+    server::{
+        helpers::{gen_signed_sponsorship_nonce, get_selector},
+        Server,
+    },
+};
+
+// -------
+// | ABI |
+// -------
+
+// The ABI for gas sponsorship events
+abigen!(
+    GasSponsorContract,
+    r#"[
+        event SponsoredExternalMatch(uint256 indexed amount, address indexed token, uint256 indexed nonce)
+    ]"#
+);
+
+// The ABI for gas sponsorship functions
+sol! {
+    function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bool refund_native_eth, uint256 refund_amount, bytes signature) external payable;
+}
+
+impl sponsorAtomicMatchSettleWithRefundOptionsCall {
+    /// Create a `sponsorAtomicMatchSettleWithRefundOptions` call from
+    /// `processAtomicMatchSettle` calldata
+    pub fn from_process_atomic_match_settle_calldata(
+        calldata: &[u8],
+        refund_address: AlloyAddress,
+        nonce: AlloyU256,
+        refund_native_eth: bool,
+        refund_amount: AlloyU256,
+        signature: AlloyBytes,
+    ) -> Result<Self, AuthServerError> {
+        let processAtomicMatchSettleCall {
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+        } = processAtomicMatchSettleCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(sponsorAtomicMatchSettleWithRefundOptionsCall {
+            receiver: AlloyAddress::ZERO,
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+            refund_address,
+            nonce,
+            refund_native_eth,
+            refund_amount,
+            signature,
+        })
+    }
+
+    /// Create a `sponsorAtomicMatchSettleWithRefundOptions` call from
+    /// `processAtomicMatchSettleWithReceiver` calldata
+    pub fn from_process_atomic_match_settle_with_receiver_calldata(
+        calldata: &[u8],
+        refund_address: AlloyAddress,
+        nonce: AlloyU256,
+        refund_native_eth: bool,
+        refund_amount: AlloyU256,
+        signature: AlloyBytes,
+    ) -> Result<Self, AuthServerError> {
+        let processAtomicMatchSettleWithReceiverCall {
+            receiver,
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+        } = processAtomicMatchSettleWithReceiverCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(sponsorAtomicMatchSettleWithRefundOptionsCall {
+            receiver,
+            internal_party_match_payload,
+            valid_match_settle_atomic_statement,
+            match_proofs,
+            match_linking_proofs,
+            refund_address,
+            nonce,
+            refund_native_eth,
+            refund_amount,
+            signature,
+        })
+    }
+}
+
+// ---------------
+// | Server Impl |
+// ---------------
+
+impl Server {
+    /// Generate the calldata for sponsoring the given match via the gas sponsor
+    pub(crate) fn generate_gas_sponsor_calldata(
+        &self,
+        external_match_resp: &ExternalMatchResponse,
+        refund_address: AlloyAddress,
+        refund_native_eth: bool,
+        refund_amount: AlloyU256,
+    ) -> Result<Bytes, AuthServerError> {
+        let (nonce, signature) = gen_signed_sponsorship_nonce(
+            refund_address,
+            refund_amount,
+            &self.gas_sponsor_auth_key,
+        )?;
+
+        let calldata = external_match_resp
+            .match_bundle
+            .settlement_tx
+            .data()
+            .ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
+
+        let selector = get_selector(calldata)?;
+
+        let gas_sponsor_call = match selector {
+            processAtomicMatchSettleCall::SELECTOR => {
+                sponsorAtomicMatchSettleWithRefundOptionsCall::from_process_atomic_match_settle_calldata(
+                    calldata,
+                    refund_address,
+                    nonce,
+                    refund_native_eth,
+                    refund_amount,
+                    signature,
+                )
+            },
+            processAtomicMatchSettleWithReceiverCall::SELECTOR => {
+                sponsorAtomicMatchSettleWithRefundOptionsCall::from_process_atomic_match_settle_with_receiver_calldata(
+                    calldata,
+                    refund_address,
+                    nonce,
+                    refund_native_eth,
+                    refund_amount,
+                    signature,
+                )
+            },
+            _ => {
+                return Err(AuthServerError::gas_sponsorship("invalid selector"));
+            },
+        }?;
+
+        let calldata = gas_sponsor_call.abi_encode().into();
+
+        Ok(calldata)
+    }
+
+    /// Get the token & amount refunded to sponsor the given settlement
+    /// transaction, and the associated transaction hash
+    pub(crate) async fn get_refunded_amount_and_tx(
+        &self,
+        settlement_tx: &TypedTransaction,
+    ) -> Result<Option<(Address, U256, TxHash)>, AuthServerError> {
+        // Parse the nonce from the TX calldata
+        let calldata =
+            settlement_tx.data().ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
+
+        let selector = get_selector(calldata)?;
+
+        let nonce = match selector {
+            sponsorAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
+                Self::get_nonce_from_sponsored_match_calldata(calldata)?
+            },
+            _ => {
+                return Err(AuthServerError::gas_sponsorship("invalid selector"));
+            },
+        };
+
+        // Search for the `AmountSponsored` event for the given nonce
+        let filter =
+            GasSponsorContract::new(self.gas_sponsor_address, self.arbitrum_client.client())
+                .event::<SponsoredExternalMatchFilter>()
+                .address(self.gas_sponsor_address.into())
+                .topic3(nonce)
+                .from_block(self.start_block_num);
+
+        let events = filter.query_with_meta().await.map_err(AuthServerError::gas_sponsorship)?;
+
+        // If no event was found, we assume that gas was not sponsored for this nonce.
+        // This could be the case if the gas sponsor was underfunded or paused.
+        let sponsorship_event =
+            events.last().map(|(event, meta)| (event.token, event.amount, meta.transaction_hash));
+
+        if sponsorship_event.is_none() {
+            warn!("No gas sponsorship event found for nonce: {}", nonce);
+        }
+
+        Ok(sponsorship_event)
+    }
+
+    /// Get the nonce from `sponsorAtomicMatchSettleWithRefundOptions` calldata
+    fn get_nonce_from_sponsored_match_calldata(calldata: &[u8]) -> Result<U256, AuthServerError> {
+        let call = sponsorAtomicMatchSettleWithRefundOptionsCall::abi_decode(
+            calldata, true, // validate
+        )
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(U256::from_big_endian(&call.nonce.to_be_bytes_vec()))
+    }
+}

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
@@ -3,132 +3,25 @@
 //! At a high level the server must first authenticate the request, then forward
 //! it to the relayer with admin authentication
 
-use alloy_primitives::{Address as AlloyAddress, Bytes as AlloyBytes, U256 as AlloyU256};
-use alloy_sol_types::{sol, SolCall};
-use auth_server_api::SponsoredMatchResponse;
+use alloy_primitives::Address as AlloyAddress;
+use auth_server_api::{
+    GasSponsorshipInfo, SignedGasSponsorshipInfo, SponsoredMatchResponse, SponsoredQuoteResponse,
+};
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
-use bytes::Bytes;
-use ethers::{
-    contract::abigen,
-    types::{transaction::eip2718::TypedTransaction, Address, TxHash, U256},
-    utils::WEI_IN_ETHER,
-};
-use renegade_arbitrum_client::abi::{
-    processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
-};
-use renegade_circuit_types::order::OrderSide;
-use renegade_common::types::token::Token;
-use renegade_constants::NATIVE_ASSET_ADDRESS;
-use tracing::{info, warn};
+use ethers::{types::Address, utils::WEI_IN_ETHER};
 
 use renegade_api::http::external_match::{
-    ApiExternalMatchResult, AtomicMatchApiBundle, ExternalMatchResponse,
+    AtomicMatchApiBundle, ExternalMatchResponse, ExternalQuoteResponse,
 };
+use renegade_util::hex::bytes_to_hex_string;
 
 use super::Server;
-use crate::server::helpers::{
-    ethers_u256_to_alloy_u256, gen_signed_sponsorship_nonce, get_nominal_buy_token_price,
-    get_selector,
-};
+use crate::server::helpers::get_nominal_buy_token_price;
 use crate::telemetry::helpers::record_gas_sponsorship_metrics;
 use crate::{error::AuthServerError, server::helpers::ethers_u256_to_bigdecimal};
 
-// -------------
-// | Constants |
-// -------------
-
-/// The number of Wei in 1 ETH, as an `AlloyU256`.
-/// Concretely, this is 10^18
-const ALLOY_WEI_IN_ETHER: AlloyU256 =
-    AlloyU256::from_limbs([1_000_000_000_000_000_000_u64, 0, 0, 0]);
-
-// -------
-// | ABI |
-// -------
-
-// The ABI for gas sponsorship functions
-sol! {
-    function sponsorAtomicMatchSettleWithRefundOptions(address receiver, bytes internal_party_match_payload, bytes valid_match_settle_atomic_statement, bytes match_proofs, bytes match_linking_proofs, address refund_address, uint256 nonce, bool refund_native_eth, uint256 refund_amount, bytes signature) external payable;
-}
-
-// The ABI for gas sponsorship events
-abigen!(
-    GasSponsorContract,
-    r#"[
-        event SponsoredExternalMatch(uint256 indexed amount, address indexed token, uint256 indexed nonce)
-    ]"#
-);
-
-impl sponsorAtomicMatchSettleWithRefundOptionsCall {
-    /// Create a `sponsorAtomicMatchSettleWithRefundOptions` call from
-    /// `processAtomicMatchSettle` calldata
-    pub fn from_process_atomic_match_settle_calldata(
-        calldata: &[u8],
-        refund_address: AlloyAddress,
-        nonce: AlloyU256,
-        refund_native_eth: bool,
-        refund_amount: AlloyU256,
-        signature: AlloyBytes,
-    ) -> Result<Self, AuthServerError> {
-        let processAtomicMatchSettleCall {
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-        } = processAtomicMatchSettleCall::abi_decode(
-            calldata, true, // validate
-        )
-        .map_err(AuthServerError::gas_sponsorship)?;
-
-        Ok(sponsorAtomicMatchSettleWithRefundOptionsCall {
-            receiver: AlloyAddress::ZERO,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-            refund_address,
-            nonce,
-            refund_native_eth,
-            refund_amount,
-            signature,
-        })
-    }
-
-    /// Create a `sponsorAtomicMatchSettleWithRefundOptions` call from
-    /// `processAtomicMatchSettleWithReceiver` calldata
-    pub fn from_process_atomic_match_settle_with_receiver_calldata(
-        calldata: &[u8],
-        refund_address: AlloyAddress,
-        nonce: AlloyU256,
-        refund_native_eth: bool,
-        refund_amount: AlloyU256,
-        signature: AlloyBytes,
-    ) -> Result<Self, AuthServerError> {
-        let processAtomicMatchSettleWithReceiverCall {
-            receiver,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-        } = processAtomicMatchSettleWithReceiverCall::abi_decode(
-            calldata, true, // validate
-        )
-        .map_err(AuthServerError::gas_sponsorship)?;
-
-        Ok(sponsorAtomicMatchSettleWithRefundOptionsCall {
-            receiver,
-            internal_party_match_payload,
-            valid_match_settle_atomic_statement,
-            match_proofs,
-            match_linking_proofs,
-            refund_address,
-            nonce,
-            refund_native_eth,
-            refund_amount,
-            signature,
-        })
-    }
-}
+pub mod contract_interaction;
+mod refund_calculation;
 
 // ---------------
 // | Server Impl |
@@ -137,198 +30,89 @@ impl sponsorAtomicMatchSettleWithRefundOptionsCall {
 /// Handle a proxied request
 impl Server {
     /// Construct a sponsored match response from an external match response
-    pub(crate) fn construct_sponsored_match_response(
+    pub(crate) async fn construct_sponsored_match_response(
         &self,
         mut external_match_resp: ExternalMatchResponse,
-        refund_address: AlloyAddress,
         refund_native_eth: bool,
-        refund_amount: Option<AlloyU256>,
+        refund_address: AlloyAddress,
     ) -> Result<SponsoredMatchResponse, AuthServerError> {
+        // Compute refund amount
+        let refund_amount = self
+            .get_refund_amount(&external_match_resp.match_bundle.match_result, refund_native_eth)
+            .await?;
+
+        let gas_sponsor_calldata = self
+            .generate_gas_sponsor_calldata(
+                &external_match_resp,
+                refund_address,
+                refund_native_eth,
+                refund_amount,
+            )?
+            .into();
+
         external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
+        external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
 
-        let is_sponsored = refund_amount.is_some();
-        if is_sponsored {
-            info!("Sponsoring match bundle via gas sponsor");
-
-            let gas_sponsor_calldata = self
-                .generate_gas_sponsor_calldata(
-                    &external_match_resp,
-                    refund_address,
-                    refund_native_eth,
-                    refund_amount.unwrap(),
-                )?
-                .into();
-
-            external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
-        }
-
-        Ok(SponsoredMatchResponse { match_bundle: external_match_resp.match_bundle, is_sponsored })
+        Ok(SponsoredMatchResponse {
+            match_bundle: external_match_resp.match_bundle,
+            is_sponsored: true,
+        })
     }
 
-    /// Get the amount to refund for a given match result
-    pub async fn get_refund_amount(
+    /// Construct a sponsored quote response from an external quote response
+    pub(crate) async fn construct_sponsored_quote_response(
         &self,
-        gas_sponsorship_rate_limited: bool,
-        match_result: &ApiExternalMatchResult,
+        mut external_quote_response: ExternalQuoteResponse,
         refund_native_eth: bool,
-    ) -> Result<Option<AlloyU256>, AuthServerError> {
-        if gas_sponsorship_rate_limited {
-            return Ok(None);
-        }
-
-        let conversion_rate =
-            self.maybe_fetch_conversion_rate(match_result, refund_native_eth).await?;
-
-        let estimated_gas_cost = ethers_u256_to_alloy_u256(self.get_gas_cost_estimate().await);
-
-        let refund_amount = if let Some(conversion_rate) = conversion_rate {
-            (estimated_gas_cost * conversion_rate) / ALLOY_WEI_IN_ETHER
-        } else {
-            estimated_gas_cost
-        };
-
-        Ok(Some(refund_amount))
-    }
-
-    /// Fetch the conversion rate from ETH to the buy-side token in the trade
-    /// from the price reporter, if necessary.
-    /// The conversion rate is in terms of nominal units of TOKEN per whole ETH.
-    #[allow(clippy::unused_async)]
-    async fn maybe_fetch_conversion_rate(
-        &self,
-        match_result: &ApiExternalMatchResult,
-        refund_native_eth: bool,
-    ) -> Result<Option<AlloyU256>, AuthServerError> {
-        let buy_mint = match match_result.direction {
-            OrderSide::Buy => &match_result.base_mint,
-            OrderSide::Sell => &match_result.quote_mint,
-        };
-        let native_eth_buy = buy_mint.to_lowercase() == NATIVE_ASSET_ADDRESS.to_lowercase();
-
-        let weth_addr = Token::from_ticker("WETH").get_addr();
-        let weth_buy = buy_mint.to_lowercase() == weth_addr.to_lowercase();
-
-        // If we're deliberately refunding via native ETH, or the buy-side token
-        // is native ETH or WETH, we don't need to get a conversion rate
-        if refund_native_eth || native_eth_buy || weth_buy {
-            return Ok(None);
-        }
-
-        // Get ETH price
-        let eth_price_f64 = self.price_reporter_client.get_eth_price().await?;
-        let eth_price = BigDecimal::from_f64(eth_price_f64)
-            .ok_or(AuthServerError::gas_sponsorship("failed to convert ETH price to BigDecimal"))?;
-
-        let buy_token_price = get_nominal_buy_token_price(buy_mint, match_result)?;
-
-        // Compute conversion rate of nominal units of TOKEN per whole ETH
-        let conversion_rate = eth_price / buy_token_price;
-
-        // Convert the scaled rate to a U256. We can use the `BigInt` component of the
-        // `BigDecimal` directly because we round to 0 digits after the decimal.
-        let (conversion_rate_bigint, _) =
-            conversion_rate.round(0 /* round_digits */).into_bigint_and_scale();
-
-        let conversion_rate_u256 = AlloyU256::try_from(conversion_rate_bigint)
-            .map_err(AuthServerError::gas_sponsorship)?;
-
-        Ok(Some(conversion_rate_u256))
-    }
-
-    /// Generate the calldata for sponsoring the given match via the gas sponsor
-    fn generate_gas_sponsor_calldata(
-        &self,
-        external_match_resp: &ExternalMatchResponse,
         refund_address: AlloyAddress,
-        refund_native_eth: bool,
-        refund_amount: AlloyU256,
-    ) -> Result<Bytes, AuthServerError> {
-        let (nonce, signature) = gen_signed_sponsorship_nonce(
-            refund_address,
-            refund_amount,
-            &self.gas_sponsor_auth_key,
-        )?;
+    ) -> Result<SponsoredQuoteResponse, AuthServerError> {
+        // Compute refund amount
+        let refund_amount = self
+            .get_refund_amount(
+                &external_quote_response.signed_quote.match_result(),
+                refund_native_eth,
+            )
+            .await?;
 
-        let calldata = external_match_resp
-            .match_bundle
-            .settlement_tx
-            .data()
-            .ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
+        let refund_amount: u128 =
+            refund_amount.try_into().map_err(AuthServerError::gas_sponsorship)?;
 
-        let selector = get_selector(calldata)?;
-
-        let gas_sponsor_call = match selector {
-            processAtomicMatchSettleCall::SELECTOR => {
-                sponsorAtomicMatchSettleWithRefundOptionsCall::from_process_atomic_match_settle_calldata(
-                    calldata,
-                    refund_address,
-                    nonce,
-                    refund_native_eth,
-                    refund_amount,
-                    signature,
-                )
-            },
-            processAtomicMatchSettleWithReceiverCall::SELECTOR => {
-                sponsorAtomicMatchSettleWithRefundOptionsCall::from_process_atomic_match_settle_with_receiver_calldata(
-                    calldata,
-                    refund_address,
-                    nonce,
-                    refund_native_eth,
-                    refund_amount,
-                    signature,
-                )
-            },
-            _ => {
-                return Err(AuthServerError::gas_sponsorship("invalid selector"));
-            },
-        }?;
-
-        let calldata = gas_sponsor_call.abi_encode().into();
-
-        Ok(calldata)
-    }
-
-    /// Get the token & amount refunded to sponsor the given settlement
-    /// transaction, and the associated transaction hash
-    async fn get_refunded_amount_and_tx(
-        &self,
-        settlement_tx: &TypedTransaction,
-    ) -> Result<Option<(Address, U256, TxHash)>, AuthServerError> {
-        // Parse the nonce from the TX calldata
-        let calldata =
-            settlement_tx.data().ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
-
-        let selector = get_selector(calldata)?;
-
-        let nonce = match selector {
-            sponsorAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
-                Self::get_nonce_from_sponsored_match_calldata(calldata)?
-            },
-            _ => {
-                return Err(AuthServerError::gas_sponsorship("invalid selector"));
-            },
-        };
-
-        // Search for the `AmountSponsored` event for the given nonce
-        let filter =
-            GasSponsorContract::new(self.gas_sponsor_address, self.arbitrum_client.client())
-                .event::<SponsoredExternalMatchFilter>()
-                .address(self.gas_sponsor_address.into())
-                .topic3(nonce)
-                .from_block(self.start_block_num);
-
-        let events = filter.query_with_meta().await.map_err(AuthServerError::gas_sponsorship)?;
-
-        // If no event was found, we assume that gas was not sponsored for this nonce.
-        // This could be the case if the gas sponsor was underfunded or paused.
-        let sponsorship_event =
-            events.last().map(|(event, meta)| (event.token, event.amount, meta.transaction_hash));
-
-        if sponsorship_event.is_none() {
-            warn!("No gas sponsorship event found for nonce: {}", nonce);
+        // Only update the quote if the refund is in-kind and the refund address is not
+        // set
+        if !refund_native_eth && refund_address.is_zero() {
+            // Update quote to reflect sponsorship
+            self.apply_sponsorship_to_quote(
+                &mut external_quote_response.signed_quote.quote,
+                refund_amount,
+            )?;
         }
 
-        Ok(sponsorship_event)
+        let refund_address =
+            if refund_address.is_zero() { None } else { Some(format!("{:#x}", refund_address)) };
+
+        let gas_sponsorship_info =
+            GasSponsorshipInfo { refund_amount, refund_native_eth, refund_address };
+
+        let signed_gas_sponsorship_info = self.sign_gas_sponsorship_info(gas_sponsorship_info)?;
+
+        Ok(SponsoredQuoteResponse {
+            external_quote_response,
+            gas_sponsorship_info: Some(signed_gas_sponsorship_info),
+        })
+    }
+
+    /// Sign the given gas sponsorship info
+    pub fn sign_gas_sponsorship_info(
+        &self,
+        gas_sponsorship_info: GasSponsorshipInfo,
+    ) -> Result<SignedGasSponsorshipInfo, AuthServerError> {
+        let gas_sponsorship_info_bytes =
+            serde_json::to_vec(&gas_sponsorship_info).map_err(AuthServerError::serde)?;
+
+        let signature = self.management_key.compute_mac(&gas_sponsorship_info_bytes);
+        let signature_hex = bytes_to_hex_string(&signature);
+
+        Ok(SignedGasSponsorshipInfo { gas_sponsorship_info, signature: signature_hex })
     }
 
     /// Record the gas sponsorship rate limit & metrics for a given settled
@@ -379,15 +163,5 @@ impl Server {
         }
 
         Ok(())
-    }
-
-    /// Get the nonce from `sponsorAtomicMatchSettleWithRefundOptions` calldata
-    fn get_nonce_from_sponsored_match_calldata(calldata: &[u8]) -> Result<U256, AuthServerError> {
-        let call = sponsorAtomicMatchSettleWithRefundOptionsCall::abi_decode(
-            calldata, true, // validate
-        )
-        .map_err(AuthServerError::gas_sponsorship)?;
-
-        Ok(U256::from_big_endian(&call.nonce.to_be_bytes_vec()))
     }
 }

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
@@ -1,0 +1,125 @@
+//! Logic for calculating refund info for a sponsored match
+
+use alloy_primitives::U256 as AlloyU256;
+use bigdecimal::{BigDecimal, FromPrimitive};
+use renegade_api::http::external_match::{ApiExternalMatchResult, ApiExternalQuote};
+use renegade_circuit_types::order::OrderSide;
+use renegade_common::types::token::Token;
+use renegade_constants::NATIVE_ASSET_ADDRESS;
+
+use crate::{
+    error::AuthServerError,
+    server::{
+        helpers::{ethers_u256_to_alloy_u256, get_nominal_buy_token_price},
+        Server,
+    },
+};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The number of Wei in 1 ETH, as an `AlloyU256`.
+/// Concretely, this is 10^18
+const ALLOY_WEI_IN_ETHER: AlloyU256 =
+    AlloyU256::from_limbs([1_000_000_000_000_000_000_u64, 0, 0, 0]);
+
+// ---------------
+// | Server Impl |
+// ---------------
+
+impl Server {
+    /// Get the amount to refund for a given match result
+    pub async fn get_refund_amount(
+        &self,
+        match_result: &ApiExternalMatchResult,
+        refund_native_eth: bool,
+    ) -> Result<AlloyU256, AuthServerError> {
+        let conversion_rate =
+            self.maybe_fetch_conversion_rate(match_result, refund_native_eth).await?;
+
+        let estimated_gas_cost = ethers_u256_to_alloy_u256(self.get_gas_cost_estimate().await);
+
+        let refund_amount = if let Some(conversion_rate) = conversion_rate {
+            (estimated_gas_cost * conversion_rate) / ALLOY_WEI_IN_ETHER
+        } else {
+            estimated_gas_cost
+        };
+
+        Ok(refund_amount)
+    }
+
+    /// Fetch the conversion rate from ETH to the buy-side token in the trade
+    /// from the price reporter, if necessary.
+    /// The conversion rate is in terms of nominal units of TOKEN per whole ETH.
+    #[allow(clippy::unused_async)]
+    async fn maybe_fetch_conversion_rate(
+        &self,
+        match_result: &ApiExternalMatchResult,
+        refund_native_eth: bool,
+    ) -> Result<Option<AlloyU256>, AuthServerError> {
+        let buy_mint = match match_result.direction {
+            OrderSide::Buy => &match_result.base_mint,
+            OrderSide::Sell => &match_result.quote_mint,
+        };
+        let native_eth_buy = buy_mint.to_lowercase() == NATIVE_ASSET_ADDRESS.to_lowercase();
+
+        let weth_addr = Token::from_ticker("WETH").get_addr();
+        let weth_buy = buy_mint.to_lowercase() == weth_addr.to_lowercase();
+
+        // If we're deliberately refunding via native ETH, or the buy-side token
+        // is native ETH or WETH, we don't need to get a conversion rate
+        if refund_native_eth || native_eth_buy || weth_buy {
+            return Ok(None);
+        }
+
+        // Get ETH price
+        let eth_price_f64 = self.price_reporter_client.get_eth_price().await?;
+        let eth_price = BigDecimal::from_f64(eth_price_f64)
+            .ok_or(AuthServerError::gas_sponsorship("failed to convert ETH price to BigDecimal"))?;
+
+        let buy_token_price = get_nominal_buy_token_price(buy_mint, match_result)?;
+
+        // Compute conversion rate of nominal units of TOKEN per whole ETH
+        let conversion_rate = eth_price / buy_token_price;
+
+        // Convert the scaled rate to a U256. We can use the `BigInt` component of the
+        // `BigDecimal` directly because we round to 0 digits after the decimal.
+        let (conversion_rate_bigint, _) =
+            conversion_rate.round(0 /* round_digits */).into_bigint_and_scale();
+
+        let conversion_rate_u256 = AlloyU256::try_from(conversion_rate_bigint)
+            .map_err(AuthServerError::gas_sponsorship)?;
+
+        Ok(Some(conversion_rate_u256))
+    }
+
+    /// Apply a gas sponsorship refund to a quote.
+    /// This method assumes that the refund was in-kind, i.e. that the refund
+    /// amount is in terms of the buy-side token.
+    pub(crate) fn apply_sponsorship_to_quote(
+        &self,
+        quote: &mut ApiExternalQuote,
+        refund_amount: u128,
+    ) -> Result<(), AuthServerError> {
+        let (base_amount, quote_amount) = match quote.match_result.direction {
+            OrderSide::Buy => {
+                (quote.match_result.base_amount + refund_amount, quote.match_result.quote_amount)
+            },
+            OrderSide::Sell => {
+                (quote.match_result.base_amount, quote.match_result.quote_amount + refund_amount)
+            },
+        };
+
+        let base_amt_f64 = base_amount as f64;
+        let quote_amt_f64 = quote_amount as f64;
+        let price = quote_amt_f64 / base_amt_f64;
+
+        quote.price.price = price.to_string();
+        quote.receive.amount += refund_amount;
+        quote.match_result.base_amount = base_amount;
+        quote.match_result.quote_amount = quote_amount;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR scaffolds the process by which gas sponsorship will be applied to requested quotes. We update the returned quote if necessary, adding the gas sponsorship info to the response object. This is useful not only to clients, but also so that we can reconstruct the original relayer-signed quote during assembly. For this reason we sign the sponsorship info in the response.

In this PR, we also move around a bit of code to make for better-packaged helpers. This is in anticipation of the assembly endpoint using the gas sponsorship info from the quote. It's worth noting that, if we want to maintain perfect backwards compatibility, we would still need to support requesting gas sponsorship at the assembly step. However this will be handled as an edge case until it is deprecated, and the structure of the helpers should not reflect that. 

Of note, we now do _not_ invoke the gas sponsor contract if the gas sponsorship rate limit was exceeded. We previously would, though this makes no difference in the actual match settlement.

### TODO
Sponsored quote assembly will come in a follow up PR.