### PR TITLE
auth-server: gas_estimation, rate_limiter: addnl sponsorship expenditure metadata

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -114,7 +114,7 @@ pub struct Cli {
     #[clap(long, env = "GAS_SPONSOR_AUTH_KEY")]
     gas_sponsor_auth_key: String,
     /// The maximum dollar value of gas sponsorship funds per day
-    #[arg(long, env = "MAX_GAS_SPONSORSHIP_VALUE", default_value = "100.0")]
+    #[arg(long, env = "MAX_GAS_SPONSORSHIP_VALUE", default_value = "25.0")]
     max_gas_sponsorship_value: f64,
 
     // -------------

--- a/auth/auth-server/src/server/gas_estimation/gas_cost_sampler.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_cost_sampler.rs
@@ -83,9 +83,15 @@ impl GasCostSampler {
         *self.latest_estimate.read().await
     }
 
-    /// Estimate the gas cost, in wei, of an external match.
-    /// This calculation was taken from https://docs.arbitrum.io/build-decentralized-apps/how-to-estimate-gas
-    async fn estimate_external_match_gas_cost(&self) -> Result<(), String> {
+    /// Sample the current L1 & L2 gas prices.
+    /// Returns a tuple containing:
+    /// - `gas_estimate_for_l1`: the cost in units of L2 gas for including all
+    ///   of the provided calldata. Effectively equal to
+    ///   `compressed_calldata_size * l1_base_fee_estimate*16 / l2_base_fee`.
+    /// - `l2_base_fee`: the cost in wei of a single unit of L2 gas.
+    /// - `l1_base_fee_estimate*16`: the cost in wei (on the L2) of including a
+    ///   single byte of calldata.
+    pub async fn sample_gas_prices(&self) -> Result<(u64, U256, U256), String> {
         // Get the estimate of the L1 gas costs of the transaction.
         // As per https://github.com/OffchainLabs/nitro-contracts/blob/main/src/node-interface/NodeInterface.sol#L102-L103,
         // this doesn't actually simulate the transaction, just estimates L1 portion of
@@ -99,7 +105,7 @@ impl GasCostSampler {
         let mut data = [0_u8; ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES];
         thread_rng().fill_bytes(&mut data);
 
-        let (gas_estimate_for_l1, base_fee, _) = node_interface
+        let (gas_estimate_for_l1, l2_base_fee, l1_base_fee_estimate) = node_interface
             .gas_estimate_l1_component(
                 self.gas_sponsor_address,
                 false, // contract_creation
@@ -109,8 +115,15 @@ impl GasCostSampler {
             .await
             .map_err(|e| e.to_string())?;
 
+        Ok((gas_estimate_for_l1, l2_base_fee, l1_base_fee_estimate * 16))
+    }
+
+    /// Estimate the gas cost, in wei, of an external match.
+    /// This calculation was taken from https://docs.arbitrum.io/build-decentralized-apps/how-to-estimate-gas
+    async fn estimate_external_match_gas_cost(&self) -> Result<(), String> {
+        let (gas_estimate_for_l1, l2_base_fee, _) = self.sample_gas_prices().await?;
         let total_gas = U256::from(ESTIMATED_L2_GAS + gas_estimate_for_l1);
-        let total_cost = total_gas * base_fee;
+        let total_cost = total_gas * l2_base_fee;
 
         let mut latest_estimate = self.latest_estimate.write().await;
         *latest_estimate = total_cost;

--- a/auth/auth-server/src/server/rate_limiter/mod.rs
+++ b/auth/auth-server/src/server/rate_limiter/mod.rs
@@ -20,6 +20,8 @@
 //! The latter is measured by waiting for nullifier spend events on-chain. This
 //! is also when we record the gas sponsorship value for sponsored bundles.
 
+use std::time::Duration;
+
 use gas_sponsorship_rate_limiter::GasSponsorshipRateLimiter;
 use user_rate_limiter::ApiTokenRateLimiter;
 
@@ -84,5 +86,14 @@ impl AuthServerRateLimiter {
     /// method will do nothing.
     pub async fn record_gas_sponsorship(&self, user_id: String, value: f64) {
         self.gas_sponsorship_rate_limiter.record_sponsorship(user_id, value).await;
+    }
+
+    /// Get the remaining value and time for a given user's gas sponsorship
+    /// bucket.
+    pub async fn remaining_gas_sponsorship_value_and_time(
+        &self,
+        user_id: String,
+    ) -> (f64, Duration) {
+        self.gas_sponsorship_rate_limiter.remaining_value_and_time(user_id).await
     }
 }

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -39,10 +39,7 @@ use crate::{
 };
 
 use super::{
-    labels::{
-        GAS_SPONSORSHIP_VALUE, KEY_DESCRIPTION_METRIC_TAG, REQUEST_ID_METRIC_TAG,
-        REQUEST_PATH_METRIC_TAG, SIDE_TAG,
-    },
+    labels::{KEY_DESCRIPTION_METRIC_TAG, REQUEST_PATH_METRIC_TAG, SIDE_TAG},
     quote_comparison::QuoteComparison,
 };
 
@@ -284,12 +281,6 @@ pub(crate) fn record_external_match_metrics(
     }
 
     Ok(())
-}
-
-/// Record the dollar value of sponsored gas for a given settled match
-pub(crate) fn record_gas_sponsorship_metrics(gas_sponsorship_value: f64, request_id: String) {
-    let labels = vec![(REQUEST_ID_METRIC_TAG.to_string(), request_id)];
-    metrics::gauge!(GAS_SPONSORSHIP_VALUE, &labels).set(gas_sponsorship_value);
 }
 
 /// Record a counter metric for relayer requests that return a 500 status code

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -91,3 +91,18 @@ pub const SOURCE_NET_OUTPUT_TAG: &str = "source_net_output";
 
 /// Metric tag to indicate that a match had its gas costs sponsored
 pub const GAS_SPONSORED_METRIC_TAG: &str = "gas_sponsored";
+/// Metric tag indicating the remaining value in a gas sponsorship rate limit
+/// bucket
+pub const REMAINING_VALUE_TAG: &str = "remaining_value";
+/// Metric tag indicating the remaining time (in seconds) in a gas sponsorship
+/// rate limit bucket
+pub const REMAINING_TIME_TAG: &str = "remaining_time";
+/// Metric tag indicating the refund asset
+pub const REFUND_ASSET_TAG: &str = "refund_asset";
+/// Metric tag indicating the refund amount (in whole units)
+pub const REFUND_AMOUNT_TAG: &str = "refund_amount";
+/// Metric tag indicating the cost per byte of L1 calldata (in L2 wei)
+pub const L1_COST_PER_BYTE_TAG: &str = "l1_cost_per_byte";
+/// Metric tag indicating the base fee (in wei) of the L2 portion of a
+/// transaction
+pub const L2_BASE_FEE_TAG: &str = "l2_base_fee";


### PR DESCRIPTION
This PR tags the `gas_sponsorship_value` metric with additional metadata helpful for monitoring our gas sponsorship expenditure, namely:
- The remaining value in the user's rate limit bucket
- The remaining time in the user's rate limit bucket
- The asset through which gas was refunded
- The refund amount, in whole units of the asset
- The L1 & L2 gas prices at the time of the expenditure being recorded
  - There is some drift in gas prices between when a bundle's refund amount was calculated, and when we sample gas prices to record expenditure, but this is still very useful

Additionally, we drop the default value of the gas sponsorship rate limit to $25.

### Testing
- [x] Run local auth server, ensuring gas costs are sampled as expected
- [ ] Test in testnet w/ external matches, checking metrics