### PR TITLE
auth-server: verify nullifier spent corresponds with bundle being waited

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "alloy-primitives 0.8.20",
  "alloy-sol-types 0.8.20",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
@@ -2862,7 +2862,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "base64 0.22.1",
  "circuit-types",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5382,7 +5382,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7571,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7622,7 +7622,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9003,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "bus",
  "common",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9922,7 +9922,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#49bb9fd7fecf410e647dcbe4a15c8af8193d2ff4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/await-nullifier-tx#872ba0dec59a351aa513e59a48e151f686615cec"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ lto = true
 [workspace.dependencies]
 # === Renegade Dependencies === #
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-renegade-arbitrum-client = { package = "arbitrum-client", git = "https://github.com/renegade-fi/renegade.git", features = [
+renegade-arbitrum-client = { package = "arbitrum-client", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx", features = [
     "rand",
 ] }
-renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
+renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx", features = [
     "auth",
 ] }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = ["metered-channels"] }
-renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx", features = ["metered-channels"] }
+renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
+renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/await-nullifier-tx" }
 
 # === Database Dependencies === #
 diesel = { version = "2.1" }

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -56,6 +56,12 @@ pub enum AuthServerError {
 }
 
 impl AuthServerError {
+    /// Create a new arbitrum client error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn arbitrum<T: ToString>(msg: T) -> Self {
+        Self::ArbitrumClient(msg.to_string())
+    }
+
     /// Create a new database connection error
     #[allow(clippy::needless_pass_by_value)]
     pub fn db<T: ToString>(msg: T) -> Self {

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -28,13 +28,12 @@ use crate::error::AuthServerError;
 use crate::telemetry::helpers::{calculate_implied_price, record_relayer_request_500};
 use crate::telemetry::labels::{GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG};
 use crate::telemetry::{
-    helpers::{
-        await_settlement, record_endpoint_metrics, record_external_match_metrics, record_fill_ratio,
-    },
+    helpers::{record_endpoint_metrics, record_external_match_metrics, record_fill_ratio},
     labels::{
         DECIMAL_CORRECTION_FIXED_METRIC_TAG, EXTERNAL_MATCH_QUOTE_REQUEST_COUNT,
         KEY_DESCRIPTION_METRIC_TAG, REQUEST_ID_METRIC_TAG,
     },
+    settlement::await_settlement,
 };
 
 mod gas_sponsorship;

--- a/auth/auth-server/src/telemetry/mod.rs
+++ b/auth/auth-server/src/telemetry/mod.rs
@@ -2,4 +2,5 @@
 pub mod helpers;
 pub mod labels;
 pub mod quote_comparison;
+pub mod settlement;
 pub mod sources;

--- a/auth/auth-server/src/telemetry/settlement.rs
+++ b/auth/auth-server/src/telemetry/settlement.rs
@@ -1,0 +1,137 @@
+//! Helper methods for settlement processing
+use alloy_sol_types::SolCall;
+use contracts_common::types::MatchPayload;
+use ethers::types::H256 as TxHash;
+use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_arbitrum_client::{
+    abi::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
+    client::ArbitrumClient,
+    helpers::deserialize_calldata,
+};
+use renegade_circuit_types::{order::OrderSide, r#match::MatchResult, wallet::Nullifier};
+use renegade_constants::Scalar;
+use renegade_util::hex::biguint_to_hex_addr;
+use std::time::Duration;
+
+use crate::{
+    error::AuthServerError,
+    server::{
+        handle_external_match::sponsorAtomicMatchSettleWithRefundOptionsCall, helpers::get_selector,
+    },
+};
+
+// --- Constants --- //
+
+/// The duration to await an atomic match settlement
+pub const ATOMIC_SETTLEMENT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Await the result of the atomic match settlement to be submitted on-chain
+///
+/// Returns `true` if the settlement succeeded on-chain, `false` otherwise
+pub(crate) async fn await_settlement(
+    match_bundle: &AtomicMatchApiBundle,
+    arbitrum_client: &ArbitrumClient,
+) -> Result<bool, AuthServerError> {
+    let nullifier = extract_nullifier_from_match_bundle(match_bundle)?;
+    let tx_hash = arbitrum_client
+        .await_nullifier_spent_from_selectors(
+            nullifier,
+            &[
+                processAtomicMatchSettleCall::SELECTOR,
+                processAtomicMatchSettleWithReceiverCall::SELECTOR,
+            ],
+            ATOMIC_SETTLEMENT_TIMEOUT,
+        )
+        .await
+        .map_err(AuthServerError::arbitrum)?;
+
+    verify_match_settlement_in_tx(arbitrum_client, match_bundle, tx_hash).await
+}
+
+/// Returns whether the provided tx corresponds to the provided external match
+async fn verify_match_settlement_in_tx(
+    arbitrum_client: &ArbitrumClient,
+    match_bundle: &AtomicMatchApiBundle,
+    tx: TxHash,
+) -> Result<bool, AuthServerError> {
+    let matches =
+        arbitrum_client.find_external_matches_in_tx(tx).await.map_err(AuthServerError::arbitrum)?;
+    let external_match = !matches.is_empty();
+
+    if !external_match {
+        return Ok(false);
+    }
+
+    let matching_settlement = matches.into_iter().any(|raw_match| match raw_match.try_into() {
+        Ok(match_result) => is_matching_settlement(match_bundle, &match_result),
+        Err(_) => false,
+    });
+
+    Ok(matching_settlement)
+}
+
+/// Returns `true` if the provided match bundle and match result are the same
+fn is_matching_settlement(match_bundle: &AtomicMatchApiBundle, match_result: &MatchResult) -> bool {
+    // Match result direction:
+    // `true` (1) corresponds to the internal party selling the base
+    // `false` (0) corresponds to the internal party buying the base
+    let direction_matches = match match_result.direction {
+        true => match_bundle.match_result.direction == OrderSide::Buy,
+        false => match_bundle.match_result.direction == OrderSide::Sell,
+    };
+
+    let amounts_match = match_bundle.match_result.quote_amount == match_result.quote_amount
+        && match_bundle.match_result.base_amount == match_result.base_amount;
+
+    let tokens_match = match_bundle.match_result.quote_mint
+        == biguint_to_hex_addr(&match_result.quote_mint)
+        && match_bundle.match_result.base_mint == biguint_to_hex_addr(&match_result.base_mint);
+
+    direction_matches && amounts_match && tokens_match
+}
+
+/// Extracts the nullifier from a match bundle's settlement transaction
+///
+/// This function attempts to decode the settlement transaction data in two
+/// ways:
+/// 1. As a standard atomic match settle call
+/// 2. As a match settle with receiver call
+fn extract_nullifier_from_match_bundle(
+    match_bundle: &AtomicMatchApiBundle,
+) -> Result<Nullifier, AuthServerError> {
+    let tx_data = match_bundle
+        .settlement_tx
+        .data()
+        .ok_or(AuthServerError::serde("No data in settlement tx"))?;
+
+    let selector = get_selector(tx_data)?;
+
+    // Retrieve serialized match payload from the transaction data
+    let serialized_match_payload = match selector {
+        processAtomicMatchSettleCall::SELECTOR => {
+            processAtomicMatchSettleCall::abi_decode(tx_data, false)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        processAtomicMatchSettleWithReceiverCall::SELECTOR => {
+            processAtomicMatchSettleWithReceiverCall::abi_decode(tx_data, false)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        sponsorAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
+            sponsorAtomicMatchSettleWithRefundOptionsCall::abi_decode(tx_data, false)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        _ => {
+            return Err(AuthServerError::serde("Invalid selector for settlement tx"));
+        },
+    };
+
+    // Extract nullifier from the payload
+    let match_payload = deserialize_calldata::<MatchPayload>(&serialized_match_payload)
+        .map_err(AuthServerError::serde)?;
+    let nullifier = Scalar::new(match_payload.valid_reblind_statement.original_shares_nullifier);
+
+    Ok(nullifier)
+}


### PR DESCRIPTION
### Purpose
This PR ensures nullifiers only result in one bundle's metrics being recorded by parsing bundle parameters from the calldata and verifying it against those of the bundle being awaited. This is a band-aid fix that works, but results in wasteful network calls since there may be up to 20 bundles per nullifier at a given time. 

The long term fix would be to listen for `NullifierSpent` events, but that requires some more effort to fit into our current metrics structure as we need access to things like `key_description` and `gas_sponsorship_info`. Since we want to both enable shared bundles for customers ASAP and have accurate settlement metrics, I opted to go this route for the time being. 

This requires changes in `renegade` [#950](https://github.com/renegade-fi/renegade/pull/950/files).

I also moved settlement related helpers into their own file as the helpers file was getting big.

### Testing
- [ ] Test in testnet