### PR TITLE
auth-server: handle_external_match: sponsored exact output in assembly & direct match

### DIFF
--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -7,6 +7,10 @@ use auth_server_api::{
     GasSponsorshipInfo, GasSponsorshipQueryParams, SponsoredMatchResponse, SponsoredQuoteResponse,
 };
 use bytes::Bytes;
+use gas_sponsorship::refund_calculation::{
+    apply_gas_sponsorship_to_exact_output_amount, remove_gas_sponsorship_from_quote,
+    requires_exact_output_amount_update,
+};
 use http::{HeaderMap, Method, Response, StatusCode};
 use renegade_api::http::external_match::{
     AssembleExternalMatchRequest, ExternalMatchRequest, ExternalMatchResponse, ExternalOrder,
@@ -18,10 +22,7 @@ use renegade_constants::EXTERNAL_MATCH_RELAYER_FEE;
 use tracing::{error, info, instrument, warn};
 use warp::{reject::Rejection, reply::Reply};
 
-use super::helpers::{
-    apply_gas_sponsorship_to_exact_output_amount, generate_quote_uuid, overwrite_response_body,
-    requires_exact_output_amount_update,
-};
+use super::helpers::{generate_quote_uuid, overwrite_response_body};
 use super::Server;
 use crate::error::AuthServerError;
 use crate::telemetry::helpers::{calculate_implied_price, record_relayer_request_500};
@@ -91,7 +92,7 @@ impl Server {
         }
 
         let sponsored_quote_response =
-            self.maybe_apply_gas_sponsorship_to_quote(resp.body(), gas_sponsorship_info).await?;
+            self.maybe_apply_gas_sponsorship_to_quote_response(resp.body(), gas_sponsorship_info)?;
 
         overwrite_response_body(&mut resp, sponsored_quote_response.clone())?;
 
@@ -135,7 +136,7 @@ impl Server {
         // Update the request to remove the effects of gas sponsorship, if
         // necessary
         let (assemble_match_req, gas_sponsorship_info) =
-            self.maybe_update_assembly_request(&body).await?;
+            self.maybe_update_assembly_request_with_gas_sponsorship(&body).await?;
 
         let req_body = serde_json::to_vec(&assemble_match_req).map_err(AuthServerError::serde)?;
 
@@ -162,8 +163,9 @@ impl Server {
             .maybe_apply_gas_sponsorship_to_assembled_quote(
                 key_desc.clone(),
                 resp.body(),
-                query_params,
                 gas_sponsorship_info,
+                &assemble_match_req,
+                query_params,
             )
             .await?;
 
@@ -174,9 +176,9 @@ impl Server {
             if let Err(e) = server_clone
                 .handle_quote_assembly_bundle_response(
                     key_desc,
-                    assemble_match_req,
+                    &assemble_match_req,
                     &headers,
-                    sponsored_match_resp,
+                    &sponsored_match_resp,
                 )
                 .await
             {
@@ -202,30 +204,39 @@ impl Server {
 
         self.check_bundle_rate_limit(key_description.clone()).await?;
 
+        let (external_match_req, gas_sponsorship_info) = self
+            .maybe_apply_gas_sponsorship_to_match_request(
+                key_description.clone(),
+                &body,
+                &query_str,
+            )
+            .await?;
+
+        let req_body = serde_json::to_vec(&external_match_req).map_err(AuthServerError::serde)?;
+
         // Send the request to the relayer, potentially sponsoring the gas costs
 
-        let mut resp =
-            self.send_admin_request(Method::POST, path_str, headers.clone(), body.clone()).await?;
+        let mut resp = self
+            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
+            .await?;
 
         let status = resp.status();
         if status == StatusCode::INTERNAL_SERVER_ERROR {
             record_relayer_request_500(key_description.clone(), path_str.to_string());
         }
         if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(&resp, &key_description, path_str, &body, &headers);
+            log_unsuccessful_relayer_request(
+                &resp,
+                &key_description,
+                path_str,
+                &req_body,
+                &headers,
+            );
             return Ok(resp);
         }
 
-        let query_params = serde_urlencoded::from_str::<GasSponsorshipQueryParams>(&query_str)
-            .map_err(AuthServerError::serde)?;
-
-        let sponsored_match_resp = self
-            .maybe_apply_gas_sponsorship_to_match(
-                key_description.clone(),
-                resp.body(),
-                &query_params,
-            )
-            .await?;
+        let sponsored_match_resp =
+            self.maybe_apply_gas_sponsorship_to_match_response(resp.body(), gas_sponsorship_info)?;
 
         overwrite_response_body(&mut resp, sponsored_match_resp.clone())?;
 
@@ -235,9 +246,9 @@ impl Server {
             if let Err(e) = server_clone
                 .handle_direct_match_bundle_response(
                     key_description,
-                    &body,
+                    &external_match_req,
                     &headers,
-                    sponsored_match_resp,
+                    &sponsored_match_resp,
                 )
                 .await
             {
@@ -268,29 +279,22 @@ impl Server {
 
         // Parse request body
         let mut external_quote_req: ExternalQuoteRequest =
-            serde_json::from_slice(&req_body).map_err(AuthServerError::serde)?;
-
-        let external_order = &mut external_quote_req.external_order;
+            serde_json::from_slice(req_body).map_err(AuthServerError::serde)?;
 
         let gas_sponsorship_info = self
-            .maybe_generate_gas_sponsorship_info(key_desc, external_order, &query_params)
+            .maybe_apply_gas_sponsorship_to_order(
+                key_desc,
+                &mut external_quote_req.external_order,
+                &query_params,
+            )
             .await?;
-
-        if let Some(ref gas_sponsorship_info) = gas_sponsorship_info
-            && requires_exact_output_amount_update(external_order, gas_sponsorship_info)
-        {
-            // Subtract the refund amount from the exact output amount requested in the
-            // order, so that the relayer produces a smaller quote which will
-            // match the exact output amount after the refund is issued
-            apply_gas_sponsorship_to_exact_output_amount(external_order, gas_sponsorship_info);
-        }
 
         Ok((external_quote_req, gas_sponsorship_info))
     }
 
     /// Potentially apply gas sponsorship to the given
     /// external quote, returning the resulting `SponsoredQuoteResponse`
-    async fn maybe_apply_gas_sponsorship_to_quote(
+    fn maybe_apply_gas_sponsorship_to_quote_response(
         &self,
         resp_body: &[u8],
         gas_sponsorship_info: Option<GasSponsorshipInfo>,
@@ -310,14 +314,15 @@ impl Server {
             external_quote_response,
             gas_sponsorship_info.unwrap(),
         )
-        .await
     }
 
     /// Check if the given assembly request pertains to a sponsored quote,
-    /// and if so, remove the effects of gas sponsorship from the quote.
+    /// and if so, remove the effects of gas sponsorship from the signed quote,
+    /// and ensure sponsorship is correctly applied to the updated order, if
+    /// present.
     ///
     /// Returns the assembly request, and the gas sponsorship info, if any.
-    async fn maybe_update_assembly_request(
+    async fn maybe_update_assembly_request_with_gas_sponsorship(
         &self,
         req_body: &[u8],
     ) -> Result<(AssembleExternalMatchRequest, Option<GasSponsorshipInfo>), AuthServerError> {
@@ -334,12 +339,19 @@ impl Server {
             Ok(gas_sponsorship_info) => gas_sponsorship_info,
         };
 
-        if let Some(ref gas_sponsorship_info) = gas_sponsorship_info
-            && gas_sponsorship_info.requires_match_result_update()
-        {
+        if let Some(ref gas_sponsorship_info) = gas_sponsorship_info {
             // Reconstruct original signed quote
-            let quote = &mut assemble_match_req.signed_quote.quote;
-            self.remove_gas_sponsorship_from_quote(quote, gas_sponsorship_info.refund_amount);
+            if gas_sponsorship_info.requires_match_result_update() {
+                let quote = &mut assemble_match_req.signed_quote.quote;
+                remove_gas_sponsorship_from_quote(quote, gas_sponsorship_info);
+            }
+
+            // Ensure that the exact output amount is respected on the updated order
+            if let Some(ref mut updated_order) = assemble_match_req.updated_order
+                && requires_exact_output_amount_update(updated_order, gas_sponsorship_info)
+            {
+                apply_gas_sponsorship_to_exact_output_amount(updated_order, gas_sponsorship_info);
+            }
         }
 
         Ok((assemble_match_req, gas_sponsorship_info))
@@ -354,79 +366,70 @@ impl Server {
         &self,
         key_description: String,
         resp_body: &[u8],
+        gas_sponsorship_info: Option<GasSponsorshipInfo>,
+        req: &AssembleExternalMatchRequest,
         mut query_params: GasSponsorshipQueryParams,
+    ) -> Result<SponsoredMatchResponse, AuthServerError> {
+        let gas_sponsorship_info = if gas_sponsorship_info.is_none()
+            && query_params.use_gas_sponsorship.unwrap_or(false)
+        {
+            // If there is no associated gas sponsorship info, but the deprecated
+            // `use_gas_sponsorship` query parameter was set, it means an
+            // outdated client must have been used to invoke the assembly endpoint.
+            // In this case, for backwards compatibility, we use the deprecated default of
+            // native ETH refunds.
+            query_params.refund_native_eth = Some(true);
+
+            let order = req.updated_order.as_ref().unwrap_or(&req.signed_quote.quote.order);
+            self.maybe_generate_gas_sponsorship_info(key_description, order, &query_params).await?
+        } else {
+            gas_sponsorship_info
+        };
+
+        self.maybe_apply_gas_sponsorship_to_match_response(resp_body, gas_sponsorship_info)
+    }
+
+    /// Potentially apply gas sponsorship to the given match request, returning
+    /// the resulting `ExternalMatchRequest` and the generated gas sponsorship
+    /// info, if any.
+    async fn maybe_apply_gas_sponsorship_to_match_request(
+        &self,
+        key_desc: String,
+        req_body: &[u8],
+        query_str: &str,
+    ) -> Result<(ExternalMatchRequest, Option<GasSponsorshipInfo>), AuthServerError> {
+        // Parse query params
+        let query_params = serde_urlencoded::from_str::<GasSponsorshipQueryParams>(query_str)
+            .map_err(AuthServerError::serde)?;
+
+        // Parse request body
+        let mut external_match_req: ExternalMatchRequest =
+            serde_json::from_slice(req_body).map_err(AuthServerError::serde)?;
+
+        let gas_sponsorship_info = self
+            .maybe_apply_gas_sponsorship_to_order(
+                key_desc,
+                &mut external_match_req.external_order,
+                &query_params,
+            )
+            .await?;
+
+        Ok((external_match_req, gas_sponsorship_info))
+    }
+
+    /// Potentially apply gas sponsorship to the given
+    /// external match response, returning the resulting
+    /// `SponsoredMatchResponse`
+    fn maybe_apply_gas_sponsorship_to_match_response(
+        &self,
+        resp_body: &[u8],
         gas_sponsorship_info: Option<GasSponsorshipInfo>,
     ) -> Result<SponsoredMatchResponse, AuthServerError> {
         // Parse response body
         let external_match_resp: ExternalMatchResponse =
             serde_json::from_slice(resp_body).map_err(AuthServerError::serde)?;
 
-        // Whether or not the quote was sponsored, we return a
-        // `SponsoredMatchResponse`. This simply has one extra field,
-        // `is_sponsored`, which we expect clients to ignore if they did not
-        // request sponsorship.
-        let sponsored_match_resp = if let Some(gas_sponsorship_info) = gas_sponsorship_info {
-            info!("Sponsoring assembled quote bundle via gas sponsor");
-
-            let refund_native_eth = gas_sponsorship_info.refund_native_eth;
-            let refund_address = gas_sponsorship_info.get_refund_address();
-            let refund_amount = gas_sponsorship_info.get_refund_amount();
-
-            self.construct_sponsored_match_response(
-                external_match_resp,
-                refund_native_eth,
-                refund_address,
-                refund_amount,
-            )?
-        } else if query_params.use_gas_sponsorship.unwrap_or(false) {
-            // If the deprecated `use_gas_sponsorship` query parameter is set, it means an
-            // outdated client must have been used to invoke the assembly endpoint.
-            // In this case, for backwards compatibility, we use the deprecated default of
-            // native ETH refunds.
-            query_params.refund_native_eth = Some(true);
-
-            return self
-                .maybe_apply_gas_sponsorship_to_match(key_description, resp_body, &query_params)
-                .await;
-        } else {
-            SponsoredMatchResponse {
-                match_bundle: external_match_resp.match_bundle,
-                is_sponsored: false,
-                gas_sponsorship_info: None,
-            }
-        };
-
-        Ok(sponsored_match_resp)
-    }
-
-    /// Potentially apply gas sponsorship to the given
-    /// external match, returning the resulting `SponsoredMatchResponse`
-    async fn maybe_apply_gas_sponsorship_to_match(
-        &self,
-        key_description: String,
-        resp_body: &[u8],
-        query_params: &GasSponsorshipQueryParams,
-    ) -> Result<SponsoredMatchResponse, AuthServerError> {
-        // Parse query params
-        let (sponsorship_omitted, refund_address, refund_native_eth) =
-            query_params.get_or_default();
-
-        // Check gas sponsorship rate limit
-        let gas_sponsorship_rate_limited =
-            !self.check_gas_sponsorship_rate_limit(key_description).await;
-
-        let sponsor_match = !(gas_sponsorship_rate_limited || sponsorship_omitted);
-
-        // Parse response body
-        let external_match_resp: ExternalMatchResponse =
-            serde_json::from_slice(resp_body).map_err(AuthServerError::serde)?;
-
-        // Whether or not sponsorship was requested, we return a
-        // `SponsoredMatchResponse`. This simply has one extra field,
-        // `is_sponsored`, which we expect clients to ignore if they did not
-        // request sponsorship.
-
-        if !sponsor_match {
+        if gas_sponsorship_info.is_none() {
             return Ok(SponsoredMatchResponse {
                 match_bundle: external_match_resp.match_bundle,
                 is_sponsored: false,
@@ -436,22 +439,39 @@ impl Server {
 
         info!("Sponsoring match bundle via gas sponsor");
 
-        // Compute refund amount
-        let refund_amount = self
-            .compute_refund_amount_for_order(
-                &external_match_resp.match_bundle.match_result,
-                refund_native_eth,
-            )
-            .await?;
-
         let sponsored_match_resp = self.construct_sponsored_match_response(
             external_match_resp,
-            refund_native_eth,
-            refund_address,
-            refund_amount,
+            gas_sponsorship_info.unwrap(),
         )?;
 
         Ok(sponsored_match_resp)
+    }
+
+    /// Generate gas sponsorship info for the given order if the query params
+    /// call for it, and update the exact output amount requested in the order
+    /// if necessary
+    async fn maybe_apply_gas_sponsorship_to_order(
+        &self,
+        key_desc: String,
+        order: &mut ExternalOrder,
+        query_params: &GasSponsorshipQueryParams,
+    ) -> Result<Option<GasSponsorshipInfo>, AuthServerError> {
+        let gas_sponsorship_info =
+            self.maybe_generate_gas_sponsorship_info(key_desc, order, query_params).await?;
+
+        // Subtract the refund amount from the exact output amount requested in the
+        // order, so that the relayer produces a smaller quote which will
+        // match the exact output amount after the refund is issued
+        if let Some(ref gas_sponsorship_info) = gas_sponsorship_info
+            && requires_exact_output_amount_update(order, gas_sponsorship_info)
+        {
+            info!(
+                "Adjusting exact output amount requested in order to account for gas sponsorship"
+            );
+            apply_gas_sponsorship_to_exact_output_amount(order, gas_sponsorship_info);
+        }
+
+        Ok(gas_sponsorship_info)
     }
 
     // --- Bundle Tracking --- //
@@ -460,9 +480,9 @@ impl Server {
     async fn handle_quote_assembly_bundle_response(
         &self,
         key: String,
-        req: AssembleExternalMatchRequest,
+        req: &AssembleExternalMatchRequest,
         headers: &HeaderMap,
-        resp: SponsoredMatchResponse,
+        resp: &SponsoredMatchResponse,
     ) -> Result<(), AuthServerError> {
         let original_order = &req.signed_quote.quote.order;
         let updated_order = req.updated_order.as_ref().unwrap_or(original_order);
@@ -475,7 +495,7 @@ impl Server {
 
         self.handle_bundle_response(
             key,
-            updated_order.clone(),
+            updated_order,
             resp,
             Some(request_id),
             "assemble-external-match",
@@ -488,16 +508,20 @@ impl Server {
     async fn handle_direct_match_bundle_response(
         &self,
         key: String,
-        req: &[u8],
+        req: &ExternalMatchRequest,
         headers: &HeaderMap,
-        resp: SponsoredMatchResponse,
+        resp: &SponsoredMatchResponse,
     ) -> Result<(), AuthServerError> {
-        let req: ExternalMatchRequest =
-            serde_json::from_slice(req).map_err(AuthServerError::serde)?;
-        let order = req.external_order;
         let sdk_version = get_sdk_version(headers);
-        self.handle_bundle_response(key, order, resp, None, "request-external-match", sdk_version)
-            .await
+        self.handle_bundle_response(
+            key,
+            &req.external_order,
+            resp,
+            None,
+            "request-external-match",
+            sdk_version,
+        )
+        .await
     }
 
     /// Record and watch a bundle that was forwarded to the client
@@ -506,8 +530,8 @@ impl Server {
     async fn handle_bundle_response(
         &self,
         key: String,
-        order: ExternalOrder,
-        resp: SponsoredMatchResponse,
+        order: &ExternalOrder,
+        resp: &SponsoredMatchResponse,
         request_id: Option<String>,
         endpoint: &str,
         sdk_version: String,
@@ -515,7 +539,7 @@ impl Server {
         // Log the bundle
         let request_id = request_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-        log_bundle(&order, &resp, &key, &request_id, endpoint, &sdk_version)?;
+        log_bundle(order, resp, &key, &request_id, endpoint, &sdk_version)?;
 
         // Note: if sponsored in-kind w/ refund going to the receiver,
         // the amounts in the match bundle will have been updated
@@ -542,12 +566,12 @@ impl Server {
         }
 
         // If the bundle settles, increase the API user's a rate limit token balance
-        let did_settle = await_settlement(&match_bundle, &self.arbitrum_client).await?;
+        let did_settle = await_settlement(match_bundle, &self.arbitrum_client).await?;
         if did_settle {
             self.add_bundle_rate_limit_token(key.clone()).await;
             if let Some(gas_sponsorship_info) = gas_sponsorship_info {
                 self.record_settled_match_sponsorship(
-                    &match_bundle,
+                    match_bundle,
                     gas_sponsorship_info,
                     key,
                     request_id,
@@ -558,7 +582,7 @@ impl Server {
         }
 
         // Record metrics
-        record_external_match_metrics(&order, &match_bundle, &labels, did_settle)?;
+        record_external_match_metrics(order, match_bundle, &labels, did_settle)?;
 
         Ok(())
     }

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -2,7 +2,6 @@
 
 use aes_gcm::{aead::Aead, AeadCore, Aes128Gcm};
 use alloy_primitives::{Address, Bytes as AlloyBytes, PrimitiveSignature, U256 as AlloyU256};
-use auth_server_api::GasSponsorshipInfo;
 use base64::{engine::general_purpose, Engine as _};
 use bigdecimal::{
     num_bigint::{BigInt, Sign},
@@ -13,10 +12,7 @@ use contracts_common::constants::NUM_BYTES_SIGNATURE;
 use ethers::{core::k256::ecdsa::SigningKey, types::U256, utils::keccak256};
 use http::{header::CONTENT_LENGTH, Response};
 use rand::{thread_rng, Rng};
-use renegade_api::http::external_match::{
-    ApiExternalMatchResult, ExternalOrder, SignedExternalQuote,
-};
-use renegade_circuit_types::order::OrderSide;
+use renegade_api::http::external_match::{ApiExternalMatchResult, SignedExternalQuote};
 use renegade_common::types::token::Token;
 use serde::Serialize;
 use serde_json::json;
@@ -166,57 +162,6 @@ pub fn get_nominal_buy_token_price(
     let adjustment: BigDecimal = BigInt::from(10).pow(quote_decimals as u32).into();
 
     Ok(price / adjustment)
-}
-
-/// Check if the exact output amount requested in the order should be updated
-/// to reflect the refund amount
-pub fn requires_exact_output_amount_update(
-    order: &ExternalOrder,
-    gas_sponsorship_info: &GasSponsorshipInfo,
-) -> bool {
-    let exact_out_requested = match order.side {
-        OrderSide::Buy => order.exact_base_output != 0,
-        OrderSide::Sell => order.exact_quote_output != 0,
-    };
-
-    exact_out_requested && gas_sponsorship_info.requires_match_result_update()
-}
-
-/// Account for the given gas sponsorship refund in the exact output amount
-/// requested in the order. Concretely, this means subtracting the refund amount
-/// from the exact output amount, so that the order matched by the relayer bears
-/// the desired output amount only _after_ the refund is issued.
-pub fn apply_gas_sponsorship_to_exact_output_amount(
-    order: &mut ExternalOrder,
-    gas_sponsorship_info: &GasSponsorshipInfo,
-) {
-    match order.side {
-        OrderSide::Buy => {
-            order.exact_base_output -= gas_sponsorship_info.refund_amount;
-        },
-        OrderSide::Sell => {
-            order.exact_quote_output -= gas_sponsorship_info.refund_amount;
-        },
-    }
-}
-
-/// Remove the effects of gas sponsorship from the exact output amount requested
-/// in the order. The order passed in is assumed to have already had the gas
-/// sponsorship refund subtracted from the exact output amount. This function
-/// reverses that operation, so that the order is restored to its original
-/// state.
-pub fn remove_gas_sponsorship_from_exact_output_amount(
-    order: &mut ExternalOrder,
-    gas_sponsorship_info: &GasSponsorshipInfo,
-) {
-    match order.side {
-        OrderSide::Buy => {
-            order.exact_base_output += gas_sponsorship_info.refund_amount;
-        },
-        OrderSide::Sell => {
-            order.exact_quote_output += gas_sponsorship_info.refund_amount;
-        },
-    }
 }
 
 /// Overwrite the body of an HTTP response


### PR DESCRIPTION
This PR ensures that exact output amounts are properly respected both when assembling quotes, and executing direct matches.

Concretely, this entails ensuring that the refund amount is subtracted from the order (or updated order) being assembled / matched directly.

This is necessary to ensure the bundle served by the relayer matches a smaller order size such that the exact output amount is met post-refund, and in the case of assembly, also ensures that the quote matches what was signed by the relayer.

### Testing
Testing is deferred to the following PR, as this one resulted in a fair bit of cleanup due to generating gas sponsorship data before proxying any requests to the relayer, and I didn't want this review to snowball