### PR TITLE
auth-server: handle gas sponsorship when deriving bundle id

### DIFF
--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -25,10 +25,7 @@ use warp::{reject::Rejection, reply::Reply};
 use super::helpers::{generate_quote_uuid, overwrite_response_body};
 use super::Server;
 use crate::error::AuthServerError;
-use crate::store::{helpers::generate_bundle_id, BundleContext};
-use crate::telemetry::helpers::{
-    calculate_implied_price, extract_nullifier_from_match_bundle, record_relayer_request_500,
-};
+use crate::telemetry::helpers::{calculate_implied_price, record_relayer_request_500};
 use crate::telemetry::labels::{GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG};
 use crate::telemetry::{
     helpers::{
@@ -41,6 +38,7 @@ use crate::telemetry::{
 };
 
 mod gas_sponsorship;
+mod settlement;
 pub use gas_sponsorship::contract_interaction::sponsorAtomicMatchSettleWithRefundOptionsCall;
 
 // -------------
@@ -165,6 +163,10 @@ impl Server {
             self.maybe_apply_gas_sponsorship_to_match_response(res.body(), gas_sponsorship_info)?;
         overwrite_response_body(&mut res, sponsored_match_resp.clone())?;
 
+        // Record the bundle context in the store
+        let bundle_id =
+            self.write_bundle_context(&sponsored_match_resp, &headers, key_desc.clone()).await?;
+
         let server_clone = self.clone();
         tokio::spawn(async move {
             if let Err(e) = server_clone
@@ -173,6 +175,7 @@ impl Server {
                     &req,
                     &headers,
                     &sponsored_match_resp,
+                    Some(bundle_id),
                 )
                 .await
             {
@@ -235,6 +238,11 @@ impl Server {
 
         overwrite_response_body(&mut resp, sponsored_match_resp.clone())?;
 
+        // Record the bundle context in the store
+        let bundle_id = self
+            .write_bundle_context(&sponsored_match_resp, &headers, key_description.clone())
+            .await?;
+
         // Watch the bundle for settlement
         let server_clone = self.clone();
         tokio::spawn(async move {
@@ -244,6 +252,7 @@ impl Server {
                     &external_match_req,
                     &headers,
                     &sponsored_match_resp,
+                    bundle_id,
                 )
                 .await
             {
@@ -443,11 +452,12 @@ impl Server {
         req: &AssembleExternalMatchRequest,
         headers: &HeaderMap,
         resp: &SponsoredMatchResponse,
+        request_id: Option<String>,
     ) -> Result<(), AuthServerError> {
         let original_order = &req.signed_quote.quote.order;
         let updated_order = req.updated_order.as_ref().unwrap_or(original_order);
 
-        let request_id = uuid::Uuid::new_v4().to_string();
+        let request_id = request_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let sdk_version = get_sdk_version(headers);
         if req.updated_order.is_some() {
             log_updated_order(&key, original_order, updated_order, &request_id, &sdk_version);
@@ -472,13 +482,14 @@ impl Server {
         req: &ExternalMatchRequest,
         headers: &HeaderMap,
         resp: &SponsoredMatchResponse,
+        request_id: String,
     ) -> Result<(), AuthServerError> {
         let sdk_version = get_sdk_version(headers);
         self.handle_bundle_response(
             key,
             &req.external_order,
             resp,
-            None,
+            Some(request_id),
             "request-external-match",
             true, // shared
             sdk_version,
@@ -508,23 +519,6 @@ impl Server {
         // Note: if sponsored in-kind w/ refund going to the receiver,
         // the amounts in the match bundle will have been updated
         let SponsoredMatchResponse { match_bundle, is_sponsored, gas_sponsorship_info } = resp;
-
-        // Record the bundle context in the store
-        let nullifier = extract_nullifier_from_match_bundle(match_bundle)?;
-        let bundle_id = generate_bundle_id(&match_bundle.match_result, &nullifier)?;
-
-        let bundle_ctx = BundleContext {
-            key_description: key.clone(),
-            request_id: bundle_id.clone(),
-            sdk_version: sdk_version.clone(),
-            gas_sponsorship_info: gas_sponsorship_info.clone(),
-            is_sponsored: *is_sponsored,
-            nullifier,
-        };
-        let bundle_store = self.bundle_store.clone();
-        if let Err(e) = bundle_store.write(bundle_id, bundle_ctx).await {
-            tracing::error!("bundle context write failed: {}", e);
-        }
 
         let labels = vec![
             (KEY_DESCRIPTION_METRIC_TAG.to_string(), key.clone()),

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -175,7 +175,7 @@ impl Server {
                     &req,
                     &headers,
                     &sponsored_match_resp,
-                    Some(bundle_id),
+                    bundle_id,
                 )
                 .await
             {
@@ -452,12 +452,11 @@ impl Server {
         req: &AssembleExternalMatchRequest,
         headers: &HeaderMap,
         resp: &SponsoredMatchResponse,
-        request_id: Option<String>,
+        request_id: String,
     ) -> Result<(), AuthServerError> {
         let original_order = &req.signed_quote.quote.order;
         let updated_order = req.updated_order.as_ref().unwrap_or(original_order);
 
-        let request_id = request_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let sdk_version = get_sdk_version(headers);
         if req.updated_order.is_some() {
             log_updated_order(&key, original_order, updated_order, &request_id, &sdk_version);

--- a/auth/auth-server/src/server/handle_external_match/settlement.rs
+++ b/auth/auth-server/src/server/handle_external_match/settlement.rs
@@ -38,8 +38,7 @@ impl Server {
         };
 
         // Write to bundle store
-        let bundle_store = self.bundle_store.clone();
-        if let Err(e) = bundle_store.write(bundle_id.clone(), bundle_ctx).await {
+        if let Err(e) = self.bundle_store.write(bundle_id.clone(), bundle_ctx).await {
             tracing::error!("bundle context write failed: {}", e);
         }
 
@@ -54,15 +53,11 @@ impl Server {
         &self,
         sponsored_match: &SponsoredMatchResponse,
     ) -> ApiExternalMatchResult {
-        if sponsored_match.is_sponsored {
-            if let Some(gas_info) = sponsored_match.gas_sponsorship_info.as_ref() {
-                self.apply_gas_sponsorship_adjustment(
-                    &sponsored_match.match_bundle.match_result,
-                    gas_info,
-                )
-            } else {
-                unreachable!("gas sponsorship info is required for sponsored matches");
-            }
+        if let Some(gas_info) = sponsored_match.gas_sponsorship_info.as_ref() {
+            self.apply_gas_sponsorship_adjustment(
+                &sponsored_match.match_bundle.match_result,
+                gas_info,
+            )
         } else {
             sponsored_match.match_bundle.match_result.clone()
         }

--- a/auth/auth-server/src/server/handle_external_match/settlement.rs
+++ b/auth/auth-server/src/server/handle_external_match/settlement.rs
@@ -1,0 +1,96 @@
+use auth_server_api::{GasSponsorshipInfo, SponsoredMatchResponse}; // Added GasSponsorshipInfo
+use http::HeaderMap;
+use renegade_api::http::external_match::ApiExternalMatchResult;
+use renegade_circuit_types::order::OrderSide;
+
+use super::{get_sdk_version, Server};
+use crate::error::AuthServerError;
+use crate::store::{helpers::generate_bundle_id, BundleContext};
+use crate::telemetry::helpers::extract_nullifier_from_match_bundle;
+
+impl Server {
+    /// Write the bundle context to the store, handling gas sponsorship if
+    /// necessary
+    /// Returns the bundle ID
+    pub async fn write_bundle_context(
+        &self,
+        sponsored_match: &SponsoredMatchResponse,
+        headers: &HeaderMap,
+        key: String,
+    ) -> Result<String, AuthServerError> {
+        // Extract the nullifier from the original match bundle
+        let nullifier = extract_nullifier_from_match_bundle(&sponsored_match.match_bundle)?;
+
+        // Determine the match result to derive ID, accounting for sponsorship
+        let match_result_for_id = self.get_match_result_for_id(sponsored_match);
+
+        // Generate bundle ID using the potentially adjusted match result
+        let bundle_id = generate_bundle_id(&match_result_for_id, &nullifier)?;
+
+        // Create bundle context
+        let bundle_ctx = BundleContext {
+            key_description: key.clone(),
+            request_id: bundle_id.clone(),
+            sdk_version: get_sdk_version(headers),
+            gas_sponsorship_info: sponsored_match.gas_sponsorship_info.clone(),
+            is_sponsored: sponsored_match.is_sponsored,
+            nullifier,
+        };
+
+        // Write to bundle store
+        let bundle_store = self.bundle_store.clone();
+        if let Err(e) = bundle_store.write(bundle_id.clone(), bundle_ctx).await {
+            tracing::error!("bundle context write failed: {}", e);
+        }
+
+        Ok(bundle_id)
+    }
+
+    /// Determines the appropriate `ApiExternalMatchResult` to use for bundle ID
+    /// generation. If the match is sponsored and info is present, it returns
+    /// a result adjusted for the gas refund; otherwise, it returns the
+    /// original match result.
+    fn get_match_result_for_id(
+        &self,
+        sponsored_match: &SponsoredMatchResponse,
+    ) -> ApiExternalMatchResult {
+        if sponsored_match.is_sponsored {
+            if let Some(gas_info) = sponsored_match.gas_sponsorship_info.as_ref() {
+                self.apply_gas_sponsorship_adjustment(
+                    &sponsored_match.match_bundle.match_result,
+                    gas_info,
+                )
+            } else {
+                unreachable!("gas sponsorship info is required for sponsored matches");
+            }
+        } else {
+            sponsored_match.match_bundle.match_result.clone()
+        }
+    }
+
+    /// Returns a new match result with gas sponsorship amount subtracted from
+    /// the appropriate side, if the refund is not native ETH.
+    fn apply_gas_sponsorship_adjustment(
+        &self,
+        original_result: &ApiExternalMatchResult,
+        gas_sponsorship_info: &GasSponsorshipInfo,
+    ) -> ApiExternalMatchResult {
+        let mut result = original_result.clone();
+
+        // If the refund is in native ETH, no adjustment needed for the match result
+        // amounts
+        if gas_sponsorship_info.refund_native_eth {
+            return result;
+        }
+
+        match result.direction {
+            OrderSide::Buy => {
+                result.base_amount -= gas_sponsorship_info.refund_amount;
+            },
+            OrderSide::Sell => {
+                result.quote_amount -= gas_sponsorship_info.refund_amount;
+            },
+        }
+        result
+    }
+}

--- a/auth/auth-server/src/store/mod.rs
+++ b/auth/auth-server/src/store/mod.rs
@@ -10,7 +10,7 @@ use crate::error::AuthServerError;
 pub mod helpers;
 
 /// Context of an external match bundle
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BundleContext {
     /// The key description that settled the bundle
     pub key_description: String,


### PR DESCRIPTION
### Purpose
This PR fixes bundle ID generation to factor in gas sponsorship, since the `chain-events` worker will derive the bundle ID from amounts net of gas sponsorship, the HTTP handler should too (unless the refund is in native ETH). This bundle ID is now used as the `request_id`.

We also write to the bundle store as early as possible to ensure post-settlement tasks can occur.

### Testing
- [x] Tested locally by running each example in `rust-sdk` and ensuring bundle contexts are successfully retrieved.