### PR TITLE
auth-server: add bundle store

### DIFF
--- a/auth/auth-server/src/chain_events/error.rs
+++ b/auth/auth-server/src/chain_events/error.rs
@@ -4,6 +4,8 @@ use std::{error::Error, fmt::Display};
 
 use renegade_arbitrum_client::errors::ArbitrumClientError;
 
+use crate::error::AuthServerError;
+
 /// The error type that the event listener emits
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
@@ -16,6 +18,8 @@ pub enum OnChainEventListenerError {
     Setup(String),
     /// The stream unexpectedly stopped
     StreamEnded,
+    /// Auth server error
+    AuthServer(String),
 }
 
 impl OnChainEventListenerError {
@@ -48,5 +52,11 @@ impl<E: Display> From<alloy::transports::RpcError<E>> for OnChainEventListenerEr
 impl From<alloy::sol_types::Error> for OnChainEventListenerError {
     fn from(e: alloy::sol_types::Error) -> Self {
         OnChainEventListenerError::Rpc(e.to_string())
+    }
+}
+
+impl From<AuthServerError> for OnChainEventListenerError {
+    fn from(err: AuthServerError) -> Self {
+        Self::AuthServer(err.to_string())
     }
 }

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -1,7 +1,7 @@
 //! Defines the core implementation of the on-chain event listener
 //! Much of the implementation is borrowed from https://github.com/renegade-fi/renegade/blob/main/workers/chain-events/src/listener.rs
 
-use std::{sync::Arc, thread::JoinHandle};
+use std::thread::JoinHandle;
 
 use alloy::{
     providers::{DynProvider, Provider, ProviderBuilder, WsConnect},
@@ -79,12 +79,12 @@ pub struct OnChainEventListenerExecutor {
     /// A copy of the config that the executor maintains
     config: OnChainEventListenerConfig,
     /// The bundle store to use for retrieving bundle contexts
-    bundle_store: Arc<BundleStore>,
+    bundle_store: BundleStore,
 }
 
 impl OnChainEventListenerExecutor {
     /// Create a new executor
-    pub fn new(config: OnChainEventListenerConfig, bundle_store: Arc<BundleStore>) -> Self {
+    pub fn new(config: OnChainEventListenerConfig, bundle_store: BundleStore) -> Self {
         Self { config, bundle_store }
     }
 

--- a/auth/auth-server/src/chain_events/worker.rs
+++ b/auth/auth-server/src/chain_events/worker.rs
@@ -1,7 +1,9 @@
 //! The worker implementation for the on-chain event listener
-use std::thread::Builder;
+use std::{sync::Arc, thread::Builder};
 use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::error;
+
+use crate::store::BundleStore;
 
 use super::{
     error::OnChainEventListenerError,
@@ -9,8 +11,11 @@ use super::{
 };
 
 impl OnChainEventListener {
-    pub fn new(config: OnChainEventListenerConfig) -> Result<Self, OnChainEventListenerError> {
-        let executor = OnChainEventListenerExecutor::new(config);
+    pub fn new(
+        config: OnChainEventListenerConfig,
+        bundle_store: Arc<BundleStore>,
+    ) -> Result<Self, OnChainEventListenerError> {
+        let executor = OnChainEventListenerExecutor::new(config, bundle_store);
         Ok(Self { executor: Some(executor), executor_handle: None })
     }
 

--- a/auth/auth-server/src/chain_events/worker.rs
+++ b/auth/auth-server/src/chain_events/worker.rs
@@ -1,5 +1,5 @@
 //! The worker implementation for the on-chain event listener
-use std::{sync::Arc, thread::Builder};
+use std::thread::Builder;
 use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::error;
 
@@ -13,7 +13,7 @@ use super::{
 impl OnChainEventListener {
     pub fn new(
         config: OnChainEventListenerConfig,
-        bundle_store: Arc<BundleStore>,
+        bundle_store: BundleStore,
     ) -> Result<Self, OnChainEventListenerError> {
         let executor = OnChainEventListenerExecutor::new(config, bundle_store);
         Ok(Self { executor: Some(executor), executor_handle: None })

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -53,6 +53,9 @@ pub enum AuthServerError {
     /// Gas cost sampler error
     #[error("Gas cost sampler error: {0}")]
     GasCostSampler(String),
+    /// Bundle store error
+    #[error("Bundle store error: {0}")]
+    BundleStore(String),
 }
 
 impl AuthServerError {

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -215,7 +215,7 @@ async fn main() {
     .expect("failed to create arbitrum client");
 
     // Create the shared in-memory bundle store
-    let bundle_store = Arc::new(BundleStore::new());
+    let bundle_store = BundleStore::new();
 
     // Start the on-chain event listener
     let chain_listener_config = OnChainEventListenerConfig {

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -23,6 +23,7 @@ pub(crate) mod models;
 #[allow(missing_docs, clippy::missing_docs_in_private_items)]
 pub(crate) mod schema;
 mod server;
+mod store;
 mod telemetry;
 
 use renegade_arbitrum_client::constants::Chain;
@@ -34,6 +35,7 @@ use reqwest::StatusCode;
 use serde_json::json;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use store::BundleStore;
 use thiserror::Error;
 use tracing::{error, info};
 use uuid::Uuid;
@@ -212,19 +214,24 @@ async fn main() {
     .await
     .expect("failed to create arbitrum client");
 
+    // Create the shared in-memory bundle store
+    let bundle_store = Arc::new(BundleStore::new());
+
     // Start the on-chain event listener
     let chain_listener_config = OnChainEventListenerConfig {
         websocket_addr: args.eth_websocket_addr.clone(),
         arbitrum_client: arbitrum_client.clone(),
     };
-    let mut chain_listener = OnChainEventListener::new(chain_listener_config)
+    let mut chain_listener = OnChainEventListener::new(chain_listener_config, bundle_store.clone())
         .expect("failed to build on-chain event listener");
     chain_listener.start().expect("failed to start on-chain event listener");
     chain_listener.watch();
 
     // Create the server
     let server = Arc::new(
-        Server::new(args, &system_clock, arbitrum_client).await.expect("Failed to create server"),
+        Server::new(args, &system_clock, arbitrum_client, bundle_store)
+            .await
+            .expect("Failed to create server"),
     );
 
     // --- Management Routes --- //

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -228,11 +228,10 @@ async fn main() {
     chain_listener.watch();
 
     // Create the server
-    let server = Arc::new(
-        Server::new(args, &system_clock, arbitrum_client, bundle_store)
-            .await
-            .expect("Failed to create server"),
-    );
+    let server_inner = Server::new(args, &system_clock, arbitrum_client, bundle_store)
+        .await
+        .expect("Failed to create server");
+    let server = Arc::new(server_inner);
 
     // --- Management Routes --- //
 

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -110,7 +110,7 @@ pub struct Server {
     /// in whole units of USDC
     pub min_sponsored_order_quote_amount: f64,
     /// The bundle store
-    pub bundle_store: Arc<BundleStore>,
+    pub bundle_store: BundleStore,
 }
 
 impl Server {
@@ -119,7 +119,7 @@ impl Server {
         args: Cli,
         system_clock: &SystemClock,
         arbitrum_client: ArbitrumClient,
-        bundle_store: Arc<BundleStore>,
+        bundle_store: BundleStore,
     ) -> Result<Self, AuthServerError> {
         configure_telemtry_from_args(&args)?;
         setup_token_mapping(&args).await?;

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -14,6 +14,7 @@ mod redis_queries;
 use std::{iter, sync::Arc, time::Duration};
 
 use crate::server::price_reporter_client::PriceReporterClient;
+use crate::store::BundleStore;
 use crate::{
     error::AuthServerError,
     models::ApiKey,
@@ -108,6 +109,8 @@ pub struct Server {
     /// The minimum order quote amount for which gas sponsorship is allowed,
     /// in whole units of USDC
     pub min_sponsored_order_quote_amount: f64,
+    /// The bundle store
+    pub bundle_store: Arc<BundleStore>,
 }
 
 impl Server {
@@ -116,6 +119,7 @@ impl Server {
         args: Cli,
         system_clock: &SystemClock,
         arbitrum_client: ArbitrumClient,
+        bundle_store: Arc<BundleStore>,
     ) -> Result<Self, AuthServerError> {
         configure_telemtry_from_args(&args)?;
         setup_token_mapping(&args).await?;
@@ -180,6 +184,7 @@ impl Server {
             price_reporter_client,
             gas_cost_sampler,
             min_sponsored_order_quote_amount: args.min_sponsored_order_quote_amount,
+            bundle_store,
         })
     }
 

--- a/auth/auth-server/src/store/helpers.rs
+++ b/auth/auth-server/src/store/helpers.rs
@@ -5,7 +5,23 @@ use renegade_constants::Scalar;
 
 use crate::error::AuthServerError;
 
-/// Generates a bundle ID from the match bundle
+/// Generates a deterministic bundle ID by hashing together the nullifier
+/// and the match amounts.
+///
+/// This approach is prone to collisions because there is no single unique
+/// customer identifier shared by both the on‑chain listener and the HTTP
+/// handler. Without a common customer identifier present in both domains that
+/// can be incorporated into the hash, it is possible for different customers to
+/// produce the same bundle ID.
+///
+/// Collisions have the following consequences, which are deemed acceptable:
+/// - Same‑customer collision: Metrics and rate‑limit accounting remain correct
+///   as the collision occurs within the same customer context.
+/// - Different‑customer collision: Metrics or rate‑limit allowance may be
+///   attributed to the wrong customer.
+///
+/// We could use the proof stored in calldata to uniquely identify each bundle,
+/// but this approach would break as soon as a bundle cache is introduced.
 pub fn generate_bundle_id(
     match_result: &ApiExternalMatchResult,
     nullifier: &Nullifier,

--- a/auth/auth-server/src/store/helpers.rs
+++ b/auth/auth-server/src/store/helpers.rs
@@ -1,0 +1,20 @@
+use alloy_primitives::{hex, keccak256};
+use renegade_api::http::external_match::ApiExternalMatchResult;
+use renegade_circuit_types::wallet::Nullifier;
+use renegade_constants::Scalar;
+
+use crate::error::AuthServerError;
+
+/// Generates a bundle ID from the match bundle
+pub fn generate_bundle_id(
+    match_result: &ApiExternalMatchResult,
+    nullifier: &Nullifier,
+) -> Result<String, AuthServerError> {
+    let quote_amt = match_result.quote_amount;
+    let base_amt = match_result.base_amount;
+
+    let mut bytes = nullifier.to_bytes_be();
+    bytes.extend(Scalar::from(quote_amt).to_bytes_be());
+    bytes.extend(Scalar::from(base_amt).to_bytes_be());
+    Ok(hex::encode(keccak256::<&[u8]>(&bytes)))
+}

--- a/auth/auth-server/src/store/mod.rs
+++ b/auth/auth-server/src/store/mod.rs
@@ -1,0 +1,92 @@
+use std::collections::{HashMap, VecDeque};
+
+use auth_server_api::GasSponsorshipInfo;
+use renegade_circuit_types::wallet::Nullifier;
+use tokio::sync::Mutex;
+
+use crate::error::AuthServerError;
+
+pub mod helpers;
+
+#[derive(Clone)]
+pub struct BundleContext {
+    /// The key description that settled the bundle
+    pub key_description: String,
+    /// The request ID of the bundle
+    pub request_id: String,
+    /// The SDK version that requested the bundle
+    pub sdk_version: String,
+    /// The gas sponsorship info for the bundle
+    pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
+    /// Whether the bundle was sponsored
+    pub is_sponsored: bool,
+    /// The nullifier that was nullified as a result of the bundle being settled
+    pub nullifier: Nullifier,
+}
+
+struct StoreInner {
+    /// bundle_id → context
+    by_id: HashMap<String, BundleContext>,
+    /// nullifier → queue of bundle_ids
+    /// TODO: Maybe use String instead of Nullifier
+    /// TODO: Is VecDeque the best data structure here?
+    by_null: HashMap<Nullifier, VecDeque<String>>,
+}
+
+pub struct BundleStore {
+    inner: Mutex<StoreInner>,
+}
+
+impl BundleStore {
+    pub fn new() -> Self {
+        Self { inner: Mutex::new(StoreInner { by_id: HashMap::new(), by_null: HashMap::new() }) }
+    }
+}
+
+impl BundleStore {
+    /// We use `lock().await` so writers queue up on the Mutex
+    /// *behind* any in‐flight writer, but *ahead* of any try_lock readers.
+    /// This guarantees that writes never block behind cleanup or read.
+    pub async fn write(
+        &self,
+        bundle_id: String,
+        ctx: BundleContext,
+    ) -> Result<(), AuthServerError> {
+        let mut inner = self.inner.lock().await;
+        inner.by_id.insert(bundle_id.clone(), ctx.clone());
+        inner.by_null.entry(ctx.nullifier).or_insert_with(VecDeque::new).push_back(bundle_id);
+        Ok(())
+    }
+
+    /// We use `try_lock()` + `yield_now()` instead of `lock().await`
+    /// so that if a writer is pending or holding the lock, we
+    /// never suspend the writer.  `try_lock()` fails immediately,
+    /// and we `yield_now()` to give the executor a chance to schedule
+    /// the writer next.  Once the lock is free, we grab it instantly.
+    pub async fn read(&self, bundle_id: &str) -> Result<Option<BundleContext>, AuthServerError> {
+        loop {
+            if let Ok(idx) = self.inner.try_lock() {
+                return Ok(idx.by_id.get(bundle_id).cloned());
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// Remove a nullifier and all associated bundle ids from the store
+    ///
+    /// Because each nullifier queue is ≤20 entries, we can safely
+    /// do a single `lock().await` and perform O(1 + k) pops/deletes
+    /// without noticeable writer blocking.  If this ever grows,
+    /// we'd switch to try_lock+yield similar to `read`.
+    pub async fn _cleanup_by_nullifier(
+        &self,
+        nullifier: &Nullifier,
+    ) -> Result<(), AuthServerError> {
+        let mut inner = self.inner.lock().await;
+        let bundle_ids = inner.by_null.remove(nullifier).unwrap_or_default();
+        for bundle_id in bundle_ids {
+            inner.by_id.remove(&bundle_id);
+        }
+        Ok(())
+    }
+}

--- a/auth/auth-server/src/store/mod.rs
+++ b/auth/auth-server/src/store/mod.rs
@@ -27,7 +27,11 @@ pub struct BundleContext {
 }
 
 struct StoreInner {
+    // The mapping from bundle ID to bundle context
     by_id: HashMap<String, BundleContext>,
+    // The mapping from nullifier to bundle IDs
+    //
+    // This is used to efficiently cleanup the store when a nullifier is spent
     by_null: HashMap<Nullifier, Vec<String>>,
 }
 

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -327,7 +327,7 @@ pub(crate) async fn await_settlement(
 /// ways:
 /// 1. As a standard atomic match settle call
 /// 2. As a match settle with receiver call
-fn extract_nullifier_from_match_bundle(
+pub fn extract_nullifier_from_match_bundle(
     match_bundle: &AtomicMatchApiBundle,
 ) -> Result<Nullifier, AuthServerError> {
     let tx_data = match_bundle


### PR DESCRIPTION
### Purpose
This PR adds a bundle store so the asynchronous `chain-events` worker can access API level details about a bundle when processing settlement. 

We maintain two in-memory maps:
-  bundle IDs -> bundle contexts
-  nullifier -> bundle IDs

Our workload prioritizes writes from the HTTP handler and only ever has one reader that is not time-sensitive, so we use a Mutex to guarantee atomic writes (over something like a RwLock). While this does mean all operations are serialized, the nature of our workload means we are okay with reads queuing up behind writes.

We remove bundle contexts on `NullifierSpent` to prevent unbounded memory growth. By indexing nullifier -> bundle_id, each cleanup holds the lock for at most O(M) (M = `MAX_CONCURRENT_TASKS`) instead of O(N).

### Todo
- [ ] Bundle IDs are derived from the nullifier and amounts parameterizing the match. This should be improved, as it allows for collisions between two bundles with the exact same {base | quote} {mint | amount}. 

### Testing
- [ ] Tested locally
- [ ] Test in testnet