### PR TITLE
auth-server: redis_queries: r/w gas sponsorship info to/from redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tracing",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
  "warp",
 ]
 
@@ -1370,7 +1370,7 @@ dependencies = [
  "alloy-primitives 0.8.25",
  "external-api",
  "serde",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -1455,7 +1455,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -2645,7 +2645,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -3096,7 +3096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 2.0.98",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3212,7 +3212,7 @@ dependencies = [
  "num-traits",
  "pq-sys",
  "r2d2",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -3939,7 +3939,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -4162,7 +4162,7 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
  "warp",
 ]
 
@@ -4180,7 +4180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -4426,7 +4426,7 @@ dependencies = [
  "sha2 0.10.8",
  "tracing",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -5262,7 +5262,7 @@ dependencies = [
  "serde",
  "tokio",
  "util",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -7323,12 +7323,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
+ "serde",
+ "serde_json",
  "sha1_smol",
  "socket2 0.5.8",
  "tokio",
  "tokio-native-tls",
  "tokio-util 0.7.13",
  "url",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -7444,7 +7447,7 @@ dependencies = [
  "renegade-dealer-api",
  "serde_json",
  "tokio",
- "uuid 1.12.1",
+ "uuid 1.16.0",
  "warp",
 ]
 
@@ -7458,7 +7461,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -7666,7 +7669,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -8174,9 +8177,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -8192,9 +8195,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8203,9 +8206,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -9079,7 +9082,7 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
- "uuid 1.12.1",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -9777,11 +9780,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.3.1",
  "serde",
 ]
 

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -16,12 +16,12 @@ tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 
 # === Database === #
 bb8 = "0.8"
-diesel = { version = "2", features = ["postgres", "chrono", "uuid"] }
+diesel = { version = "2", features = ["postgres", "chrono", "uuid"], dependencies = { uuid = "1.15.1"} }
 diesel-async = { version = "0.4", features = ["postgres", "bb8"] }
 tokio-postgres = "0.7"
 postgres-native-tls = "0.5"
 native-tls = "0.2"
-redis = { version = "0.29", features = ["tokio-native-tls-comp", "connection-manager"] }
+redis = { version = "0.29", features = ["tokio-native-tls-comp", "connection-manager", "json", "uuid"] }
 
 # === Cryptography === #
 aes-gcm = "0.10.1"
@@ -52,9 +52,9 @@ chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
 metrics = "=0.22.3"
 atomic_float = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.64"
+serde = { version = "1.0.218", features = ["derive"] }
+serde_json = "1.0.139"
 serde_urlencoded = "0.7"
 thiserror = "1.0"
 tracing = "0.1"
-uuid = { version = "1.0", features = ["serde", "v4"] }
+uuid = { version = "1.15.1", features = ["serde", "v4"] }

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod helpers;
 pub mod price_reporter_client;
 mod queries;
 mod rate_limiter;
+mod redis_queries;
 
 use crate::server::price_reporter_client::PriceReporterClient;
 use crate::{

--- a/auth/auth-server/src/server/redis_queries.rs
+++ b/auth/auth-server/src/server/redis_queries.rs
@@ -1,0 +1,57 @@
+//! Helpers for interacting with Redis
+
+use auth_server_api::GasSponsorshipInfo;
+use redis::JsonAsyncCommands;
+use uuid::Uuid;
+
+use crate::error::AuthServerError;
+
+use super::Server;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The root path for a JSON object in Redis
+const JSON_ROOT_PATH: &str = "$";
+
+impl Server {
+    // -----------
+    // | Setters |
+    // -----------
+
+    /// Write the given gas sponsorship info to Redis
+    pub async fn write_gas_sponsorship_info(
+        &self,
+        key: Uuid,
+        info: &GasSponsorshipInfo,
+    ) -> Result<(), AuthServerError> {
+        let mut client = self.redis_client.clone();
+        client.json_set(key, JSON_ROOT_PATH, info).await.map_err(AuthServerError::redis)
+    }
+
+    // -----------
+    // | Getters |
+    // -----------
+
+    /// Read the gas sponsorship info for the given key from Redis,
+    /// returning `None` if no info is found
+    pub async fn read_gas_sponsorship_info(
+        &self,
+        key: Uuid,
+    ) -> Result<Option<GasSponsorshipInfo>, AuthServerError> {
+        let mut client = self.redis_client.clone();
+        let info_str: Option<String> =
+            client.json_get(key, JSON_ROOT_PATH).await.map_err(AuthServerError::redis)?;
+
+        if info_str.is_none() {
+            return Ok(None);
+        }
+
+        // We have to deserialize to `Vec<GasSponsorshipInfo>` as per https://docs.rs/redis/latest/redis/trait.JsonAsyncCommands.html#method.json_get?
+        let mut info: Vec<GasSponsorshipInfo> =
+            serde_json::from_str(&info_str.unwrap()).map_err(AuthServerError::serde)?;
+
+        Ok(Some(info.swap_remove(0)))
+    }
+}


### PR DESCRIPTION
This PR implements the reading/writing of `GasSponsorshipInfo` structs to/from Redis, along with the associated helper for deriving a UUID from a signed quote by hashing its signature. I've confirmed that AWS ElastiCache, which we'll use to host a managed Redis cluster, supports the Redis JSON commands.

### Testing
I tested this w/ a local Redis stack & auth server, confirming that we can read/write a `GasSponsorshipInfo` struct to/from Redis as expected.