### PR TITLE
funds-manager: server: add metrics recorder for swap costs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4150,6 +4150,7 @@ dependencies = [
  "http 1.2.0",
  "http-body-util",
  "itertools 0.13.0",
+ "metrics",
  "native-tls",
  "num-bigint",
  "postgres-native-tls",

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -55,6 +55,7 @@ bytes = "1.5.0"
 futures = "0.3"
 http = "1.1"
 itertools = "0.13"
+metrics = "=0.22.3"
 num-bigint = "0.4"
 rand = "0.8"
 reqwest = { version = "0.12", features = ["json"] }

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -10,7 +10,7 @@ use ethers::{
 use funds_manager_api::quoters::ExecutionQuote;
 use tracing::info;
 
-use crate::helpers::{TransactionHash, ERC20};
+use crate::helpers::ERC20;
 
 use super::{error::ExecutionClientError, ExecutionClient};
 
@@ -20,12 +20,12 @@ impl ExecutionClient {
         &self,
         quote: ExecutionQuote,
         wallet: &LocalWallet,
-    ) -> Result<TransactionHash, ExecutionClientError> {
+    ) -> Result<TransactionReceipt, ExecutionClientError> {
         // Execute the swap
         let receipt = self.execute_swap_tx(quote, wallet).await?;
         let tx_hash = receipt.transaction_hash;
         info!("Swap executed at {tx_hash:#x}");
-        Ok(tx_hash)
+        Ok(receipt)
     }
 
     /// Execute a swap

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -19,6 +19,7 @@ pub type TransactionHash = H256;
 abigen!(
     ERC20,
     r#"[
+        event Transfer(address indexed from, address indexed to, uint256 value)
         function symbol() external view returns (string memory)
         function decimals() external view returns (uint8)
         function balanceOf(address account) external view returns (uint256)

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -1,0 +1,142 @@
+//! Defines functionality to compute and record data for swap execution
+
+use ethers::types::{Address, TransactionReceipt, U256};
+use funds_manager_api::quoters::ExecutionQuote;
+use tracing::warn;
+
+use super::MetricsRecorder;
+use crate::{
+    error::FundsManagerError,
+    helpers::{TransferFilter, ERC20},
+    metrics::labels::{
+        ASSET_TAG, HASH_TAG, SWAP_EXECUTION_COST_METRIC_NAME, SWAP_NOTIONAL_VOLUME_METRIC_NAME,
+        SWAP_RELATIVE_SPREAD_METRIC_NAME, TRADE_SIDE_FACTOR_TAG,
+    },
+};
+
+/// Represents the cost metrics for a swap operation
+#[derive(Debug)]
+pub struct SwapExecutionMetrics {
+    /// Net execution cost in USDC
+    pub execution_cost_usdc: f64,
+    /// Notional volume in USDC
+    pub notional_volume_usdc: f64,
+    /// Relative spread in decimal format
+    pub relative_spread: f64,
+}
+
+// --------------------
+// | Public Interface |
+// --------------------
+
+impl MetricsRecorder {
+    /// Record the cost metrics for a swap operation
+    pub async fn record_swap_cost(&self, receipt: &TransactionReceipt, quote: &ExecutionQuote) {
+        match self.compute_swap_execution_metrics(receipt, quote).await {
+            Ok(metrics) => {
+                self.record_swap_metrics(receipt, quote, &metrics);
+            },
+            Err(e) => {
+                warn!("Failed to record swap cost for tx {}: {}", receipt.transaction_hash, e);
+            },
+        }
+    }
+}
+
+// --------------------
+// | Private Methods |
+// --------------------
+
+impl MetricsRecorder {
+    /// Compute the cost metrics for a completed swap transaction
+    async fn compute_swap_execution_metrics(
+        &self,
+        receipt: &TransactionReceipt,
+        quote: &ExecutionQuote,
+    ) -> Result<SwapExecutionMetrics, FundsManagerError> {
+        let mint = quote.get_base_token().get_ethers_address();
+
+        let binance_price = self.get_binance_price(&mint).await?;
+        let transfer_amount = self.get_transfer_amount(receipt, mint, quote.from).await?;
+
+        let execution_price = quote.get_price(Some(transfer_amount));
+        let notional_volume_usdc = quote.notional_volume_usdc(transfer_amount);
+
+        let trade_side_factor = if quote.is_buy() { 1.0 } else { -1.0 };
+
+        let relative_spread = trade_side_factor * (execution_price - binance_price) / binance_price;
+        let execution_cost_usdc = notional_volume_usdc * relative_spread;
+
+        Ok(SwapExecutionMetrics { relative_spread, notional_volume_usdc, execution_cost_usdc })
+    }
+
+    /// Record the cost metrics for a swap operation
+    fn record_swap_metrics(
+        &self,
+        receipt: &TransactionReceipt,
+        quote: &ExecutionQuote,
+        metrics: &SwapExecutionMetrics,
+    ) {
+        let labels = self.get_labels(quote, receipt);
+
+        metrics::gauge!(SWAP_EXECUTION_COST_METRIC_NAME, &labels).set(metrics.execution_cost_usdc);
+
+        metrics::gauge!(SWAP_NOTIONAL_VOLUME_METRIC_NAME, &labels)
+            .set(metrics.notional_volume_usdc);
+
+        metrics::gauge!(SWAP_RELATIVE_SPREAD_METRIC_NAME, &labels).set(metrics.relative_spread);
+    }
+
+    /// Derive the labels given a quote and a transaction receipt
+    fn get_labels(
+        &self,
+        quote: &ExecutionQuote,
+        receipt: &TransactionReceipt,
+    ) -> Vec<(String, String)> {
+        let mint = format!("{:#x}", quote.get_base_token().get_ethers_address());
+        let asset = quote.get_base_token().get_ticker().unwrap_or(mint);
+        let side_label = if quote.is_buy() { "buy" } else { "sell" };
+
+        vec![
+            (ASSET_TAG.to_string(), asset),
+            (TRADE_SIDE_FACTOR_TAG.to_string(), side_label.to_string()),
+            (HASH_TAG.to_string(), format!("{:#x}", receipt.transaction_hash)),
+        ]
+    }
+
+    /// Extract the transfer amount from a transaction receipt
+    async fn get_transfer_amount(
+        &self,
+        receipt: &TransactionReceipt,
+        mint: Address,
+        recipient: Address,
+    ) -> Result<U256, FundsManagerError> {
+        let block_number = receipt.block_number.unwrap_or_default().as_u64();
+
+        let contract = ERC20::new(mint, self.provider.clone());
+        let filter = contract
+            .event::<TransferFilter>()
+            .from_block(block_number)
+            .to_block(block_number)
+            .topic2(recipient);
+
+        let events = filter
+            .query_with_meta()
+            .await
+            .map_err(|_| FundsManagerError::arbitrum("failed to create transfer stream"))?;
+
+        // Find the transfer event that matches our transaction hash
+        let transfer_event = events
+            .iter()
+            .find(|(_, meta)| meta.transaction_hash == receipt.transaction_hash)
+            .ok_or_else(|| FundsManagerError::custom("No matching transfer event found"))?;
+
+        Ok(transfer_event.0.value)
+    }
+
+    /// Get the Binance price for a token
+    async fn get_binance_price(&self, mint: &Address) -> Result<f64, FundsManagerError> {
+        let price = self.relayer_client.get_binance_price(&format!("{:#x}", mint)).await?;
+        price.ok_or_else(|| FundsManagerError::custom("No Binance price available for token"))
+    }
+}

--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -1,0 +1,19 @@
+//! Constants for metric labels and metric names
+
+/// Metric for the net execution cost of the swap in USD
+pub const SWAP_EXECUTION_COST_METRIC_NAME: &str = "swap_execution_cost";
+
+/// Metric for the notional volume of the swap in USD
+pub const SWAP_NOTIONAL_VOLUME_METRIC_NAME: &str = "swap_notional_volume";
+
+/// Metric for the relative spread between execution price and Binance price
+pub const SWAP_RELATIVE_SPREAD_METRIC_NAME: &str = "swap_relative_spread";
+
+/// Metric tag for the asset's ticker symbol or address
+pub const ASSET_TAG: &str = "asset";
+
+/// Metric tag for the trade side, either `"buy"` or `"sell"`
+pub const TRADE_SIDE_FACTOR_TAG: &str = "side";
+
+/// Metric tag for the transaction hash of the swap
+pub const HASH_TAG: &str = "hash";

--- a/funds-manager/funds-manager-server/src/metrics/mod.rs
+++ b/funds-manager/funds-manager-server/src/metrics/mod.rs
@@ -1,0 +1,29 @@
+//! General metrics recording functionality
+
+use ethers::prelude::*;
+use std::sync::Arc;
+
+use crate::relayer_client::RelayerClient;
+
+pub mod cost;
+pub mod labels;
+
+/// A general metrics recorder that holds the clients needed for recording
+/// metrics.
+#[derive(Clone)]
+pub struct MetricsRecorder {
+    /// Client for interacting with the relayer
+    pub relayer_client: RelayerClient,
+    /// Ethereum provider for querying chain events
+    pub provider: Arc<Provider<Http>>,
+}
+
+impl MetricsRecorder {
+    /// Create a new metrics recorder
+    pub fn new(relayer_client: RelayerClient, rpc_url: String) -> Self {
+        let provider = Provider::<Http>::try_from(rpc_url).unwrap();
+        let provider = Arc::new(provider);
+
+        MetricsRecorder { relayer_client, provider }
+    }
+}

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -21,6 +21,7 @@ use crate::{
     error::FundsManagerError,
     execution_client::ExecutionClient,
     fee_indexer::Indexer,
+    metrics::MetricsRecorder,
     relayer_client::RelayerClient,
     Cli,
 };
@@ -65,6 +66,8 @@ pub(crate) struct Server {
     pub hmac_key: Option<HmacKey>,
     /// The HMAC key for signing quotes
     pub quote_hmac_key: HmacKey,
+    /// The metrics recorder
+    pub metrics_recorder: MetricsRecorder,
 }
 
 impl Server {
@@ -128,7 +131,9 @@ impl Server {
             &args.rpc_url,
         )?;
 
-        Ok(Self {
+        let metrics_recorder = MetricsRecorder::new(relayer_client.clone(), args.rpc_url.clone());
+
+        Ok(Server {
             chain_id,
             chain: args.chain,
             relayer_client: relayer_client.clone(),
@@ -140,6 +145,7 @@ impl Server {
             aws_config: config,
             hmac_key,
             quote_hmac_key,
+            metrics_recorder,
         })
     }
 


### PR DESCRIPTION
### Purpose
This PR adds metric recording for costs incurred when executing a swap. We record three new metrics:
- `swap_execution_cost`
- `swap_notional_volume`
- `swap_relative_spread`
which will be used to create a dashboard that tracks our average execution cost. We tag each metric with `asset`, `side`, and `hash` so we can track execution costs and spreads by asset and directions.

### Testing
Tested locally that metrics are recorded, are correctly formatted, and can be accessed through the Datadog UI.