### PR TITLE
auth-server: handle_external_match: new gas sponsorship defaults

### DIFF
--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -169,11 +169,8 @@ pub struct SponsoredMatchResponse {
 /// The query parameters used for gas sponsorship
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GasSponsorshipQueryParams {
-    /// Whether to use gas sponsorship for the external match.
-    #[deprecated(since = "0.1.0", note = "Use `omit_gas_sponsorship` instead")]
-    pub use_gas_sponsorship: Option<bool>,
-    /// Whether to omit gas sponsorship for the external match.
-    pub omit_gas_sponsorship: Option<bool>,
+    /// Whether to disable gas sponsorship for the external match.
+    pub disable_gas_sponsorship: Option<bool>,
     /// The address to refund gas to.
     /// In the case of a native ETH refund, defaults to `tx::origin`.
     /// In the case of an in-kind refund, defaults to the receiver.
@@ -195,9 +192,9 @@ impl GasSponsorshipQueryParams {
 
     /// Get the gas sponsorship parameters, defaulting to in-kind gas
     /// sponsorship
-    pub fn get_or_default_in_kind(&self) -> (bool, Address, bool) {
+    pub fn get_or_default(&self) -> (bool, Address, bool) {
         (
-            self.omit_gas_sponsorship.unwrap_or(false),
+            self.disable_gas_sponsorship.unwrap_or(false),
             self.get_refund_address(),
             self.refund_native_eth.unwrap_or(false),
         )
@@ -205,7 +202,7 @@ impl GasSponsorshipQueryParams {
 
     /// Whether any gas sponsorship parameters are explicitly set
     pub fn is_set(&self) -> bool {
-        self.omit_gas_sponsorship.is_some()
+        self.disable_gas_sponsorship.is_some()
             || self.refund_address.is_some()
             || self.refund_native_eth.is_some()
     }

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -170,15 +170,16 @@ pub struct SponsoredMatchResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GasSponsorshipQueryParams {
     /// Whether to use gas sponsorship for the external match.
-    /// Defaults to `true`.
+    #[deprecated(since = "0.1.0", note = "Use `omit_gas_sponsorship` instead")]
     pub use_gas_sponsorship: Option<bool>,
+    /// Whether to omit gas sponsorship for the external match.
+    pub omit_gas_sponsorship: Option<bool>,
     /// The address to refund gas to.
     /// In the case of a native ETH refund, defaults to `tx::origin`.
     /// In the case of an in-kind refund, defaults to the receiver.
     pub refund_address: Option<String>,
     /// Whether to provide the gas refund in terms of native ETH,
     /// as opposed to the buy-side token.
-    /// Defaults to `false`, meaning the buy-side token is used.
     pub refund_native_eth: Option<bool>,
 }
 
@@ -192,11 +193,11 @@ impl GasSponsorshipQueryParams {
             .unwrap_or(Address::ZERO)
     }
 
-    /// Get the gas sponsorship parameters, defaulting to the
-    /// server's defaults if not provided
-    pub fn get_or_default(&self) -> (bool, Address, bool) {
+    /// Get the gas sponsorship parameters, defaulting to in-kind gas
+    /// sponsorship
+    pub fn get_or_default_in_kind(&self) -> (bool, Address, bool) {
         (
-            self.use_gas_sponsorship.unwrap_or(true),
+            self.omit_gas_sponsorship.unwrap_or(false),
             self.get_refund_address(),
             self.refund_native_eth.unwrap_or(false),
         )
@@ -204,7 +205,7 @@ impl GasSponsorshipQueryParams {
 
     /// Whether any gas sponsorship parameters are explicitly set
     pub fn is_set(&self) -> bool {
-        self.use_gas_sponsorship.is_some()
+        self.omit_gas_sponsorship.is_some()
             || self.refund_address.is_some()
             || self.refund_native_eth.is_some()
     }

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
@@ -8,6 +8,7 @@ use renegade_api::http::external_match::{
 use renegade_circuit_types::order::OrderSide;
 use renegade_common::types::token::Token;
 use renegade_constants::NATIVE_ASSET_ADDRESS;
+use tracing::info;
 
 use crate::{
     error::AuthServerError,
@@ -138,6 +139,8 @@ pub(crate) fn update_quote_with_gas_sponsorship(
     quote: &mut ApiExternalQuote,
     refund_amount: u128,
 ) -> Result<(), AuthServerError> {
+    info!("Updating quote to reflect gas sponsorship");
+
     update_match_result_with_gas_sponsorship(&mut quote.match_result, refund_amount);
 
     let base_amt_f64 = quote.match_result.base_amount as f64;
@@ -157,6 +160,7 @@ pub(crate) fn update_match_bundle_with_gas_sponsorship(
     match_bundle: &mut AtomicMatchApiBundle,
     refund_amount: u128,
 ) {
+    info!("Updating match bundle to reflect gas sponsorship");
     update_match_result_with_gas_sponsorship(&mut match_bundle.match_result, refund_amount);
     match_bundle.receive.amount += refund_amount;
 }

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -218,9 +218,13 @@ impl Server {
         resp_body: &[u8],
         query_params: &GasSponsorshipQueryParams,
     ) -> Result<SponsoredQuoteResponse, AuthServerError> {
-        // Parse query params
-        let (sponsorship_requested, refund_address, refund_native_eth) =
-            query_params.get_or_default();
+        // Parse query params.
+        // For backwards compatibility, we do *not* enable in-kind gas sponsorship by
+        // default for quote requests.
+        // TODO: Once clients have updated, we should enable this by default.
+        let sponsorship_requested = query_params.omit_gas_sponsorship.unwrap_or(true);
+        let refund_native_eth = query_params.refund_native_eth.unwrap_or(true);
+        let refund_address = query_params.get_refund_address();
 
         // Check gas sponsorship rate limit
         let gas_sponsorship_rate_limited =
@@ -345,7 +349,7 @@ impl Server {
     ) -> Result<SponsoredMatchResponse, AuthServerError> {
         // Parse query params
         let (sponsorship_requested, refund_address, refund_native_eth) =
-            query_params.get_or_default();
+            query_params.get_or_default_in_kind();
 
         // Check gas sponsorship rate limit
         let gas_sponsorship_rate_limited =


### PR DESCRIPTION
This PR sets appropriate default parameters for gas sponsorship. Concretely, we have to disable in-kind gas sponsorship by default in the qutoe request endpoint for backwards compatibility with SDKs. Additionally, we deprecate the `use_gas_sponsorship` query parameter in favor of `omit_gas_sponsorship`, for more intuitive `false` defaults. This is a breaking change - un-updated clients that try to explicitly disable gas sponsorship with `use_gas_sponsorship=false` will have this parameter ignored. However, un-updated clients will enjoy gas sponsorship being enabled by default for direct matches.

### Testing
- [x] Test against testnet w/ un-updated SDK