### PR TITLE
auth-server: handle_external_match: gas_sponsorship: sponsor orders above set size

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -116,6 +116,9 @@ pub struct Cli {
     /// The maximum dollar value of gas sponsorship funds per day
     #[arg(long, env = "MAX_GAS_SPONSORSHIP_VALUE", default_value = "25.0")]
     max_gas_sponsorship_value: f64,
+    /// The minimum quote amount for which gas sponsorship is allowed, in USD
+    #[arg(long, env = "MIN_SPONSORED_ORDER_QUOTE_AMOUNT", default_value = "10.0")]
+    min_sponsored_order_quote_amount: f64,
 
     // -------------
     // | Telemetry |

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -107,6 +107,9 @@ pub struct Server {
     pub price_reporter_client: Arc<PriceReporterClient>,
     /// The gas cost sampler
     pub gas_cost_sampler: Arc<GasCostSampler>,
+    /// The minimum order quote amount for which gas sponsorship is allowed,
+    /// in whole units of USDC
+    pub min_sponsored_order_quote_amount: f64,
 }
 
 impl Server {
@@ -175,6 +178,7 @@ impl Server {
             gas_sponsor_auth_key,
             price_reporter_client,
             gas_cost_sampler,
+            min_sponsored_order_quote_amount: args.min_sponsored_order_quote_amount,
         })
     }
 


### PR DESCRIPTION
This PR ensures that we only sponsor gas for orders above a given quote volume, which is configurable via the CLI / env vars and defaults to 10 USDC.

We also remove now-unnecessary backwards compatibility logic for requesting sponsorship at the assembly stage.

### Testing
- [x] Tested w/ local auth server against testnet