### PR TITLE
auth-server: price_reporter_client: stream prices for all tokens

### DIFF
--- a/auth/auth-server/src/server/price_reporter_client/error.rs
+++ b/auth/auth-server/src/server/price_reporter_client/error.rs
@@ -11,6 +11,10 @@ pub enum PriceReporterError {
     #[error("Setup error: {0}")]
     Setup(String),
 
+    /// Parsing error
+    #[error("Parsing error: {0}")]
+    Parsing(String),
+
     /// HTTP error
     #[error("HTTP error: {0}")]
     Http(HttpError),
@@ -31,6 +35,12 @@ impl PriceReporterError {
     #[allow(clippy::needless_pass_by_value)]
     pub fn setup<T: ToString>(msg: T) -> Self {
         Self::Setup(msg.to_string())
+    }
+
+    /// Create a new parsing error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn parsing<T: ToString>(msg: T) -> Self {
+        Self::Parsing(msg.to_string())
     }
 
     /// Create a new web socket error

--- a/auth/auth-server/src/server/price_reporter_client/mod.rs
+++ b/auth/auth-server/src/server/price_reporter_client/mod.rs
@@ -2,8 +2,11 @@
 //! connections
 
 use error::PriceReporterError;
-use price_stream::PriceStream;
-use renegade_common::types::{exchange::Exchange, token::Token};
+use price_stream::MultiPriceStream;
+use renegade_common::types::{
+    exchange::Exchange,
+    token::{get_all_tokens, Token, USDC_TICKER, USDT_TICKER, USD_TICKER},
+};
 use reqwest::Url;
 use tracing::warn;
 
@@ -26,14 +29,20 @@ const DEFAULT_TIMEOUT_SECS: u64 = 5;
 /// The ticker for the WETH token
 const WETH_TICKER: &str = "WETH";
 
+/// The tickers of tokens that are excluded from the price stream
+const EXCLUDED_TICKERS: [&str; 3] = [USDT_TICKER, USDC_TICKER, USD_TICKER];
+
+/// The error message for an invalid topic
+const ERR_INVALID_TOPIC: &str = "Invalid topic format";
+
 /// A client for the price reporter that supports both HTTP requests
 /// and websocket streaming for real-time price updates
 #[derive(Debug)]
 pub struct PriceReporterClient {
     /// The base URL of the price reporter
     base_url: String,
-    /// The price stream for real-time ETH price updates
-    eth_price_stream: PriceStream,
+    /// The multi-price stream for real-time token price updates
+    multi_price_stream: MultiPriceStream,
 }
 
 impl PriceReporterClient {
@@ -48,20 +57,40 @@ impl PriceReporterClient {
             .set_port(Some(WS_PORT))
             .map_err(|_| PriceReporterError::setup("Error setting websocket port"))?;
 
-        let eth = Token::from_ticker(WETH_TICKER);
-        Ok(Self { base_url, eth_price_stream: PriceStream::new(ws_url.as_str(), &eth.get_addr()) })
+        let mints = get_all_tokens()
+            .into_iter()
+            .filter(|t| !EXCLUDED_TICKERS.contains(&t.get_ticker().unwrap_or_default().as_str()))
+            .map(|t| t.get_addr())
+            .collect();
+
+        Ok(Self { base_url, multi_price_stream: MultiPriceStream::new(ws_url.to_string(), mints) })
     }
 
-    /// Construct the price topic for a given token
-    pub fn get_price_topic(mint: &str) -> String {
-        let exchange = Exchange::Binance;
-        let quote_mint = Token::from_ticker("USDT").get_addr();
-        format!("{}-{}-{}", exchange, mint, quote_mint)
+    /// A convenience method for fetching the current price of ETH in USDC.
+    pub async fn get_eth_price(&self) -> Result<f64, PriceReporterError> {
+        // Under the hood, the price reporter streams native ETH prices for the WETH
+        // token
+        let mint = Token::from_ticker(WETH_TICKER).get_addr();
+        self.get_price(&mint).await
+    }
+
+    /// Fetch the current price of a token from the price reporter.
+    ///
+    /// We first try reading the state of the price stream,
+    /// and fall back to an HTTP request if the stream is not connected.
+    pub async fn get_price(&self, mint: &str) -> Result<f64, PriceReporterError> {
+        let ws_is_connected = self.multi_price_stream.is_connected();
+        if ws_is_connected {
+            return Ok(self.multi_price_stream.get_price(mint).await);
+        }
+
+        warn!("Price stream is not connected, fetching price via HTTP");
+        self.get_price_http(mint).await
     }
 
     /// Get the price of a token from the price reporter via HTTP
-    pub async fn get_binance_price(&self, mint: &str) -> Result<f64, PriceReporterError> {
-        let price_topic = Self::get_price_topic(mint);
+    pub async fn get_price_http(&self, mint: &str) -> Result<f64, PriceReporterError> {
+        let price_topic = construct_price_topic(mint);
 
         let url = format!("{}{}/{}", self.base_url, PRICE_ROUTE, price_topic);
         let response = send_get_request(&url, DEFAULT_TIMEOUT_SECS).await?;
@@ -72,22 +101,22 @@ impl PriceReporterClient {
 
         Ok(price)
     }
+}
 
-    /// Fetch the current price of ETH in USDC.
-    ///
-    /// We first try reading the state of the ETH price stream,
-    /// and fall back to an HTTP request if the stream is not connected.
-    pub async fn get_eth_price(&self) -> Result<f64, PriceReporterError> {
-        let (price, is_connected) = self.eth_price_stream.get_state();
+// ----------------------
+// | Non-Member Helpers |
+// ----------------------
 
-        if is_connected {
-            return Ok(price);
-        }
+/// Construct the price topic for a given token
+pub fn construct_price_topic(mint: &str) -> String {
+    let exchange = Exchange::Binance;
+    let quote_mint = Token::from_ticker(USDT_TICKER).get_addr();
+    format!("{}-{}-{}", exchange, mint, quote_mint)
+}
 
-        warn!("Price stream is not connected, fetching ETH price via HTTP");
-
-        // Fall back to HTTP request if the stream is not connected
-        let eth = Token::from_ticker(WETH_TICKER);
-        self.get_binance_price(&eth.get_addr()).await
-    }
+/// Get the base mint from a price topic
+pub fn get_base_mint_from_topic(topic: &str) -> Result<String, PriceReporterError> {
+    let parts: Vec<&str> = topic.split('-').collect();
+    let base_mint = parts.get(1).ok_or(PriceReporterError::parsing(ERR_INVALID_TOPIC))?;
+    Ok(base_mint.to_string())
 }


### PR DESCRIPTION
This PR upgrades the auth server `PriceReporterClient`'s price stream from streaming a single price (ETH) to streaming prices for an arbitrary number of token mints passed in when the stream is started up.

This will be used in respecting exact output amounts for in-kind sponsored quotes, where we will have to compute refund amounts (and thus know the price of the buy-side token) before we have any match result from the relayer from which we can infer a price. We opt to stream prices for this so as to not burden the critical path of requesting a quote with the latency of an HTTP request to the price reporter.

We continue to opt for a bespoke implementation of the price reporter streaming client, as opposed to the one defined in the relayer, as the latter has a lot of path dependence on the relayer. It's configured to be spawned and managed as a relayer worker, and uses a system of message channels allowing it to handle and respond to "jobs" for streaming and peeking at prices. Not to mention, it enshrines logic for on-the-fly price conversion from UDST- to USDC-quoted prices. Not worth the overhead of integrating it directly.

### Testing
- [x] Ran a local auth server w/ a dummy price-fetching endpoint, confirming that it spawned all price streams as expected and was able to fetch prices from the stream state as opposed to HTTP requests to the price reporter. For reference, hitting this endpoint locally had a 2ms round-trip time.