### PR TITLE
auth-server: handle_external_match: update quote request to account for sponsorship

### DIFF
--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -266,7 +266,10 @@ impl Server {
     /// limit has been exceeded.
     pub async fn check_gas_sponsorship_rate_limit(&self, key_description: String) -> bool {
         if !self.rate_limiter.check_gas_sponsorship(key_description.clone()).await {
-            warn!("Gas sponsorship rate limit exceeded for key: {key_description}");
+            warn!(
+                key_description = key_description.as_str(),
+                "Gas sponsorship rate limit exceeded for key: {key_description}"
+            );
             return false;
         }
         true

--- a/auth/auth-server/src/server/price_reporter_client/error.rs
+++ b/auth/auth-server/src/server/price_reporter_client/error.rs
@@ -15,6 +15,10 @@ pub enum PriceReporterError {
     #[error("Parsing error: {0}")]
     Parsing(String),
 
+    /// Conversion error
+    #[error("Conversion error: {0}")]
+    Conversion(String),
+
     /// HTTP error
     #[error("HTTP error: {0}")]
     Http(HttpError),
@@ -22,6 +26,10 @@ pub enum PriceReporterError {
     /// WebSocket error
     #[error("WebSocket error: {0}")]
     WebSocket(String),
+
+    /// Custom error
+    #[error("Custom error: {0}")]
+    Custom(String),
 }
 
 impl From<HttpError> for PriceReporterError {
@@ -43,9 +51,21 @@ impl PriceReporterError {
         Self::Parsing(msg.to_string())
     }
 
+    /// Create a new conversion error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn conversion<T: ToString>(msg: T) -> Self {
+        Self::Conversion(msg.to_string())
+    }
+
     /// Create a new web socket error
     #[allow(clippy::needless_pass_by_value)]
     pub fn websocket<T: ToString>(msg: T) -> Self {
         Self::WebSocket(msg.to_string())
+    }
+
+    /// Create a new custom error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom<T: ToString>(msg: T) -> Self {
+        Self::Custom(msg.to_string())
     }
 }


### PR DESCRIPTION
This PR updates the quote request endpoint to properly respect requested exact output amounts for sponsored quotes. Namely, this means that when a quote is requested with an exact amount of the output token specified, _and_ in-kind gas sponsorship directed to the receiver is applied, we subtract the refund amount from the exact output amount before sending the quote request to the relayer.

As a result, the relayer will produce a _smaller_ quote which will bear the exact output amount requested when the refund is issued alongside it. We ensure that the exact output amount in the quote response sent to the user matches what they originally requested.

This requires us to compute a refund amount _prior_ to receiving a match result/quote from the relayer, which can be done efficiently by leveraging the new multi-price stream.

### TODO
- [ ] Update the quote assembly path (must properly revert gas sponsorship on order in signed quote, and handle updated orders)
- [ ] Update direct match path (effectively replicates this process)
- [ ] Testing