### PR TITLE
funds-manager-api, server: generate and verify quote signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,10 +3500,10 @@ dependencies = [
 name = "funds-manager-api"
 version = "0.1.0"
 dependencies = [
+ "common",
  "ethers",
  "external-api",
  "hex 0.4.3",
- "hmac",
  "http 0.2.12",
  "itertools 0.13.0",
  "rand 0.8.5",

--- a/funds-manager/funds-manager-api/Cargo.toml
+++ b/funds-manager/funds-manager-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 
 renegade-api = { package = "external-api", workspace = true }
-renegade-common = { package = "common", workspace = true }
+renegade-common = { package = "common", workspace = true, default-features = false, features = ["hmac"] }
 
 ethers = "2"
 hex = "0.4.3"

--- a/funds-manager/funds-manager-api/Cargo.toml
+++ b/funds-manager/funds-manager-api/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 [dependencies]
 
 renegade-api = { package = "external-api", workspace = true }
+renegade-common = { package = "common", workspace = true }
 
 ethers = "2"
 hex = "0.4.3"
-hmac = "0.12.1"
 http = "0.2.12"
 itertools = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/funds-manager/funds-manager-api/src/auth.rs
+++ b/funds-manager/funds-manager-api/src/auth.rs
@@ -56,24 +56,9 @@ fn add_headers_to_hmac(mac: &mut Hmac<Sha256>, headers: &HeaderMap) {
 
 /// Compute an HMAC signature for an execution quote
 pub fn compute_quote_hmac(key: &[u8], quote: &ExecutionQuote) -> String {
-    // Create a canonical string representation of the quote
-    let canonical = format!(
-        "{}{}{}{}{}{}{}{}{}{}",
-        quote.buy_token_address,
-        quote.sell_token_address,
-        quote.sell_amount,
-        quote.buy_amount,
-        quote.from,
-        quote.to,
-        hex::encode(&quote.data),
-        quote.value,
-        quote.gas_price,
-        quote.estimated_gas
-    );
-
     // Compute HMAC
     let mut mac = Hmac::<Sha256>::new_from_slice(key).expect("HMAC error");
-    mac.update(canonical.as_bytes());
+    mac.update(quote.to_canonical_string().as_bytes());
     let result = mac.finalize();
 
     // Convert to hex string

--- a/funds-manager/funds-manager-api/src/types/mod.rs
+++ b/funds-manager/funds-manager-api/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod fees;
 pub mod gas;
 pub mod hot_wallets;
 pub mod quoters;
+pub mod venue;
 
 /// The ping route
 pub const PING_ROUTE: &str = "ping";

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -117,7 +117,7 @@ impl ExecutionQuote {
 pub struct GetExecutionQuoteResponse {
     /// The quote, directly from the execution venue
     pub quote: ExecutionQuote,
-    /// The HMAC signature of the quote
+    /// The HMAC of the quote
     pub signature: String,
 }
 
@@ -127,7 +127,7 @@ pub struct ExecuteSwapRequest {
     /// The quote, implicitly accepted by the caller by its presence in this
     /// request
     pub quote: ExecutionQuote,
-    /// The HMAC signature of the quote
+    /// The HMAC of the quote
     pub signature: String,
 }
 

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -1,5 +1,6 @@
 //! API types for quoter management
 use ethers::types::{Address, Bytes, U256};
+use hex;
 use serde::{Deserialize, Serialize};
 
 use crate::serialization::{
@@ -90,6 +91,25 @@ pub struct ExecutionQuote {
     /// The estimated gas for the swap
     #[serde(with = "u256_string_serialization")]
     pub estimated_gas: U256,
+}
+
+impl ExecutionQuote {
+    /// Convert the quote to a canonical string representation for HMAC signing
+    pub fn to_canonical_string(&self) -> String {
+        format!(
+            "{}{}{}{}{}{}{}{}{}{}",
+            self.buy_token_address,
+            self.sell_token_address,
+            self.sell_amount,
+            self.buy_amount,
+            self.from,
+            self.to,
+            hex::encode(&self.data),
+            self.value,
+            self.gas_price,
+            self.estimated_gas
+        )
+    }
 }
 
 /// The request body for fetching a quote from the execution venue

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -97,6 +97,8 @@ pub struct ExecutionQuote {
 pub struct GetExecutionQuoteResponse {
     /// The quote, directly from the execution venue
     pub quote: ExecutionQuote,
+    /// The HMAC signature of the quote
+    pub signature: String,
 }
 
 /// The request body for executing a swap on the execution venue
@@ -105,6 +107,8 @@ pub struct ExecuteSwapRequest {
     /// The quote, implicitly accepted by the caller by its presence in this
     /// request
     pub quote: ExecutionQuote,
+    /// The HMAC signature of the quote
+    pub signature: String,
 }
 
 /// The response body for executing a swap on the execution venue

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -69,6 +69,9 @@ pub struct ExecutionQuote {
     /// The amount of tokens to sell
     #[serde(with = "u256_string_serialization")]
     pub sell_amount: U256,
+    /// The amount of tokens to buy
+    #[serde(with = "u256_string_serialization")]
+    pub buy_amount: U256,
     /// The submitting address
     #[serde(with = "address_string_serialization")]
     pub from: Address,
@@ -93,7 +96,7 @@ pub struct ExecutionQuote {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetExecutionQuoteResponse {
     /// The quote, directly from the execution venue
-    pub quote: serde_json::Value,
+    pub quote: ExecutionQuote,
 }
 
 /// The request body for executing a swap on the execution venue

--- a/funds-manager/funds-manager-api/src/types/venue.rs
+++ b/funds-manager/funds-manager-api/src/types/venue.rs
@@ -9,39 +9,54 @@ use super::quoters::ExecutionQuote;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LiFiQuoteResponse {
+    /// Transaction details including to address, calldata, value, and gas
+    /// parameters
     pub transaction_request: TransactionRequest,
+    /// Action details including token addresses and sender
     pub action: Action,
+    /// Amount estimates for the swap
     pub estimate: Estimate,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TransactionRequest {
+    /// Destination contract address
     pub to: String,
+    /// Hex-encoded calldata for the transaction
     pub data: String,
+    /// Amount of native token to send (in hex)
     pub value: String,
+    /// Gas price in hex
     pub gas_price: String,
+    /// Gas limit in hex
     pub gas_limit: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Action {
+    /// Token being sold
     pub from_token: Token,
+    /// Token being bought
     pub to_token: Token,
+    /// Address initiating the swap
     pub from_address: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Token {
+    /// Contract address of the token
     pub address: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Estimate {
+    /// Amount of tokens to sell (including decimals)
     pub from_amount: String,
+    /// Amount of tokens to receive (including decimals)
     pub to_amount: String,
 }
 

--- a/funds-manager/funds-manager-api/src/types/venue.rs
+++ b/funds-manager/funds-manager-api/src/types/venue.rs
@@ -1,0 +1,119 @@
+//! Types specific to execution venue (LiFi) integration
+//! as defined in https://apidocs.li.fi/reference/get_v1-quote
+use ethers::types::{Bytes, U256};
+use serde::Deserialize;
+
+use super::quoters::ExecutionQuote;
+
+/// Raw quote response structure from LiFi API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LiFiQuoteResponse {
+    pub transaction_request: TransactionRequest,
+    pub action: Action,
+    pub estimate: Estimate,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TransactionRequest {
+    pub to: String,
+    pub data: String,
+    pub value: String,
+    pub gas_price: String,
+    pub gas_limit: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Action {
+    pub from_token: Token,
+    pub to_token: Token,
+    pub from_address: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Token {
+    pub address: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Estimate {
+    pub from_amount: String,
+    pub to_amount: String,
+}
+
+impl TryFrom<serde_json::Value> for ExecutionQuote {
+    type Error = String;
+
+    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
+        // First deserialize into our LiFi response type
+        let quote: LiFiQuoteResponse = serde_json::from_value(value)
+            .map_err(|e| format!("Failed to parse LiFi quote: {}", e))?;
+
+        // Then convert to our ExecutionQuote
+        let buy_token_address = quote
+            .action
+            .to_token
+            .address
+            .parse()
+            .map_err(|e| format!("Invalid buy token address: {}", e))?;
+
+        let sell_token_address = quote
+            .action
+            .from_token
+            .address
+            .parse()
+            .map_err(|e| format!("Invalid sell token address: {}", e))?;
+
+        let from = quote
+            .action
+            .from_address
+            .parse()
+            .map_err(|e| format!("Invalid from address: {}", e))?;
+
+        let to = quote
+            .transaction_request
+            .to
+            .parse()
+            .map_err(|e| format!("Invalid to address: {}", e))?;
+
+        let sell_amount = U256::from_str_radix(&quote.estimate.from_amount, 10)
+            .map_err(|e| format!("Invalid sell amount: {}", e))?;
+
+        let buy_amount = U256::from_str_radix(&quote.estimate.to_amount, 10)
+            .map_err(|e| format!("Invalid buy amount: {}", e))?;
+
+        // Parse hex strings from transaction request
+        let value =
+            U256::from_str_radix(quote.transaction_request.value.trim_start_matches("0x"), 16)
+                .map_err(|e| format!("Invalid value: {}", e))?;
+
+        let gas_price =
+            U256::from_str_radix(quote.transaction_request.gas_price.trim_start_matches("0x"), 16)
+                .map_err(|e| format!("Invalid gas price: {}", e))?;
+
+        let estimated_gas =
+            U256::from_str_radix(quote.transaction_request.gas_limit.trim_start_matches("0x"), 16)
+                .map_err(|e| format!("Invalid estimated gas: {}", e))?;
+
+        let data = hex::decode(quote.transaction_request.data.trim_start_matches("0x"))
+            .map_err(|e| format!("Invalid calldata hex: {}", e))
+            .map(Bytes::from)?;
+
+        Ok(ExecutionQuote {
+            buy_token_address,
+            sell_token_address,
+            sell_amount,
+            buy_amount,
+            from,
+            to,
+            data,
+            value,
+            gas_price,
+            estimated_gas,
+        })
+    }
+}

--- a/funds-manager/funds-manager-api/src/types/venue.rs
+++ b/funds-manager/funds-manager-api/src/types/venue.rs
@@ -49,11 +49,9 @@ impl TryFrom<serde_json::Value> for ExecutionQuote {
     type Error = String;
 
     fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        // First deserialize into our LiFi response type
         let quote: LiFiQuoteResponse = serde_json::from_value(value)
             .map_err(|e| format!("Failed to parse LiFi quote: {}", e))?;
 
-        // Then convert to our ExecutionQuote
         let buy_token_address = quote
             .action
             .to_token

--- a/funds-manager/funds-manager-server/src/execution_client/quotes.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/quotes.rs
@@ -2,7 +2,8 @@
 
 use std::collections::HashMap;
 
-use serde_json;
+use funds_manager_api::quoters::ExecutionQuote;
+use funds_manager_api::venue::LiFiQuote;
 
 use super::{error::ExecutionClientError, ExecutionClient};
 
@@ -14,10 +15,11 @@ impl ExecutionClient {
     pub async fn get_quote(
         &self,
         query_params: HashMap<String, String>,
-    ) -> Result<serde_json::Value, ExecutionClientError> {
+    ) -> Result<ExecutionQuote, ExecutionClientError> {
         let params: Vec<(&str, &str)> =
             query_params.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
-        self.send_get_request(QUOTE_ENDPOINT, &params).await
+        let resp: LiFiQuote = self.send_get_request(QUOTE_ENDPOINT, &params).await?;
+        Ok(resp.into())
     }
 }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -14,8 +14,8 @@ use funds_manager_api::hot_wallets::{
     TransferToVaultRequest, WithdrawToHotWalletRequest,
 };
 use funds_manager_api::quoters::{
-    DepositAddressResponse, ExecuteSwapRequest, ExecuteSwapResponse, ExecutionQuote,
-    GetExecutionQuoteResponse, WithdrawFundsRequest, WithdrawToHyperliquidRequest,
+    DepositAddressResponse, ExecuteSwapRequest, ExecuteSwapResponse, GetExecutionQuoteResponse,
+    WithdrawFundsRequest, WithdrawToHyperliquidRequest,
 };
 use itertools::Itertools;
 use serde_json::json;
@@ -152,14 +152,11 @@ pub(crate) async fn get_execution_quote_handler(
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
     // Forward the query parameters to the execution client
-    let raw_quote = server
+    let quote = server
         .execution_client
         .get_quote(query_params)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
-
-    let quote = ExecutionQuote::try_from(raw_quote)
-        .map_err(|e| warp::reject::custom(ApiError::InternalError(e)))?;
 
     let hmac_key = server.quote_hmac_key;
     let sig = hmac_key.compute_mac(quote.to_canonical_string().as_bytes());

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -47,6 +47,7 @@ use handlers::{
     withdraw_to_hyperliquid_handler,
 };
 use middleware::{identity, with_hmac_auth, with_json_body};
+use renegade_common::types::hmac::HmacKey;
 use renegade_util::telemetry::configure_telemetry;
 use server::Server;
 use warp::Filter;
@@ -76,7 +77,7 @@ struct Cli {
     hmac_key: Option<String>,
     /// The HMAC key to use for signing quotes
     #[clap(long, env = "QUOTE_HMAC_KEY")]
-    quote_hmac_key: Option<String>,
+    quote_hmac_key: String,
     /// Whether to disable authentication
     #[clap(long, conflicts_with = "hmac_key")]
     disable_auth: bool,
@@ -153,30 +154,14 @@ impl Cli {
         }
     }
 
-    /// Get the HMAC key as a 32-byte array
-    fn get_hmac_key(&self) -> Option<[u8; 32]> {
-        self.hmac_key.as_ref().map(|key| {
-            let decoded = hex::decode(key).expect("Invalid HMAC key");
-            if decoded.len() != 32 {
-                panic!("HMAC key must be 32 bytes long");
-            }
-            let mut array = [0u8; 32];
-            array.copy_from_slice(&decoded);
-            array
-        })
+    /// Get the HMAC key
+    fn get_hmac_key(&self) -> Option<HmacKey> {
+        self.hmac_key.as_ref().map(|key| HmacKey::from_hex_string(key).expect("Invalid HMAC key"))
     }
 
-    /// Get the quote HMAC key as a 32-byte array
-    fn get_quote_hmac_key(&self) -> Option<[u8; 32]> {
-        self.quote_hmac_key.as_ref().map(|key| {
-            let decoded = hex::decode(key).expect("Invalid quote HMAC key");
-            if decoded.len() != 32 {
-                panic!("Quote HMAC key must be 32 bytes long");
-            }
-            let mut array = [0u8; 32];
-            array.copy_from_slice(&decoded);
-            array
-        })
+    /// Get the quote HMAC key
+    fn get_quote_hmac_key(&self) -> HmacKey {
+        HmacKey::from_hex_string(&self.quote_hmac_key).expect("Invalid quote HMAC key")
     }
 }
 

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -74,6 +74,9 @@ struct Cli {
     /// The HMAC key to use for authentication
     #[clap(long, conflicts_with = "disable_auth", env = "HMAC_KEY")]
     hmac_key: Option<String>,
+    /// The HMAC key to use for signing quotes
+    #[clap(long, env = "QUOTE_HMAC_KEY")]
+    quote_hmac_key: Option<String>,
     /// Whether to disable authentication
     #[clap(long, conflicts_with = "hmac_key")]
     disable_auth: bool,
@@ -156,6 +159,19 @@ impl Cli {
             let decoded = hex::decode(key).expect("Invalid HMAC key");
             if decoded.len() != 32 {
                 panic!("HMAC key must be 32 bytes long");
+            }
+            let mut array = [0u8; 32];
+            array.copy_from_slice(&decoded);
+            array
+        })
+    }
+
+    /// Get the quote HMAC key as a 32-byte array
+    fn get_quote_hmac_key(&self) -> Option<[u8; 32]> {
+        self.quote_hmac_key.as_ref().map(|key| {
+            let decoded = hex::decode(key).expect("Invalid quote HMAC key");
+            if decoded.len() != 32 {
+                panic!("Quote HMAC key must be 32 bytes long");
             }
             let mut array = [0u8; 32];
             array.copy_from_slice(&decoded);

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -5,6 +5,7 @@ use std::{error::Error, str::FromStr, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region, SdkConfig};
 use ethers::{signers::LocalWallet, types::Address};
+use funds_manager_api::quoters::ExecutionQuote;
 use renegade_arbitrum_client::{
     client::{ArbitrumClient, ArbitrumClientConfig},
     constants::Chain,
@@ -154,5 +155,14 @@ impl Server {
             self.relayer_client.clone(),
             self.custody_client.clone(),
         ))
+    }
+
+    /// Sign a quote using the quote HMAC key and returns the signature as a
+    /// hex string
+    pub fn sign_quote(&self, quote: &ExecutionQuote) -> Result<String, FundsManagerError> {
+        let canonical_string = quote.to_canonical_string();
+        let sig = self.quote_hmac_key.compute_mac(canonical_string.as_bytes());
+        let signature = hex::encode(sig);
+        Ok(signature)
     }
 }

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -10,6 +10,7 @@ use renegade_arbitrum_client::{
     constants::Chain,
 };
 use renegade_circuit_types::elgamal::DecryptionKey;
+use renegade_common::types::hmac::HmacKey;
 use renegade_config::setup_token_remaps;
 use renegade_util::raw_err_str;
 
@@ -60,9 +61,9 @@ pub(crate) struct Server {
     /// The AWS config
     pub aws_config: SdkConfig,
     /// The HMAC key for custody endpoint authentication
-    pub hmac_key: Option<[u8; 32]>,
+    pub hmac_key: Option<HmacKey>,
     /// The HMAC key for signing quotes
-    pub quote_hmac_key: Option<[u8; 32]>,
+    pub quote_hmac_key: HmacKey,
 }
 
 impl Server {

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -61,6 +61,8 @@ pub(crate) struct Server {
     pub aws_config: SdkConfig,
     /// The HMAC key for custody endpoint authentication
     pub hmac_key: Option<[u8; 32]>,
+    /// The HMAC key for signing quotes
+    pub quote_hmac_key: Option<[u8; 32]>,
 }
 
 impl Server {
@@ -98,6 +100,7 @@ impl Server {
         }
 
         let hmac_key = args.get_hmac_key();
+        let quote_hmac_key = args.get_quote_hmac_key();
         let relayer_client = RelayerClient::new(&args.relayer_url, &args.usdc_mint);
 
         // Create a database connection pool using bb8
@@ -134,6 +137,7 @@ impl Server {
             execution_client,
             aws_config: config,
             hmac_key,
+            quote_hmac_key,
         })
     }
 


### PR DESCRIPTION
### Purpose
This PR ensures only quotes that originated from the funds manager are executed. I do so by signing the quote and including this when returning quotes to clients. This signature is then verified when clients attempt to execute a quote.

We use a separate HMAC key for signing quotes than authenticating API requests. It will also be stored in ASM.

### Testing
- [x] Tested locally against mainnet env