### PR TITLE
auth-server: migrate post settlement metric recording to chain events

### DIFF
--- a/auth/auth-server/src/chain_events/mod.rs
+++ b/auth/auth-server/src/chain_events/mod.rs
@@ -5,4 +5,5 @@
 //!   related to settlement volume
 mod error;
 pub mod listener;
+mod tasks;
 pub mod worker;

--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -1,0 +1,49 @@
+use renegade_api::http::external_match::ApiExternalMatchResult;
+
+use crate::telemetry::{
+    helpers::{extend_labels_with_base_asset, record_endpoint_metrics, record_volume_with_tags},
+    labels::{
+        EXTERNAL_MATCH_SETTLED_BASE_VOLUME, EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME,
+        GAS_SPONSORED_METRIC_TAG, KEY_DESCRIPTION_METRIC_TAG, NUM_EXTERNAL_MATCH_REQUESTS,
+        REQUEST_ID_METRIC_TAG, SDK_VERSION_METRIC_TAG, SETTLEMENT_STATUS_TAG,
+    },
+};
+use crate::{chain_events::listener::OnChainEventListenerExecutor, store::BundleContext};
+
+impl OnChainEventListenerExecutor {
+    /// Record settlement metrics for a bundle
+    pub fn record_settlement_metrics(
+        &self,
+        ctx: &BundleContext,
+        match_result: &ApiExternalMatchResult,
+    ) {
+        let labels = self.get_labels(ctx);
+        record_endpoint_metrics(&match_result.base_mint, NUM_EXTERNAL_MATCH_REQUESTS, &labels);
+
+        record_volume_with_tags(
+            &match_result.base_mint,
+            match_result.base_amount,
+            EXTERNAL_MATCH_SETTLED_BASE_VOLUME,
+            &labels,
+        );
+
+        let labels = extend_labels_with_base_asset(&match_result.base_mint, labels);
+        record_volume_with_tags(
+            &match_result.quote_mint,
+            match_result.quote_amount,
+            EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME,
+            &labels,
+        );
+    }
+
+    /// Get the labels for a bundle
+    fn get_labels(&self, ctx: &BundleContext) -> Vec<(String, String)> {
+        vec![
+            (KEY_DESCRIPTION_METRIC_TAG.to_string(), ctx.key_description.clone()),
+            (REQUEST_ID_METRIC_TAG.to_string(), ctx.request_id.clone()),
+            (GAS_SPONSORED_METRIC_TAG.to_string(), ctx.is_sponsored.to_string()),
+            (SDK_VERSION_METRIC_TAG.to_string(), ctx.sdk_version.clone()),
+            (SETTLEMENT_STATUS_TAG.to_string(), "true".to_string()),
+        ]
+    }
+}

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -556,7 +556,7 @@ impl Server {
         }
 
         // Record metrics
-        record_external_match_metrics(order, match_bundle, &labels, did_settle)?;
+        record_external_match_metrics(order, match_bundle, &labels)?;
 
         Ok(())
     }

--- a/auth/auth-server/src/store/mod.rs
+++ b/auth/auth-server/src/store/mod.rs
@@ -19,6 +19,7 @@ pub struct BundleContext {
     /// The SDK version that requested the bundle
     pub sdk_version: String,
     /// The gas sponsorship info for the bundle
+    #[allow(dead_code)]
     pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
     /// Whether the bundle was sponsored
     pub is_sponsored: bool,


### PR DESCRIPTION
### Purpose
This PR migrates settlement metrics recording from the HTTP handler to the async `chain-events` worker.

### Testing
- [ ] Tested locally
- [ ] Test in testnet