### PR TITLE
auth-server: cargo update to fix get_quote_amt bug, remove logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "alloy-primitives 0.8.20",
  "alloy-sol-types 0.8.20",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
@@ -2862,7 +2862,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "base64 0.22.1",
  "circuit-types",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5382,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7622,7 +7622,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9003,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "bus",
  "common",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9922,7 +9922,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#845c8cca67f3066a3b33726df8a1604df249922d"
+source = "git+https://github.com/renegade-fi/renegade.git#0e32f017b903fe7223c5bfb426eb68e9b0f43cd2"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -18,7 +18,7 @@ use renegade_api::http::external_match::{
 };
 use renegade_circuit_types::fixed_point::FixedPoint;
 use renegade_common::types::{token::Token, TimestampedPrice};
-use renegade_constants::{Scalar, EXTERNAL_MATCH_RELAYER_FEE};
+use renegade_constants::EXTERNAL_MATCH_RELAYER_FEE;
 use tracing::{error, info, instrument, warn};
 use warp::{reject::Rejection, reply::Reply};
 
@@ -712,24 +712,6 @@ fn log_bundle(
     let requested_quote_amount = order.get_quote_amount(price_fixed, relayer_fee);
     let response_quote_amount = match_result.quote_amount;
     let quote_fill_ratio = response_quote_amount as f64 / requested_quote_amount as f64;
-
-    // Debug log for quote amount calculation issue
-    let base_amount_scalar = Scalar::from(order.base_amount);
-    let implied_quote_amount = price_fixed * base_amount_scalar;
-    info!(
-        price = price,
-        price_fixed = ?price_fixed,
-        base_amount = order.base_amount,
-        base_amount_scalar = ?base_amount_scalar,
-        implied_quote_amount = ?implied_quote_amount,
-        implied_quote_amount_floor = ?implied_quote_amount.floor(),
-        requested_quote_amount = requested_quote_amount,
-        response_quote_amount = response_quote_amount,
-        exact_quote_output_set = order.exact_quote_output != 0,
-        exact_quote_output = order.exact_quote_output,
-        request_id = request_id,
-        "Quote amount calculation debug"
-    );
 
     // Get the gas sponsorship info
     let (refund_amount, refund_native_eth) = gas_sponsorship_info


### PR DESCRIPTION
### Purpose
This PR runs `cargo update` to ingest changes made in `renegade-api` to fix the `get_quote_amount` bug as per https://github.com/renegade-fi/renegade/pull/946. Also removes logs added for debugging.

### Testing
- [ ] Tested locally
- [x] Test in testnet