### PR TITLE
auth-server: migrate gas sponsorship to listener task

### DIFF
--- a/auth/auth-server/src/chain_events/error.rs
+++ b/auth/auth-server/src/chain_events/error.rs
@@ -28,6 +28,12 @@ impl OnChainEventListenerError {
     pub fn arbitrum<T: ToString>(e: T) -> Self {
         OnChainEventListenerError::Arbitrum(e.to_string())
     }
+
+    /// Create a new auth server error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn auth_server<T: ToString>(e: T) -> Self {
+        OnChainEventListenerError::AuthServer(e.to_string())
+    }
 }
 
 impl Display for OnChainEventListenerError {
@@ -57,6 +63,6 @@ impl From<alloy::sol_types::Error> for OnChainEventListenerError {
 
 impl From<AuthServerError> for OnChainEventListenerError {
     fn from(err: AuthServerError) -> Self {
-        Self::AuthServer(err.to_string())
+        OnChainEventListenerError::auth_server(err)
     }
 }

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -211,12 +211,17 @@ impl OnChainEventListenerExecutor {
             let bundle_id = generate_bundle_id(&match_result, &nullifier).unwrap();
             let bundle_ctx = self.bundle_store.read(&bundle_id).await?;
             if let Some(bundle_ctx) = bundle_ctx {
-                self.record_settlement_metrics(&bundle_ctx, &match_result);
+                // Increase rate limit
                 self.add_bundle_rate_limit_token(
                     bundle_ctx.key_description.clone(),
                     bundle_ctx.shared,
                 )
                 .await;
+
+                // Record settlement metrics
+                self.record_settlement_metrics(&bundle_ctx, &match_result);
+
+                // Record sponsorship metrics
                 if let Some(gas_sponsorship_info) = &bundle_ctx.gas_sponsorship_info {
                     self.record_settled_match_sponsorship(
                         &bundle_ctx,

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -1,7 +1,7 @@
 //! Defines the core implementation of the on-chain event listener
 //! Much of the implementation is borrowed from https://github.com/renegade-fi/renegade/blob/main/workers/chain-events/src/listener.rs
 
-use std::thread::JoinHandle;
+use std::{sync::Arc, thread::JoinHandle};
 
 use alloy::{
     providers::{DynProvider, Provider, ProviderBuilder, WsConnect},
@@ -23,7 +23,10 @@ use renegade_circuit_types::{
 use renegade_crypto::fields::u256_to_scalar;
 use tracing::{error, info};
 
-use crate::server::rate_limiter::AuthServerRateLimiter;
+use crate::server::{
+    gas_estimation::gas_cost_sampler::GasCostSampler, price_reporter_client::PriceReporterClient,
+    rate_limiter::AuthServerRateLimiter,
+};
 use crate::store::{helpers::generate_bundle_id, BundleStore};
 
 use super::error::OnChainEventListenerError;
@@ -84,6 +87,10 @@ pub struct OnChainEventListenerExecutor {
     bundle_store: BundleStore,
     /// The rate limiter
     pub(crate) rate_limiter: AuthServerRateLimiter,
+    /// The price reporter client with WebSocket streaming support
+    pub(crate) price_reporter_client: Arc<PriceReporterClient>,
+    /// The gas cost sampler
+    pub(crate) gas_cost_sampler: Arc<GasCostSampler>,
 }
 
 impl OnChainEventListenerExecutor {
@@ -92,8 +99,10 @@ impl OnChainEventListenerExecutor {
         config: OnChainEventListenerConfig,
         bundle_store: BundleStore,
         rate_limiter: AuthServerRateLimiter,
+        price_reporter_client: Arc<PriceReporterClient>,
+        gas_cost_sampler: Arc<GasCostSampler>,
     ) -> Self {
-        Self { config, bundle_store, rate_limiter }
+        Self { config, bundle_store, rate_limiter, price_reporter_client, gas_cost_sampler }
     }
 
     /// Shorthand for fetching a reference to the arbitrum client
@@ -203,8 +212,19 @@ impl OnChainEventListenerExecutor {
             let bundle_ctx = self.bundle_store.read(&bundle_id).await?;
             if let Some(bundle_ctx) = bundle_ctx {
                 self.record_settlement_metrics(&bundle_ctx, &match_result);
-                self.add_bundle_rate_limit_token(bundle_ctx.key_description, bundle_ctx.shared)
-                    .await;
+                self.add_bundle_rate_limit_token(
+                    bundle_ctx.key_description.clone(),
+                    bundle_ctx.shared,
+                )
+                .await;
+                if let Some(gas_sponsorship_info) = &bundle_ctx.gas_sponsorship_info {
+                    self.record_settled_match_sponsorship(
+                        &bundle_ctx,
+                        &match_result,
+                        gas_sponsorship_info,
+                    )
+                    .await?;
+                }
             }
         }
         Ok(())

--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -1,14 +1,38 @@
+use auth_server_api::GasSponsorshipInfo;
+use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use renegade_api::http::external_match::ApiExternalMatchResult;
+use renegade_circuit_types::order::OrderSide;
+use renegade_common::types::token::Token;
 
-use crate::telemetry::{
-    helpers::{extend_labels_with_base_asset, record_endpoint_metrics, record_volume_with_tags},
-    labels::{
-        EXTERNAL_MATCH_SETTLED_BASE_VOLUME, EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME,
-        GAS_SPONSORED_METRIC_TAG, KEY_DESCRIPTION_METRIC_TAG, NUM_EXTERNAL_MATCH_REQUESTS,
-        REQUEST_ID_METRIC_TAG, SDK_VERSION_METRIC_TAG, SETTLEMENT_STATUS_TAG,
+use crate::{chain_events::listener::OnChainEventListenerExecutor, store::BundleContext};
+use crate::{
+    error::AuthServerError,
+    telemetry::{
+        helpers::{
+            extend_labels_with_base_asset, record_endpoint_metrics, record_volume_with_tags,
+        },
+        labels::{
+            EXTERNAL_MATCH_SETTLED_BASE_VOLUME, EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME,
+            GAS_SPONSORED_METRIC_TAG, GAS_SPONSORSHIP_VALUE, KEY_DESCRIPTION_METRIC_TAG,
+            L1_COST_PER_BYTE_TAG, L2_BASE_FEE_TAG, NUM_EXTERNAL_MATCH_REQUESTS, REFUND_AMOUNT_TAG,
+            REFUND_ASSET_TAG, REMAINING_TIME_TAG, REMAINING_VALUE_TAG, REQUEST_ID_METRIC_TAG,
+            SDK_VERSION_METRIC_TAG, SETTLEMENT_STATUS_TAG,
+        },
     },
 };
-use crate::{chain_events::listener::OnChainEventListenerExecutor, store::BundleContext};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The ticker for native ETH
+const ETH_TICKER: &str = "ETH";
+
+/// The ticker for WETH
+const WETH_TICKER: &str = "WETH";
+
+/// The error message emitted when a refund asset ticker cannot be found
+const REFUND_ASSET_TICKER_ERROR_MSG: &str = "failed to get refund asset ticker";
 
 impl OnChainEventListenerExecutor {
     /// Record settlement metrics for a bundle
@@ -39,6 +63,113 @@ impl OnChainEventListenerExecutor {
     /// Increment the token balance for a given API user
     pub async fn add_bundle_rate_limit_token(&self, key_description: String, shared: bool) {
         self.rate_limiter.add_bundle_token(key_description, shared).await;
+    }
+
+    /// Record the gas sponsorship rate limit & metrics for a given settled
+    /// match
+    pub async fn record_settled_match_sponsorship(
+        &self,
+        ctx: &BundleContext,
+        match_result: &ApiExternalMatchResult,
+        gas_sponsorship_info: &GasSponsorshipInfo,
+    ) -> Result<(), AuthServerError> {
+        let refund_asset = if gas_sponsorship_info.refund_native_eth {
+            Token::from_ticker(WETH_TICKER)
+        } else {
+            match match_result.direction {
+                OrderSide::Buy => Token::from_addr(&match_result.base_mint),
+                OrderSide::Sell => Token::from_addr(&match_result.quote_mint),
+            }
+        };
+        let nominal_price =
+            self.price_reporter_client.get_nominal_price(&refund_asset.get_addr()).await?;
+
+        let nominal_amount = BigDecimal::from_u128(gas_sponsorship_info.refund_amount)
+            .expect("u128 should be representable as BigDecimal");
+
+        let value_bigdecimal = nominal_amount * nominal_price;
+
+        let value = value_bigdecimal.to_f64().ok_or(AuthServerError::gas_sponsorship(
+            "failed to convert gas sponsorship value to f64",
+        ))?;
+
+        self.rate_limiter.record_gas_sponsorship(ctx.key_description.clone(), value).await;
+
+        self.record_gas_sponsorship_metrics(
+            value,
+            gas_sponsorship_info,
+            match_result,
+            ctx.key_description.clone(),
+            ctx.request_id.clone(),
+            ctx.sdk_version.clone(),
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    /// Record the dollar value of sponsored gas for a settled match
+    async fn record_gas_sponsorship_metrics(
+        &self,
+        gas_sponsorship_value: f64,
+        gas_sponsorship_info: &GasSponsorshipInfo,
+        match_result: &ApiExternalMatchResult,
+        key: String,
+        request_id: String,
+        sdk_version: String,
+    ) -> Result<(), AuthServerError> {
+        // Extra sponsorship metadata:
+        // - Remaining value in user's rate limit bucket
+        // - Remaining time in user's rate limit bucket
+        // - Refund asset
+        // - Refund amount (whole units)
+        // - Gas prices (L1 & L2)
+
+        let (remaining_value, remaining_time) =
+            self.rate_limiter.remaining_gas_sponsorship_value_and_time(key.clone()).await;
+
+        let (refund_asset_ticker, refund_amount_whole) = if gas_sponsorship_info.refund_native_eth {
+            // WETH uses the same decimals as ETH, so we use it to obtain the refund amount
+            // in whole units
+            let weth = Token::from_ticker(WETH_TICKER);
+            let refund_amount_whole = weth.convert_to_decimal(gas_sponsorship_info.refund_amount);
+            (ETH_TICKER.to_string(), refund_amount_whole)
+        } else {
+            let refund_asset = match match_result.direction {
+                OrderSide::Buy => Token::from_addr(&match_result.base_mint),
+                OrderSide::Sell => Token::from_addr(&match_result.quote_mint),
+            };
+            let refund_amount_whole =
+                refund_asset.convert_to_decimal(gas_sponsorship_info.refund_amount);
+
+            let refund_asset_ticker = refund_asset
+                .get_ticker()
+                .ok_or(AuthServerError::gas_cost_sampler(REFUND_ASSET_TICKER_ERROR_MSG))?;
+
+            (refund_asset_ticker, refund_amount_whole)
+        };
+
+        let (_, l2_base_fee, l1_cost_per_byte) = self
+            .gas_cost_sampler
+            .sample_gas_prices()
+            .await
+            .map_err(AuthServerError::gas_sponsorship)?;
+
+        let labels = vec![
+            (KEY_DESCRIPTION_METRIC_TAG.to_string(), key),
+            (REQUEST_ID_METRIC_TAG.to_string(), request_id),
+            (SDK_VERSION_METRIC_TAG.to_string(), sdk_version),
+            (REMAINING_VALUE_TAG.to_string(), remaining_value.to_string()),
+            (REMAINING_TIME_TAG.to_string(), remaining_time.as_secs().to_string()),
+            (REFUND_ASSET_TAG.to_string(), refund_asset_ticker),
+            (REFUND_AMOUNT_TAG.to_string(), refund_amount_whole.to_string()),
+            (L2_BASE_FEE_TAG.to_string(), l2_base_fee.to_string()),
+            (L1_COST_PER_BYTE_TAG.to_string(), l1_cost_per_byte.to_string()),
+        ];
+
+        metrics::gauge!(GAS_SPONSORSHIP_VALUE, &labels).set(gas_sponsorship_value);
+
+        Ok(())
     }
 
     /// Get the labels for a bundle

--- a/auth/auth-server/src/chain_events/worker.rs
+++ b/auth/auth-server/src/chain_events/worker.rs
@@ -1,9 +1,15 @@
 //! The worker implementation for the on-chain event listener
-use std::thread::Builder;
+use std::{sync::Arc, thread::Builder};
 use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::error;
 
-use crate::{server::rate_limiter::AuthServerRateLimiter, store::BundleStore};
+use crate::{
+    server::{
+        gas_estimation::gas_cost_sampler::GasCostSampler,
+        price_reporter_client::PriceReporterClient, rate_limiter::AuthServerRateLimiter,
+    },
+    store::BundleStore,
+};
 
 use super::{
     error::OnChainEventListenerError,
@@ -15,8 +21,16 @@ impl OnChainEventListener {
         config: OnChainEventListenerConfig,
         bundle_store: BundleStore,
         rate_limiter: AuthServerRateLimiter,
+        price_reporter_client: Arc<PriceReporterClient>,
+        gas_cost_sampler: Arc<GasCostSampler>,
     ) -> Result<Self, OnChainEventListenerError> {
-        let executor = OnChainEventListenerExecutor::new(config, bundle_store, rate_limiter);
+        let executor = OnChainEventListenerExecutor::new(
+            config,
+            bundle_store,
+            rate_limiter,
+            price_reporter_client,
+            gas_cost_sampler,
+        );
         Ok(Self { executor: Some(executor), executor_handle: None })
     }
 

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -28,9 +28,7 @@ use crate::error::AuthServerError;
 use crate::telemetry::helpers::{calculate_implied_price, record_relayer_request_500};
 use crate::telemetry::labels::{GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG};
 use crate::telemetry::{
-    helpers::{
-        await_settlement, record_endpoint_metrics, record_external_match_metrics, record_fill_ratio,
-    },
+    helpers::{record_endpoint_metrics, record_external_match_metrics, record_fill_ratio},
     labels::{
         DECIMAL_CORRECTION_FIXED_METRIC_TAG, EXTERNAL_MATCH_QUOTE_REQUEST_COUNT,
         KEY_DESCRIPTION_METRIC_TAG, REQUEST_ID_METRIC_TAG,
@@ -175,16 +173,13 @@ impl Server {
 
         let server_clone = self.clone();
         tokio::spawn(async move {
-            if let Err(e) = server_clone
-                .handle_quote_assembly_bundle_response(
-                    key_desc,
-                    &req,
-                    &headers,
-                    &sponsored_match_resp,
-                    bundle_id,
-                )
-                .await
-            {
+            if let Err(e) = server_clone.handle_quote_assembly_bundle_response(
+                key_desc,
+                &req,
+                &headers,
+                &sponsored_match_resp,
+                bundle_id,
+            ) {
                 warn!("Error handling bundle: {e}");
             };
         });
@@ -257,16 +252,13 @@ impl Server {
         // Watch the bundle for settlement
         let server_clone = self.clone();
         tokio::spawn(async move {
-            if let Err(e) = server_clone
-                .handle_direct_match_bundle_response(
-                    key_description,
-                    &external_match_req,
-                    &headers,
-                    &sponsored_match_resp,
-                    bundle_id,
-                )
-                .await
-            {
+            if let Err(e) = server_clone.handle_direct_match_bundle_response(
+                key_description,
+                &external_match_req,
+                &headers,
+                &sponsored_match_resp,
+                bundle_id,
+            ) {
                 warn!("Error handling bundle: {e}");
             };
         });
@@ -457,7 +449,7 @@ impl Server {
     // --- Bundle Tracking --- //
 
     /// Handle a bundle response from a quote assembly request
-    async fn handle_quote_assembly_bundle_response(
+    fn handle_quote_assembly_bundle_response(
         &self,
         key: String,
         req: &AssembleExternalMatchRequest,
@@ -481,11 +473,10 @@ impl Server {
             "assemble-external-match",
             sdk_version,
         )
-        .await
     }
 
     /// Handle a bundle response from a direct match request
-    async fn handle_direct_match_bundle_response(
+    fn handle_direct_match_bundle_response(
         &self,
         key: String,
         req: &ExternalMatchRequest,
@@ -502,14 +493,13 @@ impl Server {
             "request-external-match",
             sdk_version,
         )
-        .await
     }
 
     /// Record and watch a bundle that was forwarded to the client
     ///
     /// This method will await settlement and update metrics, rate limits, etc
     #[allow(clippy::too_many_arguments)]
-    async fn handle_bundle_response(
+    fn handle_bundle_response(
         &self,
         key: String,
         order: &ExternalOrder,
@@ -525,7 +515,7 @@ impl Server {
 
         // Note: if sponsored in-kind w/ refund going to the receiver,
         // the amounts in the match bundle will have been updated
-        let SponsoredMatchResponse { match_bundle, is_sponsored, gas_sponsorship_info } = resp;
+        let SponsoredMatchResponse { match_bundle, is_sponsored, .. } = resp;
 
         let labels = vec![
             (KEY_DESCRIPTION_METRIC_TAG.to_string(), key.clone()),
@@ -545,21 +535,6 @@ impl Server {
             tokio::spawn(async move {
                 quote_metrics.record_quote_comparison(&bundle_clone, &labels_clone).await;
             });
-        }
-
-        // If the bundle settles, increase the API user's a rate limit token balance
-        let did_settle = await_settlement(match_bundle, &self.arbitrum_client).await?;
-        if did_settle {
-            if let Some(gas_sponsorship_info) = gas_sponsorship_info {
-                self.record_settled_match_sponsorship(
-                    match_bundle,
-                    gas_sponsorship_info,
-                    key,
-                    request_id,
-                    sdk_version,
-                )
-                .await?;
-            }
         }
 
         // Record metrics

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -92,8 +92,6 @@ pub struct Server {
     pub api_key_cache: ApiKeyCache,
     /// The HTTP client
     pub client: Client,
-    /// The Arbitrum client
-    pub arbitrum_client: ArbitrumClient,
     /// The rate limiter
     pub rate_limiter: AuthServerRateLimiter,
     /// The quote metrics recorder
@@ -182,6 +180,8 @@ impl Server {
             chain_listener_config,
             bundle_store.clone(),
             rate_limiter.clone(),
+            price_reporter_client.clone(),
+            gas_cost_sampler.clone(),
         )
         .expect("failed to build on-chain event listener");
         chain_listener.start().expect("failed to start on-chain event listener");
@@ -196,7 +196,6 @@ impl Server {
             encryption_key,
             api_key_cache: Arc::new(RwLock::new(UnboundCache::new())),
             client: Client::new(),
-            arbitrum_client,
             rate_limiter,
             quote_metrics,
             metrics_sampling_rate: args


### PR DESCRIPTION
### Purpose
This PR migrates gas sponsorship metrics recording and rate limiting logic to the `chain-events` listener. It also deletes unused code, namely the polling method of awaiting nullifiers from the previous implementation.

### Testing
- [ ] Tested locally
- [ ] Test in testnet