### PR TITLE
auth-server: handle_external_match: use cached gas sponsorship info

### DIFF
--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -7,9 +7,7 @@
 #![feature(trivial_bounds)]
 
 use alloy_primitives::{ruint::FromUintError, Address, U256};
-use renegade_api::http::external_match::{
-    AssembleExternalMatchRequest, AtomicMatchApiBundle, ExternalOrder, SignedExternalQuote,
-};
+use renegade_api::http::external_match::{AtomicMatchApiBundle, SignedExternalQuote};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -65,6 +63,7 @@ pub struct SignedGasSponsorshipInfo {
     /// The signed gas sponsorship info
     pub gas_sponsorship_info: GasSponsorshipInfo,
     /// The auth server's signature over the gas sponsorship info
+    #[deprecated(since = "0.1.1", note = "Gas sponsorship info signatures are no longer used")]
     pub signature: String,
 }
 
@@ -115,42 +114,6 @@ impl GasSponsorshipInfo {
             .as_ref()
             .map(|s| s.parse().unwrap_or(Address::ZERO))
             .unwrap_or(Address::ZERO)
-    }
-}
-
-/// A request to assemble a potentially sponsored quote into a settlement bundle
-///
-/// We manually flatten the fields of [`AssembleExternalMatchRequest`]
-/// into this struct, as `serde` does not support `u128`s when using
-/// `#[serde(flatten)]`:
-/// https://github.com/serde-rs/json/issues/625
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AssembleSponsoredMatchRequest {
-    /// Whether or not to include gas estimation in the response
-    #[serde(default)]
-    pub do_gas_estimation: bool,
-    /// The receiver address of the match, if not the message sender
-    #[serde(default)]
-    pub receiver_address: Option<String>,
-    /// The updated order if any changes have been made
-    #[serde(default)]
-    pub updated_order: Option<ExternalOrder>,
-    /// The signed quote
-    pub signed_quote: SignedExternalQuote,
-    /// The signed gas sponsorship info associated with the quote,
-    /// if sponsorship was requested
-    pub gas_sponsorship_info: Option<SignedGasSponsorshipInfo>,
-}
-
-impl AssembleSponsoredMatchRequest {
-    /// Extract an [`AssembleExternalMatchRequest`]
-    pub fn assemble_external_match_request(&self) -> AssembleExternalMatchRequest {
-        AssembleExternalMatchRequest {
-            do_gas_estimation: self.do_gas_estimation,
-            receiver_address: self.receiver_address.clone(),
-            updated_order: self.updated_order.clone(),
-            signed_quote: self.signed_quote.clone(),
-        }
     }
 }
 

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
@@ -105,7 +105,7 @@ impl Server {
         &self,
         quote: &mut ApiExternalQuote,
         refund_amount: u128,
-    ) -> Result<(), AuthServerError> {
+    ) {
         let (base_amount, quote_amount) = match quote.match_result.direction {
             OrderSide::Buy => {
                 (quote.match_result.base_amount - refund_amount, quote.match_result.quote_amount)
@@ -123,8 +123,6 @@ impl Server {
         quote.receive.amount -= refund_amount;
         quote.match_result.base_amount = base_amount;
         quote.match_result.quote_amount = quote_amount;
-
-        Ok(())
     }
 }
 

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -4,22 +4,21 @@
 //! it to the relayer with admin authentication
 
 use auth_server_api::{
-    AssembleSponsoredMatchRequest, GasSponsorshipInfo, GasSponsorshipQueryParams,
-    SponsoredMatchResponse, SponsoredQuoteResponse,
+    GasSponsorshipInfo, GasSponsorshipQueryParams, SponsoredMatchResponse, SponsoredQuoteResponse,
 };
 use bytes::Bytes;
 use http::{Method, Response, StatusCode};
 use renegade_api::http::external_match::{
-    ExternalMatchRequest, ExternalMatchResponse, ExternalOrder, ExternalQuoteRequest,
-    ExternalQuoteResponse,
+    AssembleExternalMatchRequest, ExternalMatchRequest, ExternalMatchResponse, ExternalOrder,
+    ExternalQuoteRequest, ExternalQuoteResponse,
 };
 use renegade_circuit_types::fixed_point::FixedPoint;
 use renegade_common::types::{token::Token, TimestampedPrice};
 use renegade_constants::EXTERNAL_MATCH_RELAYER_FEE;
-use tracing::{info, instrument, warn};
+use tracing::{error, info, instrument, warn};
 use warp::{reject::Rejection, reply::Reply};
 
-use super::helpers::overwrite_response_body;
+use super::helpers::{generate_quote_uuid, overwrite_response_body};
 use super::Server;
 use crate::error::AuthServerError;
 use crate::telemetry::helpers::{calculate_implied_price, record_relayer_request_500};
@@ -78,6 +77,11 @@ impl Server {
             .maybe_apply_gas_sponsorship_to_quote(key_desc.clone(), resp.body(), &query_params)
             .await?;
 
+        // Cache the gas sponsorship info for the quote in Redis if it exists
+        if let Err(e) = self.cache_quote_gas_sponsorship_info(&sponsored_quote_response).await {
+            error!("Error caching quote gas sponsorship info: {e}");
+        }
+
         overwrite_response_body(&mut resp, sponsored_quote_response.clone())?;
 
         let server_clone = self.clone();
@@ -108,11 +112,10 @@ impl Server {
 
         // Update the request to remove the effects of gas sponsorship, if
         // necessary
-        let assemble_sponsored_match_req = self.maybe_update_assembly_request(&body)?;
+        let (assemble_match_req, gas_sponsorship_info) =
+            self.maybe_update_assembly_request(&body).await?;
 
-        let req_body =
-            serde_json::to_vec(&assemble_sponsored_match_req.assemble_external_match_request())
-                .map_err(AuthServerError::serde)?;
+        let req_body = serde_json::to_vec(&assemble_match_req).map_err(AuthServerError::serde)?;
 
         // Send the request to the relayer
         let mut resp = self
@@ -132,11 +135,6 @@ impl Server {
         let query_params = serde_urlencoded::from_str::<GasSponsorshipQueryParams>(&query_str)
             .map_err(AuthServerError::serde)?;
 
-        let gas_sponsorship_info = assemble_sponsored_match_req
-            .gas_sponsorship_info
-            .as_ref()
-            .map(|s| &s.gas_sponsorship_info);
-
         // Apply gas sponsorship to the resulting bundle, if necessary
         let sponsored_match_resp = self
             .maybe_apply_gas_sponsorship_to_assembled_quote(
@@ -154,7 +152,7 @@ impl Server {
             if let Err(e) = server_clone
                 .handle_quote_assembly_bundle_response(
                     key_desc,
-                    assemble_sponsored_match_req,
+                    assemble_match_req,
                     sponsored_match_resp,
                 )
                 .await
@@ -273,31 +271,36 @@ impl Server {
         Ok(sponsored_quote_response)
     }
 
-    /// Update the given sponsored assembly request to remove the effects of gas
-    /// sponsorship from the quote, if necessary
-    fn maybe_update_assembly_request(
+    /// Check if the given assembly request pertains to a sponsored quote,
+    /// and if so, remove the effects of gas sponsorship from the quote.
+    ///
+    /// Returns the assembly request, and the gas sponsorship info, if any.
+    async fn maybe_update_assembly_request(
         &self,
         req_body: &[u8],
-    ) -> Result<AssembleSponsoredMatchRequest, AuthServerError> {
-        let mut assemble_sponsored_match_req: AssembleSponsoredMatchRequest =
+    ) -> Result<(AssembleExternalMatchRequest, Option<GasSponsorshipInfo>), AuthServerError> {
+        let mut assemble_match_req: AssembleExternalMatchRequest =
             serde_json::from_slice(req_body).map_err(AuthServerError::serde)?;
 
-        let signed_gas_sponsorship_info = match assemble_sponsored_match_req.gas_sponsorship_info {
-            None => return Ok(assemble_sponsored_match_req),
-            Some(ref signed_gas_sponsorship_info) => signed_gas_sponsorship_info,
+        let redis_key = generate_quote_uuid(&assemble_match_req.signed_quote);
+        let gas_sponsorship_info = match self.read_gas_sponsorship_info_from_redis(redis_key).await
+        {
+            Err(e) => {
+                error!("Error reading gas sponsorship info from Redis: {e}");
+                None
+            },
+            Ok(gas_sponsorship_info) => gas_sponsorship_info,
         };
 
-        // Validate sponsorship info signature
-        self.validate_gas_sponsorship_info_signature(signed_gas_sponsorship_info)?;
-
-        let gas_sponsorship_info = &signed_gas_sponsorship_info.gas_sponsorship_info;
-        if gas_sponsorship_info.requires_match_result_update() {
+        if let Some(ref gas_sponsorship_info) = gas_sponsorship_info
+            && gas_sponsorship_info.requires_match_result_update()
+        {
             // Reconstruct original signed quote
-            let quote = &mut assemble_sponsored_match_req.signed_quote.quote;
-            self.remove_gas_sponsorship_from_quote(quote, gas_sponsorship_info.refund_amount)?;
+            let quote = &mut assemble_match_req.signed_quote.quote;
+            self.remove_gas_sponsorship_from_quote(quote, gas_sponsorship_info.refund_amount);
         }
 
-        Ok(assemble_sponsored_match_req)
+        Ok((assemble_match_req, gas_sponsorship_info))
     }
 
     /// Apply gas sponsorship to the given assembled quote, returning the
@@ -310,7 +313,7 @@ impl Server {
         key_description: String,
         resp_body: &[u8],
         mut query_params: GasSponsorshipQueryParams,
-        gas_sponsorship_info: Option<&GasSponsorshipInfo>,
+        gas_sponsorship_info: Option<GasSponsorshipInfo>,
     ) -> Result<SponsoredMatchResponse, AuthServerError> {
         // Parse response body
         let external_match_resp: ExternalMatchResponse =
@@ -412,7 +415,7 @@ impl Server {
     async fn handle_quote_assembly_bundle_response(
         &self,
         key: String,
-        req: AssembleSponsoredMatchRequest,
+        req: AssembleExternalMatchRequest,
         resp: SponsoredMatchResponse,
     ) -> Result<(), AuthServerError> {
         let original_order = &req.signed_quote.quote.order;

--- a/auth/auth-server/src/server/redis_queries.rs
+++ b/auth/auth-server/src/server/redis_queries.rs
@@ -21,7 +21,7 @@ impl Server {
     // -----------
 
     /// Write the given gas sponsorship info to Redis
-    pub async fn write_gas_sponsorship_info(
+    pub async fn write_gas_sponsorship_info_to_redis(
         &self,
         key: Uuid,
         info: &GasSponsorshipInfo,
@@ -36,7 +36,7 @@ impl Server {
 
     /// Read the gas sponsorship info for the given key from Redis,
     /// returning `None` if no info is found
-    pub async fn read_gas_sponsorship_info(
+    pub async fn read_gas_sponsorship_info_from_redis(
         &self,
         key: Uuid,
     ) -> Result<Option<GasSponsorshipInfo>, AuthServerError> {


### PR DESCRIPTION
This PR updates the quote request & assembly handlers to cache the calculated gas sponsorship info in Redis, and use that cached value, respectively.

### Testing
- [x] Test a basic external match against testnet using an un-updated SDK, confirm that it is sponsored automatically