### PR TITLE
funds-manager: custody_client: implement withdrawal to hyperliquid

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -29,6 +29,8 @@ pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
 pub const GET_EXECUTION_QUOTE_ROUTE: &str = "get-execution-quote";
 /// The route to execute a swap on the quoter hot wallet
 pub const EXECUTE_SWAP_ROUTE: &str = "execute-swap";
+/// The route to withdraw USDC to Hyperliquid from the quoter hot wallet
+pub const WITHDRAW_TO_HYPERLIQUID_ROUTE: &str = "withdraw-to-hyperliquid";
 
 // -------------
 // | Api Types |
@@ -107,4 +109,12 @@ pub struct ExecuteSwapRequest {
 pub struct ExecuteSwapResponse {
     /// The tx hash of the swap
     pub tx_hash: String,
+}
+
+/// The request body for withdrawing USDC to Hyperliquid from the quoter hot
+/// wallet
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WithdrawToHyperliquidRequest {
+    /// The amount of USDC to withdraw, in decimal format (i.e., whole units)
+    pub amount: f64,
 }

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -166,8 +166,7 @@ impl CustodyClient {
         amount: f64,
     ) -> Result<TransactionReceipt, FundsManagerError> {
         // Get the quoter hot wallet's private key
-        let source = DepositWithdrawSource::Quoter.vault_name();
-        let quoter_wallet = self.get_hot_wallet_by_vault(source).await?;
+        let quoter_wallet = self.get_quoter_hot_wallet().await?;
         let signer = self.get_hot_wallet_private_key(&quoter_wallet.address).await?;
 
         let bal = self.get_erc20_balance(mint, &quoter_wallet.address).await?;

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -121,9 +121,9 @@ impl CustodyClient {
         self.withdraw_from_fireblocks(source, mint, amount).await
     }
 
-    // ------------
-    // | Handlers |
-    // ------------
+    // -----------
+    // | Helpers |
+    // -----------
 
     /// The secret name for a hot wallet
     pub(crate) fn hot_wallet_secret_name(address: &str) -> String {

--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -12,6 +12,8 @@ use crate::db::schema::hot_wallets;
 use crate::error::FundsManagerError;
 use crate::CustodyClient;
 
+use super::DepositWithdrawSource;
+
 impl CustodyClient {
     // ---------------
     // | Gas Wallets |
@@ -157,6 +159,12 @@ impl CustodyClient {
             .first::<HotWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))
+    }
+
+    /// Convenience method for getting the quoter hot wallet
+    pub async fn get_quoter_hot_wallet(&self) -> Result<HotWallet, FundsManagerError> {
+        let vault = DepositWithdrawSource::Quoter.vault_name();
+        self.get_hot_wallet_by_vault(vault).await
     }
 
     // --- Setters --- //

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -3,13 +3,34 @@ use std::str::FromStr;
 
 use crate::{error::FundsManagerError, helpers::get_secret};
 use bigdecimal::{BigDecimal, FromPrimitive};
-use ethers::signers::LocalWallet;
+use ethers::signers::{LocalWallet, Signer};
 use fireblocks_sdk::types::{PeerType, TransactionStatus};
+use renegade_arbitrum_client::constants::Chain;
+use renegade_common::types::token::{Token, USDC_TICKER};
 use tracing::info;
 
 use super::{CustodyClient, DepositWithdrawSource};
 
+// -------------
+// | Constants |
+// -------------
+
+/// The suffix for the secret name for the Hyperliquid private key
+const HYPERLIQUID_PKEY_SECRET_SUFFIX: &str = "hyperliquid-private-key";
+/// The address of the Hyperliquid bridge on Arbitrum mainnet.
+const MAINNET_HYPERLIQUID_BRIDGE_ADDRESS: &str = "0x2df1c51e09aecf9cacb7bc98cb1742757f163df7";
+/// The address of the Hyperliquid bridge on Arbitrum testnet.
+const TESTNET_HYPERLIQUID_BRIDGE_ADDRESS: &str = "0x08cfc1B6b2dCF36A1480b99353A354AA8AC56f89";
+
+// ---------------
+// | Client impl |
+// ---------------
+
 impl CustodyClient {
+    // ------------
+    // | Handlers |
+    // ------------
+
     /// Withdraw from hot wallet custody with a provided token address
     pub(crate) async fn withdraw_from_hot_wallet(
         &self,
@@ -121,6 +142,94 @@ impl CustodyClient {
         // Execute the transfer
         let tx = self.transfer_ether(to, amount, wallet).await?;
         info!("Withdrew {amount} ETH from gas wallet to {to}. Tx: {:#}", tx.transaction_hash);
+
+        Ok(())
+    }
+
+    /// Withdraw USDC to Hyperliquid from the quoter hot wallet
+    pub(crate) async fn withdraw_to_hyperliquid(
+        &self,
+        amount: f64,
+    ) -> Result<(), FundsManagerError> {
+        let hot_wallet = self.get_quoter_hot_wallet().await?;
+        let usdc_mint = Token::from_ticker(USDC_TICKER).get_addr();
+        let bal = self.get_erc20_balance(&usdc_mint, &hot_wallet.address).await?;
+        if bal < amount {
+            return Err(FundsManagerError::Custom("Insufficient balance".to_string()));
+        }
+
+        let secret_name = format!("{}-{}", self.chain, HYPERLIQUID_PKEY_SECRET_SUFFIX);
+        let hyperliquid_pkey = get_secret(&secret_name, &self.aws_config).await?;
+
+        let hyperliquid_account = LocalWallet::from_str(&hyperliquid_pkey)
+            .map_err(FundsManagerError::parse)
+            .map(|w| w.with_chain_id(self.chain_id))?;
+
+        let hyperliquid_address = format!("{:#x}", hyperliquid_account.address());
+
+        // Transfer the USDC to the Hyperliquid account
+        self.transfer_to_hyperliquid_account(
+            amount,
+            &hot_wallet.address,
+            &hyperliquid_address,
+            &usdc_mint,
+        )
+        .await?;
+
+        // Transfer the USDC from the Hyperliquid account to the bridge.
+        // This is necessary so that the USDC is credited to the same account on the
+        // Hyperliquid L1.
+        // TODO: If we want to avoid funding the Hyperliquid keypair with ETH for this
+        // transfer, we can have the funds manager submit a
+        // `batchedDepositWithPermit` on its behalf:
+        // https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/bridge2#deposit-with-permit
+        self.bridge_to_hyperliquid(amount, hyperliquid_account, &usdc_mint).await
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Transfer USDC from the quoter hot wallet to the Hyperliquid account's
+    /// keypair
+    async fn transfer_to_hyperliquid_account(
+        &self,
+        amount: f64,
+        quoter_hot_wallet_addr: &str,
+        hyperliquid_addr: &str,
+        usdc_mint: &str,
+    ) -> Result<(), FundsManagerError> {
+        // Fetch the quoter hot wallet private key
+        let hot_wallet = self.get_hot_wallet_private_key(quoter_hot_wallet_addr).await?;
+
+        // Transfer the USDC to the address used by the Hyperliquid account.
+        let tx = self.erc20_transfer(usdc_mint, hyperliquid_addr, amount, hot_wallet).await?;
+
+        info!(
+            "Withdrew {amount} USDC from hot wallet to {hyperliquid_addr}. Tx: {:#x}",
+            tx.transaction_hash
+        );
+
+        Ok(())
+    }
+
+    /// Bridge USDC to Hyperliquid using the given account
+    async fn bridge_to_hyperliquid(
+        &self,
+        amount: f64,
+        hyperliquid_account: LocalWallet,
+        usdc_mint: &str,
+    ) -> Result<(), FundsManagerError> {
+        let bridge_address = match self.chain {
+            Chain::Mainnet => MAINNET_HYPERLIQUID_BRIDGE_ADDRESS,
+            Chain::Testnet => TESTNET_HYPERLIQUID_BRIDGE_ADDRESS,
+            _ => return Err(FundsManagerError::Custom("Unsupported chain".to_string())),
+        };
+
+        let tx =
+            self.erc20_transfer(usdc_mint, bridge_address, amount, hyperliquid_account).await?;
+
+        info!("Sent {amount} USDC to Hyperliquid bridge. Tx: {:#x}", tx.transaction_hash);
 
         Ok(())
     }


### PR DESCRIPTION
This PR adds a `/custody/quoters/withdraw-to-hyperliquid` endpoint, used to bridge funds into Hyperliquid. We do this from the quoter hot wallet to simplify custody management.

This requires first transferring USDC from the quoter hot wallet to the _same keypair we use for Hyperliquid, on Arbitrum_, before then transferring from that keypair to the bridge contract. This is necessary as the funds will be credited to the same address (on Hyperliquid) that sent them to the Arbitrum bridge.

### Testing
This was tested against testnet, where I confirmed that funds were received in Hyperliquid.
Note, that when testing this functionality, we need to use Hyperliquid's [dummy USDC token](https://sepolia.arbiscan.io/address/0x1baabb04529d43a73232b713c0fe471f7c7334d5).