### PR TITLE
funds-manager: custody_client: upgrade fireblocks sdk, implement typed data signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "alloy-sol-type-parser",
  "alloy-sol-types 1.0.0",
  "const-hex",
+ "derive_more 2.0.1",
  "itoa",
  "serde",
  "serde_json",
@@ -425,7 +426,7 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru 0.13.0",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project",
  "reqwest 0.12.15",
  "serde",
@@ -712,7 +713,7 @@ dependencies = [
  "derive_more 2.0.1",
  "futures",
  "futures-utils-wasm",
- "parking_lot",
+ "parking_lot 0.12.3",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1877,7 +1878,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1991,7 +1992,7 @@ checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
 dependencies = [
  "async-trait",
  "futures-util",
- "parking_lot",
+ "parking_lot 0.12.3",
  "tokio",
 ]
 
@@ -2198,6 +2199,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "borsh"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,7 +2276,7 @@ checksum = "4b7118d0221d84fada881b657c2ddb7cd55108db79c8764c9ee212c0c259b783"
 dependencies = [
  "crossbeam-channel",
  "num_cpus",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -3241,7 +3267,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -4196,24 +4222,33 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fireblocks-sdk"
-version = "0.4.3"
-source = "git+https://github.com/renegade-fi/fireblocks-sdk-rs#ec3d26dcf0f22cf17e6429de8a64e4ca4a794220"
+version = "2.0.1"
+source = "git+https://github.com/renegade-fi/fireblocks-sdk-rs.git?branch=v2.0.1#eea687c37b5f0e21115a232cdc0d6a416ba0eec6"
 dependencies = [
- "bigdecimal 0.4.8",
+ "anyhow",
+ "async-trait",
+ "bon",
+ "bytes",
  "chrono",
  "futures",
+ "http 1.3.1",
  "jsonwebtoken 9.3.1",
  "rand 0.8.5",
  "reqwest 0.12.15",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "reqwest-tracing",
  "serde",
- "serde_derive",
  "serde_json",
+ "serde_repr",
+ "serde_with",
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.14",
  "tracing",
  "url",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -4312,6 +4347,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 name = "funds-manager"
 version = "0.1.0"
 dependencies = [
+ "alloy-dyn-abi",
  "alloy-json-rpc",
  "alloy-sol-types 1.0.0",
  "arbitrum-client",
@@ -5319,6 +5355,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -5707,7 +5746,7 @@ dependencies = [
  "multihash",
  "multistream-select",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5876,6 +5915,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
 
 [[package]]
 name = "matrixmultiply"
@@ -6687,12 +6732,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -6703,7 +6773,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.11",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -7332,7 +7402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot",
+ "parking_lot 0.12.3",
  "scheduled-thread-pool",
 ]
 
@@ -7487,7 +7557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ea961700fd7260e7fa3701c8287d901b2172c51f9c1421fa0f21d7f7e184b7"
 dependencies = [
  "clocksource",
- "parking_lot",
+ "parking_lot 0.12.3",
  "thiserror 1.0.69",
 ]
 
@@ -7565,6 +7635,15 @@ dependencies = [
  "tokio-util 0.7.14",
  "url",
  "uuid 1.16.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -7723,7 +7802,7 @@ dependencies = [
  "external-api",
  "futures-util",
  "hyper 0.14.32",
- "matchit",
+ "matchit 0.7.3",
  "price-reporter",
  "serde",
  "serde_json",
@@ -7806,6 +7885,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -7825,6 +7905,68 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest 0.12.15",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.15",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.15",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75b0eee96990cfb4c09545847385e89b2d2d2e571143d55264a05d77c713780"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.15",
+ "http 1.3.1",
+ "matchit 0.8.6",
+ "reqwest 0.12.15",
+ "reqwest-middleware",
+ "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -8274,7 +8416,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
@@ -8487,6 +8629,17 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -8903,7 +9056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.12.3",
  "phf_shared",
  "precomputed-hash",
 ]
@@ -9334,7 +9487,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.9",
@@ -9401,7 +9554,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot",
+ "parking_lot 0.12.3",
  "percent-encoding",
  "phf",
  "pin-project-lite",
@@ -10270,6 +10423,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10277,7 +10445,7 @@ checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-utils",
  "slab",
  "wasm-bindgen",
@@ -10333,7 +10501,7 @@ dependencies = [
  "jsonrpc-core",
  "log",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project",
  "reqwest 0.11.27",
  "rlp",
@@ -10395,7 +10563,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall",
+ "redox_syscall 0.5.11",
  "wasite",
  "web-sys",
 ]

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -26,13 +26,14 @@ aws-config = "1.5"
 bb8 = "0.8"
 diesel = { workspace = true, features = ["postgres", "numeric", "uuid"] }
 diesel-async = { workspace = true, features = ["postgres", "bb8"] }
-fireblocks-sdk = { git = "https://github.com/renegade-fi/fireblocks-sdk-rs" }
+fireblocks-sdk = { git = "https://github.com/renegade-fi/fireblocks-sdk-rs.git", branch = "v2.0.1" }
 native-tls = "0.2"
 postgres-native-tls = "0.5"
 tokio-postgres = "0.7.7"
 
 # === Blockchain Interaction === #
 alloy-sol-types = "1.0.0"
+alloy-dyn-abi = { version = "1.0.0", features = ["eip712"] }
 alloy-json-rpc = "0.14.0"
 ethers = "2"
 

--- a/funds-manager/funds-manager-server/src/custody_client/deposit.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/deposit.rs
@@ -39,8 +39,7 @@ impl CustodyClient {
             .ok_or_else(|| FundsManagerError::fireblocks(format!("no asset for mint: {mint}")))?;
 
         // Fetch the wallet addresses for the asset
-        let client = self.get_fireblocks_client()?;
-        let (addresses, _rid) = client.addresses(deposit_vault.id, &asset_id).await?;
+        let addresses = self.fireblocks_client.addresses(&deposit_vault.id, &asset_id).await?;
         let addr = addresses.first().ok_or_else(|| {
             FundsManagerError::fireblocks(format!("no addresses for asset: {}", asset_id))
         })?;

--- a/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
@@ -1,9 +1,31 @@
 //! Implements an opinionated handler for Ethereum JSON-RPC requests, which
 //! can be used, for example, by EIP-1193 compliant Javascript clients.
 
-use alloy_json_rpc::{Request, Response as JsonRpcResponse, ResponsePayload, RpcError, RpcResult};
+use alloy_json_rpc::{
+    ErrorPayload, Request, Response as JsonRpcResponse, ResponsePayload, RpcError, RpcResult,
+};
+use fireblocks_sdk::{
+    apis::transactions_api::CreateTransactionParams,
+    models::{
+        unsigned_message::Type as MessageType, CreateTransactionResponse, ExtraParameters,
+        ExtraParametersRawMessageData, SourceTransferPeerPath, TransactionOperation,
+        TransactionRequest, TransactionStatus, UnsignedMessage,
+    },
+};
 use renegade_arbitrum_client::constants::Chain;
 use serde_json::Value;
+use tracing::error;
+
+// Note: We deliberately use the Ethers implementation of EIP-712 TypedData
+// rather than Alloy's, because Alloy will fail to deserialize TypedData which
+// contains type identifiers that are not valid Solidity types.
+// For example, a Hyperliquid withdrawal action contains a field with the type
+// identifier `HyperliquidTransaction:Withdraw`. Due to the usage of the `:`
+// character, Alloy will fail to deserialize the TypedData.
+use ethers::types::{
+    transaction::eip712::{EIP712Domain, TypedData},
+    U256,
+};
 
 use crate::error::FundsManagerError;
 
@@ -24,6 +46,13 @@ const ARB_MAINNET_ETH_ASSET_ID: &str = "ETH-AETH";
 const ARB_TESTNET_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
 /// The name of the Fireblocks vault custodying the Hyperliquid keypair
 const HYPERLIQUID_VAULT_NAME: &str = "Hyperliquid";
+/// The EIP-712 domain name for Hyperliquid L1 actions
+const HYPERLIQUID_L1_ACTION_DOMAIN: &str = "Exchange";
+/// The EIP-712 domain name for Hyperliquid user actions
+const HYPERLIQUID_USER_ACTION_DOMAIN: &str = "HyperliquidSignTransaction";
+/// The set of allowed EIP-712 domains for typed data signing requests.
+const ALLOWED_EIP712_DOMAIN_NAMES: [&str; 2] =
+    [HYPERLIQUID_L1_ACTION_DOMAIN, HYPERLIQUID_USER_ACTION_DOMAIN];
 
 /// The error message emitted when an unsupported RPC method is requested.
 const ERR_UNSUPPORTED_METHOD: &str = "Unsupported RPC method";
@@ -34,6 +63,15 @@ const ERR_HYPERLIQUID_VAULT_NOT_FOUND: &str = "Hyperliquid vault not found";
 /// The error message emitted when no addresses are found for the Hyperliquid
 /// vault.
 const ERR_NO_ADDRESSES: &str = "No addresses found for Hyperliquid vault";
+/// The error message emitted when the signing account is invalid.
+const ERR_INVALID_SIGNING_ACCOUNT: &str = "Invalid signing account";
+/// The error message emitted when the chain ID in an EIP-712 domain is invalid.
+const ERR_INVALID_CHAIN_ID: &str = "Invalid chain ID";
+/// The error message emitted when the EIP-712 domain name is invalid.
+const ERR_INVALID_DOMAIN_NAME: &str = "Invalid domain name";
+/// The error message emitted when a signature is not found in the Fireblocks
+/// transaction response.
+const ERR_SIGNATURE_NOT_FOUND: &str = "Signature not found in Fireblocks transaction response";
 
 // ---------
 // | Types |
@@ -48,7 +86,22 @@ pub type JsonRpcRequest = Request<Value>;
 /// response type.
 type FundsManagerRpcResult<T> = RpcResult<T, FundsManagerError, Value>;
 
+// ----------
+// | Macros |
+// ----------
+
+/// A macro for creating an invalid parameters JSON-RPC error response.
+macro_rules! invalid_params {
+    () => {
+        RpcError::err_resp(ErrorPayload::invalid_params())
+    };
+}
+
 impl CustodyClient {
+    // ------------
+    // | Handlers |
+    // ------------
+
     /// Handle an incoming JSON-RPC request, wrapping the result in a
     /// `JsonRpcResponse` appropriately.
     pub async fn handle_rpc_request(
@@ -56,7 +109,7 @@ impl CustodyClient {
         request: JsonRpcRequest,
     ) -> JsonRpcResponse<Value, Value> {
         let id = request.meta.id.clone();
-        let result = self.try_handle_rpc_request(&request).await;
+        let result = self.try_handle_rpc_request(request).await;
 
         match result {
             Ok(result) => JsonRpcResponse { id, payload: ResponsePayload::Success(result) },
@@ -73,12 +126,14 @@ impl CustodyClient {
     /// validating the request and returning an arbitrary result value.
     async fn try_handle_rpc_request(
         &self,
-        request: &JsonRpcRequest,
+        request: JsonRpcRequest,
     ) -> FundsManagerRpcResult<Value> {
         let method: &str = &request.meta.method;
 
         match method {
-            ETH_SIGN_TYPED_DATA_V4_METHOD => todo!(),
+            ETH_SIGN_TYPED_DATA_V4_METHOD => {
+                self.handle_eth_sign_typed_data_v4_request(request).await.map(Value::from)
+            },
             ETH_ACCOUNTS_METHOD => self.handle_eth_accounts_request().await.map(Value::from),
             _ => Err(RpcError::UnsupportedFeature(ERR_UNSUPPORTED_METHOD)),
         }
@@ -88,24 +143,209 @@ impl CustodyClient {
     /// Currently, we only support RPC requests pertaining to the Hyperliquid
     /// keypair.
     async fn handle_eth_accounts_request(&self) -> FundsManagerRpcResult<Vec<String>> {
-        let asset_id = match self.chain {
-            Chain::Mainnet => ARB_MAINNET_ETH_ASSET_ID,
-            Chain::Testnet => ARB_TESTNET_ETH_ASSET_ID,
-            _ => return Err(RpcError::UnsupportedFeature(ERR_UNSUPPORTED_CHAIN)),
-        };
+        let hyperliquid_vault_id = self.get_hyperliquid_vault_id().await?;
+        let hyperliquid_address = self.get_hyperliquid_address(&hyperliquid_vault_id).await?;
+        Ok(vec![hyperliquid_address])
+    }
+
+    /// Handle an incoming `eth_signTypedData_v4` JSON-RPC request
+    async fn handle_eth_sign_typed_data_v4_request(
+        &self,
+        request: JsonRpcRequest,
+    ) -> FundsManagerRpcResult<String> {
+        // Parse request parameters
+        let (address, typed_data) = parse_sign_typed_data_params(request.params)?;
+
+        let hyperliquid_vault_id = self.get_hyperliquid_vault_id().await?;
+
+        // Validate request parameters
+        self.validate_signing_account(&address, &hyperliquid_vault_id).await?;
+        self.validate_typed_data(&typed_data)?;
+
+        // Sign the typed data
+        let note = self.generate_typed_data_note(HYPERLIQUID_VAULT_NAME, &typed_data);
+        let tx_resp = self
+            .send_fireblocks_typed_data_signature_request(hyperliquid_vault_id, typed_data, note)
+            .await?;
+
+        let tx = self.poll_fireblocks_transaction(&tx_resp.id).await?;
+        if tx.status != TransactionStatus::Completed {
+            let err_msg = format!("Typed data signature request unsuccessful: {}", tx.status);
+            error!("{err_msg}");
+            return Err(FundsManagerError::fireblocks(err_msg).into());
+        }
+
+        let signature = tx
+            .signed_messages
+            .and_then(|signed_messages| signed_messages.first().cloned())
+            .and_then(|signed_message| signed_message.signature)
+            .and_then(|signature| {
+                signature.r.zip(signature.s).zip(signature.v).map(|((r, s), v)| {
+                    let v_hex = hex::encode([v as u8]);
+                    format!("0x{r}{s}{v_hex}")
+                })
+            })
+            .ok_or(FundsManagerError::fireblocks(ERR_SIGNATURE_NOT_FOUND))?;
+
+        Ok(signature)
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Validate the signing account of an `eth_signTypedData_v4` JSON-RPC
+    /// request.
+    async fn validate_signing_account(
+        &self,
+        address: &str,
+        hyperliquid_vault_id: &str,
+    ) -> FundsManagerRpcResult<()> {
+        if address != self.get_hyperliquid_address(hyperliquid_vault_id).await?.as_str() {
+            return Err(FundsManagerError::json_rpc(ERR_INVALID_SIGNING_ACCOUNT).into());
+        }
+        Ok(())
+    }
+
+    /// Validate the contents of the typed data requested to be signed.
+    fn validate_typed_data(&self, typed_data: &TypedData) -> FundsManagerRpcResult<()> {
+        self.validate_domain(&typed_data.domain)?;
+        // TODO: More validation
+        Ok(())
+    }
+
+    /// Validate the EIP-712 signing domain of a typed data request.
+    ///
+    /// Currently, we only support Hyperliquid typed data signing requests.
+    fn validate_domain(&self, domain: &EIP712Domain) -> Result<(), FundsManagerError> {
+        match domain.chain_id {
+            None => return Err(FundsManagerError::json_rpc(ERR_INVALID_CHAIN_ID)),
+            Some(chain_id) => {
+                if chain_id != U256::from(self.chain_id) {
+                    return Err(FundsManagerError::json_rpc(ERR_INVALID_CHAIN_ID));
+                }
+            },
+        }
+
+        if domain.name.is_none() {
+            return Err(FundsManagerError::json_rpc(ERR_INVALID_DOMAIN_NAME));
+        }
+
+        match domain.name.as_ref() {
+            None => Err(FundsManagerError::json_rpc(ERR_INVALID_DOMAIN_NAME)),
+            Some(name) if ALLOWED_EIP712_DOMAIN_NAMES.contains(&name.as_str()) => Ok(()),
+            _ => Err(FundsManagerError::json_rpc(ERR_INVALID_DOMAIN_NAME)),
+        }
+    }
+
+    /// Get the Fireblocks asset ID for the native asset (ETH) of the configured
+    /// chain.
+    fn get_native_eth_asset_id(&self) -> FundsManagerRpcResult<String> {
+        match self.chain {
+            Chain::Mainnet => Ok(ARB_MAINNET_ETH_ASSET_ID.to_string()),
+            Chain::Testnet => Ok(ARB_TESTNET_ETH_ASSET_ID.to_string()),
+            _ => Err(RpcError::UnsupportedFeature(ERR_UNSUPPORTED_CHAIN)),
+        }
+    }
+
+    /// Get the Fireblocks vault ID for the Hyperliquid vault.
+    async fn get_hyperliquid_vault_id(&self) -> FundsManagerRpcResult<String> {
         let hyperliquid_vault = self
             .get_vault_account(HYPERLIQUID_VAULT_NAME)
             .await?
             .ok_or(FundsManagerError::fireblocks(ERR_HYPERLIQUID_VAULT_NOT_FOUND))?;
 
-        let client = self.get_fireblocks_client()?;
-        let (addresses, _rid) = client
-            .addresses(hyperliquid_vault.id, &asset_id)
+        Ok(hyperliquid_vault.id)
+    }
+
+    /// Get the address of the Hyperliquid account.
+    /// This is expected to be the only address managing native ETH in the
+    /// Hyperliquid vault.
+    async fn get_hyperliquid_address(
+        &self,
+        hyperliquid_vault_id: &str,
+    ) -> FundsManagerRpcResult<String> {
+        let asset_id = self.get_native_eth_asset_id()?;
+        let addresses = self
+            .fireblocks_client
+            .addresses(hyperliquid_vault_id, &asset_id)
             .await
             .map_err(FundsManagerError::from)?;
 
         let addr = addresses.first().ok_or(FundsManagerError::fireblocks(ERR_NO_ADDRESSES))?;
-
-        Ok(vec![addr.address.clone()])
+        Ok(addr.address.clone())
     }
+
+    /// Generate a note for a Fireblocks transaction that signs a typed data
+    /// message
+    fn generate_typed_data_note(&self, vault_name: &str, typed_data: &TypedData) -> String {
+        let action = &typed_data.primary_type;
+        format!("Signing {action} using {vault_name}")
+    }
+
+    /// Send a request to Fireblocks to sign a typed data message.
+    async fn send_fireblocks_typed_data_signature_request(
+        &self,
+        vault_id: String,
+        typed_data: TypedData,
+        note: String,
+    ) -> FundsManagerRpcResult<CreateTransactionResponse> {
+        let source = SourceTransferPeerPath { id: Some(vault_id), ..Default::default() };
+        let content = serde_json::to_value(&typed_data).map_err(FundsManagerError::json_rpc)?;
+        let extra_parameters = ExtraParameters {
+            raw_message_data: Some(ExtraParametersRawMessageData {
+                messages: Some(vec![UnsignedMessage {
+                    r#type: Some(MessageType::Eip712),
+                    content,
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let asset_id = self.get_native_eth_asset_id()?;
+
+        let params = CreateTransactionParams::builder()
+            .transaction_request(TransactionRequest {
+                operation: Some(TransactionOperation::TypedMessage),
+                source: Some(source),
+                extra_parameters: Some(extra_parameters),
+                note: Some(note),
+                asset_id: Some(asset_id),
+                ..Default::default()
+            })
+            .build();
+
+        let resp = self
+            .fireblocks_client
+            .transactions_api()
+            .create_transaction(params)
+            .await
+            .map_err(FundsManagerError::fireblocks)?;
+
+        Ok(resp)
+    }
+}
+
+// ----------------------
+// | Non-Member Helpers |
+// ----------------------
+
+/// Parse the parameters of an `eth_signTypedData_v4` JSON-RPC request,
+/// namely the address of the signing account and the typed data to be signed.
+fn parse_sign_typed_data_params(mut params: Value) -> FundsManagerRpcResult<(String, TypedData)> {
+    let mut params_iter = params.as_array_mut().ok_or(invalid_params!())?.iter_mut();
+
+    let address =
+        params_iter.next().and_then(|value| value.as_str()).ok_or(invalid_params!())?.to_string();
+
+    let raw_data = params_iter.next().ok_or(invalid_params!())?.take();
+    let raw_data_str = serde_json::to_string(&raw_data).expect("Failed to re-serialize typed data");
+
+    let typed_data: TypedData = serde_json::from_value(raw_data).map_err(|err| {
+        error!("Failed to deserialize typed data: {}", err);
+        RpcError::deser_err(err, raw_data_str)
+    })?;
+
+    Ok((address, typed_data))
 }

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -123,7 +123,7 @@ impl Server {
             arc_pool.clone(),
             config.clone(),
             gas_sponsor_address,
-        );
+        )?;
 
         let execution_client = ExecutionClient::new(
             args.execution_venue_api_key,


### PR DESCRIPTION
This PR implements EIP-712 typed data signing with the Fireblocks Hyperliquid vault. Due to the incompatibility of the current Fireblocks Rust SDK version with the current Fireblocks API, this PR includes a major version upgrade of the Fireblocks Rust SDK. This results in some updating of other code paths invoking the Fireblocks Rust SDK.

### Testing
- [x] Test `eth_signTypedData_v4` request to `/rpc` endpoint via integration with Hyperliquid TypeScript SDK
- [x] Test `/custody/hot-wallets/transfer-to-vault`, ensuring that updated usage of the Fireblocks SDK in all downstream codepaths exhibits expected behavior
- [x] Test `/custody/hot-wallets/withdraw-to-hot-wallet`, ensuring that updated usage of the Fireblocks SDK in all downstream codepaths exhibits expected behavior

### TODO
- [ ] Additional typed data validation logic, e.g. withdrawal amount bounds
- [ ] Remove usage of Hyperliquid pkey from AWS SM, i.e. implement deposits into Hyperliquid using Fireblocks vault

These tests should cover all code paths which interact with the `custody_client.fireblocks_client`.