### PR TITLE
auth-server: handle_external_match: gas_sponsorship: update match bundle w/ refund amount

### DIFF
--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -98,8 +98,8 @@ impl GasSponsorshipInfo {
     }
 
     /// Whether this sponsorship implies an update to the effective price /
-    /// receive amount of the associated quote
-    pub fn requires_quote_update(&self) -> bool {
+    /// receive amount of the associated match result
+    pub fn requires_match_result_update(&self) -> bool {
         !self.refund_native_eth && self.refund_address.is_none()
     }
 
@@ -157,10 +157,13 @@ impl AssembleSponsoredMatchRequest {
 /// A sponsored match response from the auth server
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SponsoredMatchResponse {
-    /// The external match bundle
+    /// The external match bundle, potentially updated to reflect the
+    /// post-sponsorship receive amount
     pub match_bundle: AtomicMatchApiBundle,
     /// Whether or not the match was sponsored
     pub is_sponsored: bool,
+    /// The gas sponsorship info
+    pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
 }
 
 /// The query parameters used for gas sponsorship

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/contract_interaction.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/contract_interaction.rs
@@ -3,15 +3,11 @@
 use alloy_primitives::{Address as AlloyAddress, Bytes as AlloyBytes, U256 as AlloyU256};
 use alloy_sol_types::{sol, SolCall};
 use bytes::Bytes;
-use ethers::{
-    contract::abigen,
-    types::{transaction::eip2718::TypedTransaction, Address, TxHash, U256},
-};
+use ethers::contract::abigen;
 use renegade_api::http::external_match::ExternalMatchResponse;
 use renegade_arbitrum_client::abi::{
     processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
 };
-use tracing::warn;
 
 use crate::{
     error::AuthServerError,
@@ -165,58 +161,5 @@ impl Server {
         let calldata = gas_sponsor_call.abi_encode().into();
 
         Ok(calldata)
-    }
-
-    /// Get the token & amount refunded to sponsor the given settlement
-    /// transaction, and the associated transaction hash
-    pub(crate) async fn get_refunded_amount_and_tx(
-        &self,
-        settlement_tx: &TypedTransaction,
-    ) -> Result<Option<(Address, U256, TxHash)>, AuthServerError> {
-        // Parse the nonce from the TX calldata
-        let calldata =
-            settlement_tx.data().ok_or(AuthServerError::gas_sponsorship("expected calldata"))?;
-
-        let selector = get_selector(calldata)?;
-
-        let nonce = match selector {
-            sponsorAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
-                Self::get_nonce_from_sponsored_match_calldata(calldata)?
-            },
-            _ => {
-                return Err(AuthServerError::gas_sponsorship("invalid selector"));
-            },
-        };
-
-        // Search for the `AmountSponsored` event for the given nonce
-        let filter =
-            GasSponsorContract::new(self.gas_sponsor_address, self.arbitrum_client.client())
-                .event::<SponsoredExternalMatchFilter>()
-                .address(self.gas_sponsor_address.into())
-                .topic3(nonce)
-                .from_block(self.start_block_num);
-
-        let events = filter.query_with_meta().await.map_err(AuthServerError::gas_sponsorship)?;
-
-        // If no event was found, we assume that gas was not sponsored for this nonce.
-        // This could be the case if the gas sponsor was underfunded or paused.
-        let sponsorship_event =
-            events.last().map(|(event, meta)| (event.token, event.amount, meta.transaction_hash));
-
-        if sponsorship_event.is_none() {
-            warn!("No gas sponsorship event found for nonce: {}", nonce);
-        }
-
-        Ok(sponsorship_event)
-    }
-
-    /// Get the nonce from `sponsorAtomicMatchSettleWithRefundOptions` calldata
-    fn get_nonce_from_sponsored_match_calldata(calldata: &[u8]) -> Result<U256, AuthServerError> {
-        let call = sponsorAtomicMatchSettleWithRefundOptionsCall::abi_decode(
-            calldata, true, // validate
-        )
-        .map_err(AuthServerError::gas_sponsorship)?;
-
-        Ok(U256::from_big_endian(&call.nonce.to_be_bytes_vec()))
     }
 }

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -143,8 +143,8 @@ impl Server {
             if let Err(e) = server_clone
                 .handle_quote_assembly_bundle_response(
                     key_desc,
-                    &assemble_sponsored_match_req,
-                    &sponsored_match_resp,
+                    assemble_sponsored_match_req,
+                    sponsored_match_resp,
                 )
                 .await
             {
@@ -198,7 +198,7 @@ impl Server {
         let server_clone = self.clone();
         tokio::spawn(async move {
             if let Err(e) = server_clone
-                .handle_direct_match_bundle_response(key_description, &body, &sponsored_match_resp)
+                .handle_direct_match_bundle_response(key_description, &body, sponsored_match_resp)
                 .await
             {
                 warn!("Error handling bundle: {e}");
@@ -275,7 +275,7 @@ impl Server {
         self.validate_gas_sponsorship_info_signature(signed_gas_sponsorship_info)?;
 
         let gas_sponsorship_info = &signed_gas_sponsorship_info.gas_sponsorship_info;
-        if gas_sponsorship_info.requires_quote_update() {
+        if gas_sponsorship_info.requires_match_result_update() {
             // Reconstruct original signed quote
             let quote = &mut assemble_sponsored_match_req.signed_quote.quote;
             self.remove_gas_sponsorship_from_quote(quote, gas_sponsorship_info.refund_amount)?;
@@ -328,6 +328,7 @@ impl Server {
             SponsoredMatchResponse {
                 match_bundle: external_match_resp.match_bundle,
                 is_sponsored: false,
+                gas_sponsorship_info: None,
             }
         };
 
@@ -365,6 +366,7 @@ impl Server {
             return Ok(SponsoredMatchResponse {
                 match_bundle: external_match_resp.match_bundle,
                 is_sponsored: false,
+                gas_sponsorship_info: None,
             });
         }
 
@@ -391,8 +393,8 @@ impl Server {
     async fn handle_quote_assembly_bundle_response(
         &self,
         key: String,
-        req: &AssembleSponsoredMatchRequest,
-        resp: &SponsoredMatchResponse,
+        req: AssembleSponsoredMatchRequest,
+        resp: SponsoredMatchResponse,
     ) -> Result<(), AuthServerError> {
         let original_order = &req.signed_quote.quote.order;
         let updated_order = req.updated_order.as_ref().unwrap_or(original_order);
@@ -410,7 +412,7 @@ impl Server {
         &self,
         key: String,
         req: &[u8],
-        resp: &SponsoredMatchResponse,
+        resp: SponsoredMatchResponse,
     ) -> Result<(), AuthServerError> {
         let req: ExternalMatchRequest =
             serde_json::from_slice(req).map_err(AuthServerError::serde)?;
@@ -425,15 +427,17 @@ impl Server {
         &self,
         key: String,
         order: ExternalOrder,
-        resp: &SponsoredMatchResponse,
+        resp: SponsoredMatchResponse,
         request_id: Option<String>,
     ) -> Result<(), AuthServerError> {
         // Log the bundle
         let request_id = request_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-        self.log_bundle(&order, resp, &key, &request_id)?;
+        self.log_bundle(&order, &resp, &key, &request_id)?;
 
-        let SponsoredMatchResponse { match_bundle, is_sponsored } = resp;
+        // Note: if sponsored in-kind w/ refund going to the receiver,
+        // the amounts in the match bundle will have been updated
+        let SponsoredMatchResponse { match_bundle, is_sponsored, gas_sponsorship_info } = resp;
 
         let labels = vec![
             (KEY_DESCRIPTION_METRIC_TAG.to_string(), key.clone()),
@@ -444,19 +448,26 @@ impl Server {
 
         // Record quote comparisons before settlement, if enabled
         if let Some(quote_metrics) = &self.quote_metrics {
-            quote_metrics.record_quote_comparison(match_bundle, labels.as_slice()).await;
+            quote_metrics.record_quote_comparison(&match_bundle, labels.as_slice()).await;
         }
 
         // If the bundle settles, increase the API user's a rate limit token balance
-        let did_settle = await_settlement(match_bundle, &self.arbitrum_client).await?;
+        let did_settle = await_settlement(&match_bundle, &self.arbitrum_client).await?;
         if did_settle {
             self.add_bundle_rate_limit_token(key.clone()).await;
-            self.record_settled_match_sponsorship(match_bundle, *is_sponsored, key, request_id)
+            if let Some(gas_sponsorship_info) = gas_sponsorship_info {
+                self.record_settled_match_sponsorship(
+                    &match_bundle,
+                    gas_sponsorship_info,
+                    key,
+                    request_id,
+                )
                 .await?;
+            }
         }
 
         // Record metrics
-        record_external_match_metrics(&order, match_bundle, &labels, did_settle).await?;
+        record_external_match_metrics(&order, &match_bundle, &labels, did_settle).await?;
 
         Ok(())
     }
@@ -465,19 +476,28 @@ impl Server {
 
     /// Log a quote
     fn log_quote(&self, resp: &SponsoredQuoteResponse) -> Result<(), AuthServerError> {
-        let signed_quote = &resp.signed_quote;
+        let SponsoredQuoteResponse { signed_quote, gas_sponsorship_info } = resp;
         let match_result = signed_quote.match_result();
         let is_buy = match_result.direction;
         let recv = signed_quote.receive_amount();
         let send = signed_quote.send_amount();
-        let is_sponsored = resp.gas_sponsorship_info.is_some();
+        let is_sponsored = gas_sponsorship_info.is_some();
+        let (refund_amount, refund_native_eth) = gas_sponsorship_info
+            .as_ref()
+            .map(|s| {
+                (s.gas_sponsorship_info.refund_amount, s.gas_sponsorship_info.refund_native_eth)
+            })
+            .unwrap_or((0, false));
+
         info!(
             is_sponsored = is_sponsored,
-            "Sending quote(is_buy: {is_buy}, receive: {} ({}), send: {} ({})) to client",
+            "Sending quote(is_buy: {is_buy}, receive: {} ({}), send: {} ({}), refund_amount: {} (refund_native_eth: {})) to client",
             recv.amount,
             recv.mint,
             send.amount,
-            send.mint
+            send.mint,
+            refund_amount,
+            refund_native_eth
         );
 
         Ok(())
@@ -511,7 +531,7 @@ impl Server {
         key_description: &str,
         request_id: &str,
     ) -> Result<(), AuthServerError> {
-        let SponsoredMatchResponse { match_bundle, is_sponsored } = resp;
+        let SponsoredMatchResponse { match_bundle, is_sponsored, gas_sponsorship_info } = resp;
 
         // Get the decimal-corrected price
         let price = calculate_implied_price(match_bundle, true /* decimal_correct */)?;
@@ -534,6 +554,12 @@ impl Server {
         let response_quote_amount = match_result.quote_amount;
         let quote_fill_ratio = response_quote_amount as f64 / requested_quote_amount as f64;
 
+        // Get the gas sponsorship info
+        let (refund_amount, refund_native_eth) = gas_sponsorship_info
+            .as_ref()
+            .map(|info| (info.refund_amount, info.refund_native_eth))
+            .unwrap_or((0, false));
+
         info!(
             requested_base_amount = requested_base_amount,
             response_base_amount = response_base_amount,
@@ -544,12 +570,14 @@ impl Server {
             key_description = key_description,
             request_id = request_id,
             is_sponsored = is_sponsored,
-            "Sending bundle(is_buy: {}, recv: {} ({}), send: {} ({})) to client",
+            "Sending bundle(is_buy: {}, recv: {} ({}), send: {} ({}), refund_amount: {} (refund_native_eth: {})) to client",
             is_buy,
             recv.amount,
             recv.mint,
             send.amount,
-            send.mint
+            send.mint,
+            refund_amount,
+            refund_native_eth
         );
 
         Ok(())

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -26,7 +26,7 @@ use diesel_async::{
     pooled_connection::{AsyncDieselConnectionManager, ManagerConfig},
     AsyncPgConnection,
 };
-use ethers::{abi::Address, core::k256::ecdsa::SigningKey, types::BlockNumber, utils::hex};
+use ethers::{abi::Address, core::k256::ecdsa::SigningKey, utils::hex};
 use gas_estimation::gas_cost_sampler::GasCostSampler;
 use http::header::CONTENT_LENGTH;
 use http::{HeaderMap, Method, Response};
@@ -83,9 +83,6 @@ pub struct Server {
     pub gas_sponsor_address: Address,
     /// The auth key for the gas sponsor
     pub gas_sponsor_auth_key: SigningKey,
-    /// The block number at which the server started, used to filter gas
-    /// sponsorship events for rate limiting
-    pub start_block_num: BlockNumber,
     /// The price reporter client with WebSocket streaming support
     pub price_reporter_client: Arc<PriceReporterClient>,
     /// The gas cost sampler
@@ -142,9 +139,6 @@ impl Server {
         let gas_sponsor_auth_key =
             SigningKey::from_slice(&gas_sponsor_auth_key_bytes).map_err(AuthServerError::setup)?;
 
-        let start_block_num =
-            arbitrum_client.block_number().await.map_err(AuthServerError::setup)?;
-
         let gas_cost_sampler = Arc::new(
             GasCostSampler::new(
                 arbitrum_client.client().clone(),
@@ -170,7 +164,6 @@ impl Server {
                 .unwrap_or(1.0 /* default no sampling */),
             gas_sponsor_address,
             gas_sponsor_auth_key,
-            start_block_num,
             price_reporter_client,
             gas_cost_sampler,
         })

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use alloy_sol_types::SolCall;
 use contracts_common::types::MatchPayload;
-use ethers::types::TxHash;
 use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalOrder};
 use renegade_arbitrum_client::{
     abi::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
@@ -39,7 +38,7 @@ use crate::{
 };
 
 use super::{
-    labels::{GAS_SPONSORSHIP_VALUE, REQUEST_ID_METRIC_TAG, SIDE_TAG, TX_HASH_METRIC_TAG},
+    labels::{GAS_SPONSORSHIP_VALUE, REQUEST_ID_METRIC_TAG, SIDE_TAG},
     quote_comparison::QuoteComparison,
 };
 
@@ -284,15 +283,8 @@ pub(crate) async fn record_external_match_metrics(
 }
 
 /// Record the dollar value of sponsored gas for a given settled match
-pub(crate) fn record_gas_sponsorship_metrics(
-    gas_sponsorship_value: f64,
-    tx_hash: TxHash,
-    request_id: String,
-) {
-    let labels = vec![
-        (REQUEST_ID_METRIC_TAG.to_string(), request_id),
-        (TX_HASH_METRIC_TAG.to_string(), format!("{:#x}", tx_hash)),
-    ];
+pub(crate) fn record_gas_sponsorship_metrics(gas_sponsorship_value: f64, request_id: String) {
+    let labels = vec![(REQUEST_ID_METRIC_TAG.to_string(), request_id)];
     metrics::gauge!(GAS_SPONSORSHIP_VALUE, &labels).set(gas_sponsorship_value);
 }
 

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -86,5 +86,3 @@ pub const SOURCE_NET_OUTPUT_TAG: &str = "source_net_output";
 
 /// Metric tag to indicate that a match had its gas costs sponsored
 pub const GAS_SPONSORED_METRIC_TAG: &str = "gas_sponsored";
-/// Metric tag for a transaction hash
-pub const TX_HASH_METRIC_TAG: &str = "tx_hash";


### PR DESCRIPTION
This PR ensures that the match bundles resulting from sponsored quotes also have their traded amounts updated to reflect gas sponsorship, when appropriate (i.e., when the refund is in-kind and goes to the receiver). We also make some updates to recorded telemetry. Note that telemetry will be recorded using post-sponsorship amounts / prices, this is a more accurate view anyway.

### Testing
- [x] Test against testnet