### PR TITLE
price-reporter: http_server: add cors headers to /price endpoint

### DIFF
--- a/price-reporter/src/http_server/routes.rs
+++ b/price-reporter/src/http_server/routes.rs
@@ -94,10 +94,14 @@ impl Handler for PriceHandler {
         match self.get_price(topic).await {
             Ok(price) => Response::builder()
                 .status(StatusCode::OK)
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Content-Type", "text/plain")
                 .body(Body::from(price.to_string()))
                 .unwrap(),
             Err(e) => Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header("Access-Control-Allow-Origin", "*")
+                .header("Content-Type", "text/plain")
                 .body(Body::from(e.to_string()))
                 .unwrap(),
         }


### PR DESCRIPTION
### Purpose
This PR adds headers to the `/price` Response to ensure cross-origin requests are allowed to hit it. This enables frontends to fetch prices over HTTP.

### Testing
- [x] Tested locally