### PR TITLE
funds-manager: execution_client: use provided estimated gas limit

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -94,13 +94,16 @@ pub struct ExecutionQuote {
     /// The estimated gas for the swap
     #[serde(with = "u256_string_serialization")]
     pub estimated_gas: U256,
+    /// The gas limit for the swap
+    #[serde(with = "u256_string_serialization")]
+    pub gas_limit: U256,
 }
 
 impl ExecutionQuote {
     /// Convert the quote to a canonical string representation for HMAC signing
     pub fn to_canonical_string(&self) -> String {
         format!(
-            "{}{}{}{}{}{}{}{}{}{}",
+            "{}{}{}{}{}{}{}{}{}{}{}",
             self.buy_token_address,
             self.sell_token_address,
             self.sell_amount,
@@ -110,7 +113,8 @@ impl ExecutionQuote {
             hex::encode(&self.data),
             self.value,
             self.gas_price,
-            self.estimated_gas
+            self.estimated_gas,
+            self.gas_limit
         )
     }
 }

--- a/funds-manager/funds-manager-api/src/types/venue.rs
+++ b/funds-manager/funds-manager-api/src/types/venue.rs
@@ -17,6 +17,8 @@ struct TransactionRequest {
     value: String,
     /// Gas price in hex
     gas_price: String,
+    /// Gas limit in hex
+    gas_limit: String,
 }
 
 /// Gas cost information from LiFi API
@@ -90,6 +92,9 @@ impl From<LiFiQuote> for ExecutionQuote {
         let gas_price =
             U256::from_str_radix(quote.transaction_request.gas_price.trim_start_matches("0x"), 16)
                 .unwrap();
+        let gas_limit =
+            U256::from_str_radix(quote.transaction_request.gas_limit.trim_start_matches("0x"), 16)
+                .unwrap();
         let estimated_gas =
             U256::from_str_radix(&quote.estimate.gas_costs[0].estimate, 10).unwrap();
 
@@ -109,6 +114,7 @@ impl From<LiFiQuote> for ExecutionQuote {
             value,
             gas_price,
             estimated_gas,
+            gas_limit,
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -56,7 +56,8 @@ impl ExecutionClient {
             .value(quote.value)
             .data(quote.data)
             .max_fee_per_gas(latest_basefee * 2)
-            .max_priority_fee_per_gas(latest_basefee * 2);
+            .max_priority_fee_per_gas(latest_basefee * 2)
+            .gas(quote.gas_limit);
 
         // Send the transaction
         let pending_tx = client


### PR DESCRIPTION
### Purpose
This PR adds and uses the gas limit field to the `ExecutionQuote` fetched from the execution venue. This fixes transactions reverting due to `out of gas`.

### Testing
- [x] Tested locally (mainnet env)