### PR TITLE
funds-manager: custody_client: init rpc_shim w/ eth_accounts impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4312,6 +4312,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 name = "funds-manager"
 version = "0.1.0"
 dependencies = [
+ "alloy-json-rpc",
  "alloy-sol-types 1.0.0",
  "arbitrum-client",
  "aws-config",

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -33,6 +33,7 @@ tokio-postgres = "0.7.7"
 
 # === Blockchain Interaction === #
 alloy-sol-types = "1.0.0"
+alloy-json-rpc = "0.14.0"
 ethers = "2"
 
 # === Renegade Dependencies === #

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -4,6 +4,7 @@ pub mod gas_sponsor;
 pub mod gas_wallets;
 mod hot_wallets;
 mod queries;
+pub mod rpc_shim;
 pub mod withdraw;
 
 use aws_config::SdkConfig as AwsConfig;

--- a/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
@@ -1,0 +1,111 @@
+//! Implements an opinionated handler for Ethereum JSON-RPC requests, which
+//! can be used, for example, by EIP-1193 compliant Javascript clients.
+
+use alloy_json_rpc::{Request, Response as JsonRpcResponse, ResponsePayload, RpcError, RpcResult};
+use renegade_arbitrum_client::constants::Chain;
+use serde_json::Value;
+
+use crate::error::FundsManagerError;
+
+use super::CustodyClient;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The method name for the `eth_accounts` JSON-RPC method.
+const ETH_ACCOUNTS_METHOD: &str = "eth_accounts";
+/// The method name for the `eth_signTypedData_v4` JSON-RPC method.
+const ETH_SIGN_TYPED_DATA_V4_METHOD: &str = "eth_signTypedData_v4";
+
+/// The Fireblocks asset ID for ETH on Arbitrum mainnet
+const ARB_MAINNET_ETH_ASSET_ID: &str = "ETH-AETH";
+/// The Fireblocks asset ID for ETH on Arbitrum testnet
+const ARB_TESTNET_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
+/// The name of the Fireblocks vault custodying the Hyperliquid keypair
+const HYPERLIQUID_VAULT_NAME: &str = "Hyperliquid";
+
+/// The error message emitted when an unsupported RPC method is requested.
+const ERR_UNSUPPORTED_METHOD: &str = "Unsupported RPC method";
+/// The error message emitted when an unsupported chain is configured.
+const ERR_UNSUPPORTED_CHAIN: &str = "Unsupported chain";
+/// The error message emitted when the Hyperliquid vault is not found.
+const ERR_HYPERLIQUID_VAULT_NOT_FOUND: &str = "Hyperliquid vault not found";
+/// The error message emitted when no addresses are found for the Hyperliquid
+/// vault.
+const ERR_NO_ADDRESSES: &str = "No addresses found for Hyperliquid vault";
+
+// ---------
+// | Types |
+// ---------
+
+/// A type alias for the JSON-RPC request type.
+pub type JsonRpcRequest = Request<Value>;
+
+/// A type alias for the result type of the funds manager's JSON-RPC handler.
+/// This is generic over the success type, expects `FundsManagerError` as the
+/// custom transport error type, and expects a JSON `Value` as the RPC error
+/// response type.
+type FundsManagerRpcResult<T> = RpcResult<T, FundsManagerError, Value>;
+
+impl CustodyClient {
+    /// Handle an incoming JSON-RPC request, wrapping the result in a
+    /// `JsonRpcResponse` appropriately.
+    pub async fn handle_rpc_request(
+        &self,
+        request: JsonRpcRequest,
+    ) -> JsonRpcResponse<Value, Value> {
+        let id = request.meta.id.clone();
+        let result = self.try_handle_rpc_request(&request).await;
+
+        match result {
+            Ok(result) => JsonRpcResponse { id, payload: ResponsePayload::Success(result) },
+            Err(error) => match error.as_error_resp() {
+                Some(error_payload) => {
+                    JsonRpcResponse { id, payload: ResponsePayload::Failure(error_payload.clone()) }
+                },
+                None => JsonRpcResponse::internal_error_message(id, error.to_string().into()),
+            },
+        }
+    }
+
+    /// Handle an incoming JSON-RPC request,
+    /// validating the request and returning an arbitrary result value.
+    async fn try_handle_rpc_request(
+        &self,
+        request: &JsonRpcRequest,
+    ) -> FundsManagerRpcResult<Value> {
+        let method: &str = &request.meta.method;
+
+        match method {
+            ETH_SIGN_TYPED_DATA_V4_METHOD => todo!(),
+            ETH_ACCOUNTS_METHOD => self.handle_eth_accounts_request().await.map(Value::from),
+            _ => Err(RpcError::UnsupportedFeature(ERR_UNSUPPORTED_METHOD)),
+        }
+    }
+
+    /// Get the list of accounts managed by the custody client.
+    /// Currently, we only support RPC requests pertaining to the Hyperliquid
+    /// keypair.
+    async fn handle_eth_accounts_request(&self) -> FundsManagerRpcResult<Vec<String>> {
+        let asset_id = match self.chain {
+            Chain::Mainnet => ARB_MAINNET_ETH_ASSET_ID,
+            Chain::Testnet => ARB_TESTNET_ETH_ASSET_ID,
+            _ => return Err(RpcError::UnsupportedFeature(ERR_UNSUPPORTED_CHAIN)),
+        };
+        let hyperliquid_vault = self
+            .get_vault_account(HYPERLIQUID_VAULT_NAME)
+            .await?
+            .ok_or(FundsManagerError::fireblocks(ERR_HYPERLIQUID_VAULT_NOT_FOUND))?;
+
+        let client = self.get_fireblocks_client()?;
+        let (addresses, _rid) = client
+            .addresses(hyperliquid_vault.id, &asset_id)
+            .await
+            .map_err(FundsManagerError::from)?;
+
+        let addr = addresses.first().ok_or(FundsManagerError::fireblocks(ERR_NO_ADDRESSES))?;
+
+        Ok(vec![addr.address.clone()])
+    }
+}

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -1,5 +1,6 @@
 //! Route handlers for the funds manager
 
+use crate::custody_client::rpc_shim::JsonRpcRequest;
 use crate::custody_client::DepositWithdrawSource;
 use crate::error::ApiError;
 use crate::Server;
@@ -367,4 +368,15 @@ pub(crate) async fn withdraw_from_vault_handler(
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
     Ok(warp::reply::json(&"Withdrawal from vault to hot wallet initiated"))
+}
+
+// --- RPC --- //
+
+/// Handler for the RPC shim
+pub(crate) async fn rpc_handler(
+    req: JsonRpcRequest,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let rpc_response = server.custody_client.handle_rpc_request(req).await;
+    Ok(warp::reply::json(&rpc_response))
 }


### PR DESCRIPTION
This PR introduces the `rpc_shim` module to the funds manager's `CustodyClient`, which is responsible for handling a subset of RPC method calls with opinionated validation logic. This lets us use the funds manager as a custom RPC "transport" to implement [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)-compatible clients in libraries such as [Viem](https://viem.sh/docs/clients/transports/custom).

Our concrete use case for this is to sign `eth_signTypedData_v4` requests generated when interacting with our Hyperliquid account from a keypair custodied in Fireblocks, while applying application-specific validation logic to the incoming requests, such as: "do we really want to deposit this much into Hyperliquid?"

### Testing
- [x] The `eth_accounts` RPC method was tested by running a local funds manager, and invoking the JSON RPC request manually. I subbed out the soon-to-be-made `Hyperliquid` vault for the `Quoters` vault and confirmed that the correct address was returned.