### PR TITLE
auth-server: metrics: record req counter in correct ctx

### DIFF
--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -8,15 +8,13 @@ use crate::{chain_events::listener::OnChainEventListenerExecutor, store::BundleC
 use crate::{
     error::AuthServerError,
     telemetry::{
-        helpers::{
-            extend_labels_with_base_asset, record_endpoint_metrics, record_volume_with_tags,
-        },
+        helpers::{extend_labels_with_base_asset, record_volume_with_tags},
         labels::{
             EXTERNAL_MATCH_SETTLED_BASE_VOLUME, EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME,
             GAS_SPONSORED_METRIC_TAG, GAS_SPONSORSHIP_VALUE, KEY_DESCRIPTION_METRIC_TAG,
-            L1_COST_PER_BYTE_TAG, L2_BASE_FEE_TAG, NUM_EXTERNAL_MATCH_REQUESTS, REFUND_AMOUNT_TAG,
-            REFUND_ASSET_TAG, REMAINING_TIME_TAG, REMAINING_VALUE_TAG, REQUEST_ID_METRIC_TAG,
-            SDK_VERSION_METRIC_TAG, SETTLEMENT_STATUS_TAG,
+            L1_COST_PER_BYTE_TAG, L2_BASE_FEE_TAG, REFUND_AMOUNT_TAG, REFUND_ASSET_TAG,
+            REMAINING_TIME_TAG, REMAINING_VALUE_TAG, REQUEST_ID_METRIC_TAG, SDK_VERSION_METRIC_TAG,
+            SETTLEMENT_STATUS_TAG,
         },
     },
 };
@@ -42,8 +40,6 @@ impl OnChainEventListenerExecutor {
         match_result: &ApiExternalMatchResult,
     ) {
         let labels = self.get_labels(ctx);
-        record_endpoint_metrics(&match_result.base_mint, NUM_EXTERNAL_MATCH_REQUESTS, &labels);
-
         record_volume_with_tags(
             &match_result.base_mint,
             match_result.base_amount,

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -35,8 +35,7 @@ use crate::{
 
 use super::{
     labels::{
-        EXTERNAL_MATCH_SETTLED_BASE_VOLUME, KEY_DESCRIPTION_METRIC_TAG, REQUEST_PATH_METRIC_TAG,
-        SIDE_TAG,
+        KEY_DESCRIPTION_METRIC_TAG, NUM_EXTERNAL_MATCH_REQUESTS, REQUEST_PATH_METRIC_TAG, SIDE_TAG,
     },
     quote_comparison::QuoteComparison,
 };
@@ -154,6 +153,8 @@ fn record_external_match_request_metrics(
     let labels = extend_labels_with_base_asset(&base_mint, labels.to_vec());
     record_volume_with_tags(&quote_mint, quote_amount, EXTERNAL_ORDER_QUOTE_VOLUME, &labels);
 
+    record_endpoint_metrics(&base_mint, NUM_EXTERNAL_MATCH_REQUESTS, &labels);
+
     Ok(())
 }
 
@@ -227,13 +228,6 @@ pub(crate) fn record_external_match_metrics(
     if let Err(e) = record_external_match_response_metrics(match_bundle, labels) {
         warn!("Error recording response metrics: {e}");
     }
-
-    record_volume_with_tags(
-        &match_bundle.match_result.base_mint,
-        match_bundle.match_result.base_amount,
-        EXTERNAL_MATCH_SETTLED_BASE_VOLUME,
-        labels,
-    );
 
     Ok(())
 }


### PR DESCRIPTION
### Purpose
This PR ensures we increment the "number of external match requests" counter when an external match is requested (previously was incrementing when we observed a settlement nullifier). It also removes erroneous recording of `EXTERNAL_MATCH_SETTLED_BASE_VOLUME`. These bugs were introduced in the recent migration to a chain events worker.

### Testing
- [ ] Tested locally
- [x] Test in testnet