### PR TITLE
auth-server-api: manually flatten nested API types

### DIFF
--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -52,7 +52,7 @@ futures-util = "0.3"
 metrics = "=0.22.3"
 atomic_float = "1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = "1.0.64"
 serde_urlencoded = "0.7"
 thiserror = "1.0"
 tracing = "0.1"

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
@@ -92,7 +92,7 @@ impl Server {
         let signed_gas_sponsorship_info = self.sign_gas_sponsorship_info(gas_sponsorship_info)?;
 
         Ok(SponsoredQuoteResponse {
-            external_quote_response,
+            signed_quote: external_quote_response.signed_quote,
             gas_sponsorship_info: Some(signed_gas_sponsorship_info),
         })
     }

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -28,6 +28,7 @@ use diesel_async::{
 };
 use ethers::{abi::Address, core::k256::ecdsa::SigningKey, types::BlockNumber, utils::hex};
 use gas_estimation::gas_cost_sampler::GasCostSampler;
+use http::header::CONTENT_LENGTH;
 use http::{HeaderMap, Method, Response};
 use native_tls::TlsConnector;
 use postgres_native_tls::MakeTlsConnector;
@@ -188,6 +189,10 @@ impl Server {
         mut headers: HeaderMap,
         body: Bytes,
     ) -> Result<Response<Bytes>, ApiError> {
+        // Ensure that the content-length header is set correctly
+        // so that the relayer can deserialize the proxied request
+        headers.insert(CONTENT_LENGTH, body.len().into());
+
         // Admin authenticate the request
         self.admin_authenticate(path, &mut headers, &body)?;
 


### PR DESCRIPTION
This PR tweaks the sponsored API request/response types to manually flatten the fields of the relayer API types they wrap. This is necessary because `u128`s are not supported where `#[serde(flatten)]` is used: https://github.com/serde-rs/json/issues/625.

Additionally, when proxying the quote assembly request to the relayer, we need to ensure that the `content-length` header is appropriately updated so that the relayer can properly deserialize the request body.

### Testing
- [x] Basic in-kind sponsored buy
- [x] Basic in-kind sponsored sell

In both of these test cases, I asserted that the requested quote had the price and receive amount appropriately updated, and that assembled/settled bundle matched up with the expected receive amount.

This implicitly verified that "reversing" the effects of sponsorship on the sponsored quote so that the assembly request can be proxied to the relayer works, assuaging concerns about `f64` arithmetic precision.

This makes sense: as long as the auth server and relayer run on the same architecture, with the same Rust version, we should expect `f64` operations on identical operands to have the same results.