### PR TITLE
funds manager server: modifications for switching execution venues

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -15,6 +15,17 @@ pub const GET_DEPOSIT_ADDRESS_ROUTE: &str = "deposit-address";
 /// The route to withdraw funds from custody
 pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
 /// The route to fetch an execution quote on the quoter hot wallet
+///
+/// Expected query parameters (proxied directly to LiFi API):
+/// - fromChain: Source chain ID
+/// - toChain: Destination chain ID
+/// - fromToken: Source token address
+/// - toToken: Destination token address
+/// - fromAddress: Source wallet address
+/// - toAddress: Destination wallet address
+/// - fromAmount: Source token amount
+/// - order: Order preference for routing (e.g. 'CHEAPEST')
+/// - slippage: Slippage tolerance as a decimal (e.g. 0.0001 for 0.01%)
 pub const GET_EXECUTION_QUOTE_ROUTE: &str = "get-execution-quote";
 /// The route to execute a swap on the quoter hot wallet
 pub const EXECUTE_SWAP_ROUTE: &str = "execute-swap";
@@ -56,8 +67,6 @@ pub struct ExecutionQuote {
     /// The amount of tokens to sell
     #[serde(with = "u256_string_serialization")]
     pub sell_amount: U256,
-    /// The quoted price
-    pub price: String,
     /// The submitting address
     #[serde(with = "address_string_serialization")]
     pub from: Address,
@@ -80,22 +89,9 @@ pub struct ExecutionQuote {
 
 /// The request body for fetching a quote from the execution venue
 #[derive(Debug, Serialize, Deserialize)]
-pub struct GetExecutionQuoteRequest {
-    /// The token address we're buying
-    #[serde(with = "address_string_serialization")]
-    pub buy_token_address: Address,
-    /// The token address we're selling
-    #[serde(with = "address_string_serialization")]
-    pub sell_token_address: Address,
-    /// The amount of tokens to sell
-    pub sell_amount: u128,
-}
-
-/// The response body for fetching a quote from the execution venue
-#[derive(Debug, Serialize, Deserialize)]
 pub struct GetExecutionQuoteResponse {
     /// The quote, directly from the execution venue
-    pub quote: ExecutionQuote,
+    pub quote: serde_json::Value,
 }
 
 /// The request body for executing a swap on the execution venue

--- a/funds-manager/funds-manager-server/src/execution_client/quotes.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/quotes.rs
@@ -1,121 +1,23 @@
 //! Client methods for fetching quotes and prices from the execution venue
 
-use std::{str::FromStr, sync::Arc};
+use std::collections::HashMap;
 
-use ethers::{
-    signers::{LocalWallet, Signer},
-    types::{Address, U256},
-};
-use funds_manager_api::quoters::ExecutionQuote;
-use serde::Deserialize;
-use tracing::info;
-
-use crate::helpers::ERC20;
+use serde_json;
 
 use super::{error::ExecutionClientError, ExecutionClient};
 
-/// The price endpoint
-const PRICE_ENDPOINT: &str = "swap/v1/price";
 /// The quote endpoint
-const QUOTE_ENDPOINT: &str = "swap/v1/quote";
-
-/// The buy token url param
-const BUY_TOKEN: &str = "buyToken";
-/// The sell token url param
-const SELL_TOKEN: &str = "sellToken";
-/// The sell amount url param
-const SELL_AMOUNT: &str = "sellAmount";
-/// The taker address url param
-const TAKER_ADDRESS: &str = "takerAddress";
-
-/// The 0x exchange proxy contract address
-///
-/// TODO: This is the same across _most_ chains, but if we wish to support
-/// one-off chains like ethereum sepolia, we should make this configurable
-///
-/// See: https://0x.org/docs/introduction/0x-cheat-sheet#exchange-proxy-addresses
-const EXCHANGE_PROXY_ADDRESS: &str = "0xdef1c0ded9bec7f1a1670819833240f027b25eff";
-
-/// The price response
-#[derive(Debug, Deserialize)]
-pub struct PriceResponse {
-    /// The price
-    pub price: String,
-}
+const QUOTE_ENDPOINT: &str = "v1/quote";
 
 impl ExecutionClient {
-    /// Fetch a price for an asset
-    pub async fn get_price(
-        &self,
-        buy_asset: &str,
-        sell_asset: &str,
-        amount: u128,
-    ) -> Result<f64, ExecutionClientError> {
-        let amount_str = amount.to_string();
-        let params =
-            [(BUY_TOKEN, buy_asset), (SELL_TOKEN, sell_asset), (SELL_AMOUNT, amount_str.as_str())];
-
-        let resp: PriceResponse = self.send_get_request(PRICE_ENDPOINT, &params).await?;
-        resp.price.parse::<f64>().map_err(ExecutionClientError::parse)
-    }
-
-    /// Fetch a quote for an asset
+    /// Fetch a quote by forwarding raw query parameters
     pub async fn get_quote(
         &self,
-        buy_asset: Address,
-        sell_asset: Address,
-        amount: u128,
-        wallet: &LocalWallet,
-    ) -> Result<ExecutionQuote, ExecutionClientError> {
-        // First, set an approval for the sell token, the 0x api will not give a quote
-        // if its contract is not an approved spender for the requested amount
-        let exchange_addr = Address::from_str(EXCHANGE_PROXY_ADDRESS).unwrap();
-        self.approve_erc20_allowance(sell_asset, exchange_addr, U256::from(amount), wallet).await?;
-
-        let buy = format!("{buy_asset:#x}");
-        let sell = format!("{sell_asset:#x}");
-        let recipient = format!("{:#x}", wallet.address());
-        let amount_str = amount.to_string();
-        let params = [
-            (BUY_TOKEN, buy.as_str()),
-            (SELL_TOKEN, sell.as_str()),
-            (SELL_AMOUNT, amount_str.as_str()),
-            (TAKER_ADDRESS, recipient.as_str()),
-        ];
+        query_params: HashMap<String, String>,
+    ) -> Result<serde_json::Value, ExecutionClientError> {
+        let params: Vec<(&str, &str)> =
+            query_params.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
         self.send_get_request(QUOTE_ENDPOINT, &params).await
-    }
-
-    /// Approve an erc20 allowance
-    async fn approve_erc20_allowance(
-        &self,
-        token_address: Address,
-        spender: Address,
-        amount: U256,
-        wallet: &LocalWallet,
-    ) -> Result<(), ExecutionClientError> {
-        let client = self.get_signer(wallet.clone());
-        let erc20 = ERC20::new(token_address, Arc::new(client));
-
-        // First, check if the allowance is already sufficient
-        let allowance = erc20
-            .allowance(wallet.address(), spender)
-            .await
-            .map_err(ExecutionClientError::arbitrum)?;
-        if allowance >= amount {
-            info!("Already approved erc20 allowance for {spender:#x}");
-            return Ok(());
-        }
-
-        // Otherwise, approve the allowance
-        let tx = erc20.approve(spender, amount);
-        let pending_tx = tx.send().await.map_err(ExecutionClientError::arbitrum)?;
-
-        let receipt = pending_tx
-            .await
-            .map_err(ExecutionClientError::arbitrum)?
-            .ok_or_else(|| ExecutionClientError::arbitrum("Transaction failed"))?;
-        info!("Approved erc20 allowance at: {:#x}", receipt.transaction_hash);
-        Ok(())
     }
 }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -14,8 +14,7 @@ use funds_manager_api::hot_wallets::{
     TransferToVaultRequest, WithdrawToHotWalletRequest,
 };
 use funds_manager_api::quoters::{
-    DepositAddressResponse, ExecuteSwapRequest, ExecuteSwapResponse, GetExecutionQuoteRequest,
-    GetExecutionQuoteResponse, WithdrawFundsRequest,
+    DepositAddressResponse, ExecuteSwapRequest, ExecuteSwapResponse, WithdrawFundsRequest,
 };
 use itertools::Itertools;
 use serde_json::json;
@@ -145,21 +144,18 @@ pub(crate) async fn get_deposit_address_handler(
 
 /// Handler for getting an execution quote
 pub(crate) async fn get_execution_quote_handler(
-    req: GetExecutionQuoteRequest,
+    _body: Bytes, // no body
+    query_params: HashMap<String, String>,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    // Fetch the quoter hot wallet information
-    let vault = DepositWithdrawSource::Quoter.vault_name();
-    let hot_wallet = server.custody_client.get_hot_wallet_by_vault(vault).await?;
-    let wallet = server.custody_client.get_hot_wallet_private_key(&hot_wallet.address).await?;
+    // Forward the query parameters to the execution client
     let quote = server
         .execution_client
-        .get_quote(req.buy_token_address, req.sell_token_address, req.sell_amount, &wallet)
+        .get_quote(query_params)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
-    let resp = GetExecutionQuoteResponse { quote };
-    Ok(warp::reply::json(&resp))
+    Ok(warp::reply::json(&quote))
 }
 
 /// Handler for executing a swap

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -32,8 +32,8 @@ use funds_manager_api::hot_wallets::{
     TRANSFER_TO_VAULT_ROUTE, WITHDRAW_TO_HOT_WALLET_ROUTE,
 };
 use funds_manager_api::quoters::{
-    ExecuteSwapRequest, GetExecutionQuoteRequest, WithdrawFundsRequest, EXECUTE_SWAP_ROUTE,
-    GET_DEPOSIT_ADDRESS_ROUTE, GET_EXECUTION_QUOTE_ROUTE, WITHDRAW_CUSTODY_ROUTE,
+    ExecuteSwapRequest, WithdrawFundsRequest, EXECUTE_SWAP_ROUTE, GET_DEPOSIT_ADDRESS_ROUTE,
+    GET_EXECUTION_QUOTE_ROUTE, WITHDRAW_CUSTODY_ROUTE,
 };
 use funds_manager_api::PING_ROUTE;
 use handlers::{
@@ -241,13 +241,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(get_deposit_address_handler);
 
-    let get_execution_quote = warp::post()
+    let get_execution_quote = warp::get()
         .and(warp::path("custody"))
         .and(warp::path("quoters"))
         .and(warp::path(GET_EXECUTION_QUOTE_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<GetExecutionQuoteRequest>)
-        .and_then(identity)
+        .and(warp::query::<HashMap<String, String>>())
         .and(with_server(server.clone()))
         .and_then(get_execution_quote_handler);
 


### PR DESCRIPTION
### Purpose
This PR modifies the `/get-execution-quote` endpoint to essentially proxy requests to the LiFi `/quote` endpoint. This is because we don't need to any type validation of query params and/or response bodies as we can just forward requests, responses, errors. 

In a future PR, we will sign the quote for verification in the `/execute-swap` endpoint.

This requires moving the erc20 approval into the `/execute-swap` route.

### Testing
- [x] Tested fetching / executing quotes locally on mainnet env