### PR TITLE
auth-server: handle_external_match, telemetry: record unsuccessful relayer req metric

### DIFF
--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -22,7 +22,7 @@ use warp::{reject::Rejection, reply::Reply};
 use super::helpers::overwrite_response_body;
 use super::Server;
 use crate::error::AuthServerError;
-use crate::telemetry::helpers::calculate_implied_price;
+use crate::telemetry::helpers::{calculate_implied_price, record_relayer_request_500};
 use crate::telemetry::labels::GAS_SPONSORED_METRIC_TAG;
 use crate::telemetry::{
     helpers::{
@@ -62,6 +62,9 @@ impl Server {
             self.send_admin_request(Method::POST, path_str, headers, body.clone()).await?;
 
         let status = resp.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_desc.clone(), path_str.to_string());
+        }
         if status != StatusCode::OK {
             log_unsuccessful_relayer_request(&resp, &key_desc, path_str, &body);
             return Ok(resp);
@@ -117,6 +120,9 @@ impl Server {
             .await?;
 
         let status = resp.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_desc.clone(), path_str.to_string());
+        }
         if status != StatusCode::OK {
             log_unsuccessful_relayer_request(&resp, &key_desc, path_str, &req_body);
             return Ok(resp);
@@ -181,6 +187,9 @@ impl Server {
             self.send_admin_request(Method::POST, path_str, headers, body.clone()).await?;
 
         let status = resp.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_description.clone(), path_str.to_string());
+        }
         if status != StatusCode::OK {
             log_unsuccessful_relayer_request(&resp, &key_description, path_str, &body);
             return Ok(resp);

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -34,11 +34,15 @@ use crate::{
         QUOTE_OUTPUT_NET_OF_GAS_DIFF_BPS_METRIC, QUOTE_PRICE_DIFF_BPS_METRIC,
         SETTLEMENT_STATUS_TAG, SOURCE_NAME_TAG, SOURCE_NET_OUTPUT_TAG,
         SOURCE_OUTPUT_NET_OF_FEE_TAG, SOURCE_OUTPUT_NET_OF_GAS_TAG, SOURCE_PRICE_TAG,
+        UNSUCCESSFUL_RELAYER_REQUEST_COUNT,
     },
 };
 
 use super::{
-    labels::{GAS_SPONSORSHIP_VALUE, REQUEST_ID_METRIC_TAG, SIDE_TAG},
+    labels::{
+        GAS_SPONSORSHIP_VALUE, KEY_DESCRIPTION_METRIC_TAG, REQUEST_ID_METRIC_TAG,
+        REQUEST_PATH_METRIC_TAG, SIDE_TAG,
+    },
     quote_comparison::QuoteComparison,
 };
 
@@ -286,6 +290,16 @@ pub(crate) async fn record_external_match_metrics(
 pub(crate) fn record_gas_sponsorship_metrics(gas_sponsorship_value: f64, request_id: String) {
     let labels = vec![(REQUEST_ID_METRIC_TAG.to_string(), request_id)];
     metrics::gauge!(GAS_SPONSORSHIP_VALUE, &labels).set(gas_sponsorship_value);
+}
+
+/// Record a counter metric for relayer requests that return a 500 status code
+pub(crate) fn record_relayer_request_500(key_description: String, path: String) {
+    let labels = vec![
+        (KEY_DESCRIPTION_METRIC_TAG.to_string(), key_description),
+        (REQUEST_PATH_METRIC_TAG.to_string(), path),
+    ];
+
+    metrics::counter!(UNSUCCESSFUL_RELAYER_REQUEST_COUNT, &labels).increment(1);
 }
 
 // --- Settlement Processing --- //

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -45,6 +45,9 @@ pub const QUOTE_NET_OUTPUT_DIFF_BPS_METRIC: &str = "quote.net_output_diff_bps";
 /// Metric describing the value of gas sponsorship for a given request
 pub const GAS_SPONSORSHIP_VALUE: &str = "gas_sponsorship_value";
 
+/// Metric describing the number of unsuccessful relayer requests
+pub const UNSUCCESSFUL_RELAYER_REQUEST_COUNT: &str = "num_unsuccessful_relayer_requests";
+
 // ---------------
 // | METRIC TAGS |
 // ---------------
@@ -62,6 +65,8 @@ pub const REQUEST_ID_METRIC_TAG: &str = "request_id";
 pub const BASE_ASSET_METRIC_TAG: &str = "base_asset";
 /// Metric tag to indicate data was recorded post decimal correction fix
 pub const DECIMAL_CORRECTION_FIXED_METRIC_TAG: &str = "post_decimal_fix";
+/// Metric tag for the path of the request
+pub const REQUEST_PATH_METRIC_TAG: &str = "request_path";
 
 /// Metric tag for identifying the source of a quote (our server or competitor)
 pub const SOURCE_NAME_TAG: &str = "source_name";


### PR DESCRIPTION
This PR adds a `num_unsuccessful_relayer_requests` metric, a counter which is incremented each time a non-200 status code is returned by the relayer for quote, assembly, or direct match requests. The metric is tagged with the requesting entity, the status code, and the path which was invoked.