### PR TITLE
auth-server: handle-external-match: Add malleable match handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
@@ -367,7 +367,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "hex-literal",
  "itoa",
  "ruint",
@@ -901,8 +901,9 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
+ "alloy",
  "alloy-primitives 1.0.0",
  "alloy-sol-types 1.0.0",
  "ark-bn254",
@@ -1451,9 +1452,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c39646d1a6b51240a1a23bb57ea4eebede7e16fbc237fdc876980233dcecb4f"
+checksum = "b6fcc63c9860579e4cb396239570e979376e70aab79e496621748a09913f8b36"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1481,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1503,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddeb19ee86cb16ecfc871e5b0660aff6285760957aaedda6284cf0e790d3769"
+checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1516,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
+checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1533,7 +1534,6 @@ dependencies = [
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.82.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6eab2900764411ab01c8e91a76fd11a63b4e12bc3da97d9e14a0ce1343d86d3"
+checksum = "51384750334005f40e1a334b0d54eca822a77eacdcf3c50fdf38f583c5eee7a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1577,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.68.0"
+version = "1.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c18fb03c6aad6a5de2a36e44eebc83640eea9a025bf407579f503b5dc4cd0b0"
+checksum = "dff24b4eb5d06e80d028b74ccf1c7a1d34f05f9960c5a0e8223fbb82afd905c6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.64.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736"
+checksum = "8efec445fb78df585327094fcef4cad895b154b58711e504db7a93c41aa27151"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1623,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbbb3ce8da257aedbccdcb1aadafbbb6a5fe9adf445db0e1ea897bdc7e22d08"
+checksum = "5e49cca619c10e7b002dc8e66928ceed66ab7f56c1a3be86c5437bf2d8d89bba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a78a8f50a1630db757b60f679c8226a8a70ee2ab5f5e6e51dc67f6c61c7cfd"
+checksum = "7420479eac0a53f776cc8f0d493841ffe58ad9d9783f3947be7265784471b47a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1670,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
+checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -1686,7 +1686,6 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
- "once_cell",
  "p256",
  "percent-encoding",
  "ring 0.17.14",
@@ -1743,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -1756,7 +1755,6 @@ dependencies = [
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -1802,12 +1800,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445d065e76bc1ef54963db400319f1dd3ebb3e0a74af20f7f7630625b0cc7cc0"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
 dependencies = [
  "aws-smithy-runtime-api",
- "once_cell",
 ]
 
 [[package]]
@@ -1822,9 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0152749e17ce4d1b47c7747bdfec09dac1ccafdcbc741ebf9daa2a373356730f"
+checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1838,7 +1835,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "once_cell",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -1847,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da37cf5d57011cb1753456518ec76e31691f1f474b73934a284eb2a1c76510f"
+checksum = "a1e5d9e3a80a18afa109391fb5ad09c3daf887b516c6fd805a157c6ea7994a57"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -1864,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836155caafba616c0ff9b07944324785de2ab016141c3550bd1c07882f8cee8f"
+checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1885,7 +1881,7 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
 ]
 
 [[package]]
@@ -1899,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -2573,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2584,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2615,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2797,13 +2793,13 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
 ]
 
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -2866,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
@@ -2938,7 +2934,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3373,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -4154,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "base64 0.22.1",
  "circuit-types",
@@ -4261,7 +4257,7 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "tracing",
  "url",
 ]
@@ -4592,9 +4588,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4652,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -4705,7 +4701,7 @@ dependencies = [
  "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "tracing",
 ]
 
@@ -4724,7 +4720,7 @@ dependencies = [
  "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "tracing",
 ]
 
@@ -5496,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -5690,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libp2p"
@@ -5703,7 +5699,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "instant",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
@@ -7084,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7488,7 +7484,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -7611,7 +7607,7 @@ dependencies = [
  "socket2 0.5.9",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "url",
  "uuid 1.16.0",
 ]
@@ -7631,7 +7627,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -7698,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7749,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -7821,7 +7817,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7920,7 +7916,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -8727,9 +8723,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -9133,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "bus",
  "common",
@@ -9145,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9461,7 +9457,7 @@ dependencies = [
  "rand 0.9.1",
  "socket2 0.5.9",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "whoami",
 ]
 
@@ -9494,7 +9490,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
 ]
 
 [[package]]
@@ -9573,15 +9569,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "pin-project-lite",
  "tokio",
 ]
@@ -9671,7 +9667,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10060,7 +10056,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#181139b322f16b6fd6139e5f0d799b2e4857fb89"
+source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -10103,7 +10099,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "serde",
 ]
 
@@ -10208,7 +10204,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "tokio-util 0.7.14",
+ "tokio-util 0.7.15",
  "tower-service",
  "tracing",
 ]
@@ -10379,7 +10375,7 @@ dependencies = [
  "arrayvec",
  "base64 0.13.1",
  "bytes",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ethabi 16.0.0",
  "ethereum-types 0.12.1",
  "futures",
@@ -10857,9 +10853,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "alloy",
  "alloy-primitives 1.0.0",
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2611,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2799,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "ark-mpc",
  "async-trait",
@@ -2862,7 +2862,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "arbitrum-client",
  "base64 0.13.1",
@@ -2934,7 +2934,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3965,7 +3965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.100",
- "toml 0.8.20",
+ "toml 0.8.21",
  "walkdir",
 ]
 
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "base64 0.22.1",
  "circuit-types",
@@ -4648,7 +4648,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5492,7 +5492,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7049,7 +7049,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -7080,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7694,7 +7694,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7745,7 +7745,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9129,7 +9129,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "bus",
  "common",
@@ -9141,7 +9141,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9593,9 +9593,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -9605,25 +9605,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tonic"
@@ -10056,7 +10063,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#f027aaefa30dc371309f2b203d4b350fb2e6c525"
+source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -10981,11 +10988,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -11001,9 +11008,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -7,7 +7,9 @@
 #![feature(trivial_bounds)]
 
 use alloy_primitives::{ruint::FromUintError, Address, U256};
-use renegade_api::http::external_match::{AtomicMatchApiBundle, SignedExternalQuote};
+use renegade_api::http::external_match::{
+    AtomicMatchApiBundle, MalleableAtomicMatchApiBundle, SignedExternalQuote,
+};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -125,6 +127,16 @@ pub struct SponsoredMatchResponse {
     pub match_bundle: AtomicMatchApiBundle,
     /// Whether or not the match was sponsored
     pub is_sponsored: bool,
+    /// The gas sponsorship info
+    pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
+}
+
+/// A sponsored malleable match response from the auth server
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SponsoredMalleableMatchResponse {
+    /// The malleable match bundle, potentially updated to reflect the
+    /// post-sponsorship receive amount
+    pub match_bundle: MalleableAtomicMatchApiBundle,
     /// The gas sponsorship info
     pub gas_sponsorship_info: Option<GasSponsorshipInfo>,
 }

--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -1,3 +1,4 @@
+//! Helpers for executing subroutines in the on-chain event listener
 use auth_server_api::GasSponsorshipInfo;
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use renegade_api::http::external_match::ApiExternalMatchResult;

--- a/auth/auth-server/src/chain_events/worker.rs
+++ b/auth/auth-server/src/chain_events/worker.rs
@@ -17,6 +17,7 @@ use super::{
 };
 
 impl OnChainEventListener {
+    /// Create a new on-chain event listener
     pub fn new(
         config: OnChainEventListenerConfig,
         bundle_store: BundleStore,
@@ -34,6 +35,7 @@ impl OnChainEventListener {
         Ok(Self { executor: Some(executor), executor_handle: None })
     }
 
+    /// Start the listener on its own runtime
     pub fn start(&mut self) -> Result<(), OnChainEventListenerError> {
         // Spawn the execution loop in a separate thread
         let executor = self.executor.take().unwrap();

--- a/auth/auth-server/src/helpers.rs
+++ b/auth/auth-server/src/helpers.rs
@@ -1,3 +1,4 @@
+//! Helper methods for the auth server
 use ethers::signers::LocalWallet;
 use renegade_arbitrum_client::{
     client::{ArbitrumClient, ArbitrumClientConfig},
@@ -5,6 +6,7 @@ use renegade_arbitrum_client::{
 };
 use std::str::FromStr;
 
+/// The interval at which we poll filter updates
 const DEFAULT_BLOCK_POLLING_INTERVAL_MS: u64 = 100;
 
 /// The dummy private key used to instantiate the arbitrum client

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -266,6 +266,21 @@ async fn main() {
             server.handle_external_quote_assembly_request(path, headers, body, query_str).await
         });
 
+    let external_malleable_assembly_path = warp::path("v0")
+        .and(warp::path("matching-engine"))
+        .and(warp::path("assemble-malleable-external-match"))
+        .and(warp::post())
+        .and(warp::path::full())
+        .and(warp::header::headers_cloned())
+        .and(warp::body::bytes())
+        .and(with_query_string())
+        .and(with_server(server.clone()))
+        .and_then(|path, headers, body, query_str, server: Arc<Server>| async move {
+            server
+                .handle_external_malleable_quote_assembly_request(path, headers, body, query_str)
+                .await
+        });
+
     let atomic_match_path = warp::path("v0")
         .and(warp::path("matching-engine"))
         .and(warp::path("request-external-match"))
@@ -296,6 +311,7 @@ async fn main() {
         .or(atomic_match_path)
         .or(external_quote_path)
         .or(external_quote_assembly_path)
+        .or(external_malleable_assembly_path)
         .or(expire_api_key)
         .or(add_api_key)
         .or(order_book_depth)

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
@@ -5,6 +5,7 @@ use auth_server_api::GasSponsorshipInfo;
 use bigdecimal::{BigDecimal, FromPrimitive};
 use renegade_api::http::external_match::{
     ApiExternalMatchResult, ApiExternalQuote, AtomicMatchApiBundle, ExternalOrder,
+    MalleableAtomicMatchApiBundle,
 };
 use renegade_circuit_types::order::OrderSide;
 use renegade_common::types::token::Token;
@@ -188,6 +189,16 @@ pub(crate) fn apply_gas_sponsorship_to_match_result(
 
     match_result.base_amount = base_amount;
     match_result.quote_amount = quote_amount;
+}
+
+/// Apply a gas sponsorship refund a malleable match bundle
+pub(crate) fn apply_gas_sponsorship_to_malleable_match_bundle(
+    match_bundle: &mut MalleableAtomicMatchApiBundle,
+    refund_amount: u128,
+) {
+    info!("Updating malleable match bundle to reflect gas sponsorship");
+    match_bundle.max_receive.amount += refund_amount;
+    match_bundle.min_receive.amount += refund_amount;
 }
 
 /// Check if the exact output amount requested in the order should be updated

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -4,7 +4,8 @@
 //! it to the relayer with admin authentication
 
 use auth_server_api::{
-    GasSponsorshipInfo, GasSponsorshipQueryParams, SponsoredMatchResponse, SponsoredQuoteResponse,
+    GasSponsorshipInfo, GasSponsorshipQueryParams, SponsoredMalleableMatchResponse,
+    SponsoredMatchResponse, SponsoredQuoteResponse,
 };
 use bytes::Bytes;
 use gas_sponsorship::refund_calculation::{
@@ -14,7 +15,7 @@ use gas_sponsorship::refund_calculation::{
 use http::{HeaderMap, Method, StatusCode};
 use renegade_api::http::external_match::{
     AssembleExternalMatchRequest, ExternalMatchRequest, ExternalMatchResponse, ExternalOrder,
-    ExternalQuoteRequest, ExternalQuoteResponse,
+    ExternalQuoteRequest, ExternalQuoteResponse, MalleableExternalMatchResponse,
 };
 use renegade_circuit_types::fixed_point::FixedPoint;
 use renegade_common::types::{token::Token, TimestampedPrice};
@@ -132,6 +133,8 @@ impl Server {
         // necessary
         let gas_sponsorship_info =
             self.maybe_update_assembly_request_with_gas_sponsorship(&mut req).await?;
+
+        // Serialize the potentially updated request body
         let req_body = serde_json::to_vec(&req).map_err(AuthServerError::serde)?;
 
         // Send the request to the relayer
@@ -176,6 +179,56 @@ impl Server {
             };
         });
 
+        Ok(res)
+    }
+
+    /// Handle an external malleable quote assembly request
+    pub async fn handle_external_malleable_quote_assembly_request(
+        &self,
+        path: warp::path::FullPath,
+        headers: warp::hyper::HeaderMap,
+        body: Bytes,
+        query_str: String,
+    ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        let path_str = path.as_str();
+        let key_desc = self.authorize_request(path_str, &query_str, &headers, &body).await?;
+
+        // Check the bundle rate limit
+        let mut req: AssembleExternalMatchRequest =
+            serde_json::from_slice(&body).map_err(AuthServerError::serde)?;
+        self.check_bundle_rate_limit(key_desc.clone(), req.allow_shared).await?;
+
+        // Update the request to remove the effects of gas sponsorship, if
+        // necessary
+        let gas_sponsorship_info =
+            self.maybe_update_assembly_request_with_gas_sponsorship(&mut req).await?;
+
+        // Serialize the potentially updated request body
+        let req_body = serde_json::to_vec(&req).map_err(AuthServerError::serde)?;
+
+        // Send the request to the relayer
+        let mut res = self
+            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
+            .await?;
+
+        let status = res.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_desc.clone(), path_str.to_string());
+        }
+        if status != StatusCode::OK {
+            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &req_body, &headers);
+            return Ok(res);
+        }
+
+        // Apply gas sponsorship to the resulting bundle, if necessary
+        let sponsored_match_resp = self.maybe_apply_gas_sponsorship_to_malleable_match_bundle(
+            res.body(),
+            gas_sponsorship_info,
+        )?;
+        overwrite_response_body(&mut res, sponsored_match_resp.clone())?;
+
+        // TODO: record bundle metrics
         Ok(res)
     }
 
@@ -408,6 +461,30 @@ impl Server {
             gas_sponsorship_info.unwrap(),
         )?;
 
+        Ok(sponsored_match_resp)
+    }
+
+    /// Apply gas sponsorship to the given malleable match bundle, returning
+    /// a `SponsoredMalleableMatchResponse  `
+    fn maybe_apply_gas_sponsorship_to_malleable_match_bundle(
+        &self,
+        resp_body: &[u8],
+        gas_sponsorship_info: Option<GasSponsorshipInfo>,
+    ) -> Result<SponsoredMalleableMatchResponse, AuthServerError> {
+        // Deserialize the response body from the relayer
+        let match_resp: MalleableExternalMatchResponse =
+            serde_json::from_slice(resp_body).map_err(AuthServerError::serde)?;
+        if gas_sponsorship_info.is_none() {
+            return Ok(SponsoredMalleableMatchResponse {
+                match_bundle: match_resp.match_bundle,
+                gas_sponsorship_info: None,
+            });
+        }
+
+        // Construct the sponsored match response
+        let info = gas_sponsorship_info.unwrap();
+        let sponsored_match_resp =
+            self.construct_sponsored_malleable_match_response(match_resp, info)?;
         Ok(sponsored_match_resp)
     }
 

--- a/auth/auth-server/src/server/handle_external_match/settlement.rs
+++ b/auth/auth-server/src/server/handle_external_match/settlement.rs
@@ -1,3 +1,4 @@
+//! Server methods that watch for external match settlement
 use auth_server_api::{GasSponsorshipInfo, SponsoredMatchResponse}; // Added GasSponsorshipInfo
 use http::HeaderMap;
 use renegade_api::http::external_match::ApiExternalMatchResult;

--- a/auth/auth-server/src/server/order_book/mod.rs
+++ b/auth/auth-server/src/server/order_book/mod.rs
@@ -1,3 +1,4 @@
+//! Orderbook endpoint handlers
 use bytes::Bytes;
 use http::{HeaderMap, Method, StatusCode};
 use tracing::instrument;

--- a/auth/auth-server/src/store/helpers.rs
+++ b/auth/auth-server/src/store/helpers.rs
@@ -1,3 +1,4 @@
+//! Helper methods for the bundle store
 use alloy_primitives::{hex, keccak256};
 use renegade_api::http::external_match::ApiExternalMatchResult;
 use renegade_circuit_types::wallet::Nullifier;

--- a/auth/auth-server/src/store/mod.rs
+++ b/auth/auth-server/src/store/mod.rs
@@ -33,15 +33,16 @@ pub struct BundleContext {
 }
 
 struct StoreInner {
-    // The mapping from bundle ID to bundle context
+    /// The mapping from bundle ID to bundle context
     by_id: HashMap<String, BundleContext>,
-    // The mapping from nullifier to bundle IDs
-    //
-    // This is used to efficiently cleanup the store when a nullifier is spent
+    /// The mapping from nullifier to bundle IDs
+    ///
+    /// This is used to efficiently cleanup the store when a nullifier is spent
     by_null: HashMap<Nullifier, HashSet<String>>,
 }
 
 impl StoreInner {
+    /// Create a new inner store
     pub fn new() -> Self {
         Self { by_id: HashMap::new(), by_null: HashMap::new() }
     }
@@ -50,14 +51,17 @@ impl StoreInner {
 /// A thread-safe store for tracking bundle contexts by ID and nullifier.
 #[derive(Clone)]
 pub struct BundleStore {
+    /// The inner store
     inner: Arc<RwLock<StoreInner>>,
 }
 
 impl BundleStore {
+    /// Create a new bundle store
     pub fn new() -> Self {
         Self { inner: Arc::new(RwLock::new(StoreInner::new())) }
     }
 
+    /// Write a bundle to the store
     pub async fn write(
         &self,
         bundle_id: String,
@@ -69,11 +73,13 @@ impl BundleStore {
         Ok(())
     }
 
+    /// Read a bundle from the store by its ID
     pub async fn read(&self, bundle_id: &str) -> Result<Option<BundleContext>, AuthServerError> {
         let inner = self.inner.read().await;
         Ok(inner.by_id.get(bundle_id).cloned())
     }
 
+    /// Cleanup (remove) all bundles that were indexed with the given nullifier
     pub async fn cleanup_by_nullifier(&self, nullifier: &Nullifier) -> Result<(), AuthServerError> {
         let mut inner = self.inner.write().await;
         if let Some(bundle_ids) = inner.by_null.remove(nullifier) {


### PR DESCRIPTION
### Purpose
This PR adds a handler for malleable matches to the auth server. This implementation largely follows the implementation of the standard assembly endpoint. 

### Todo
- Add post-bundle metrics and store bundle in `BundleStore`

### Tesitng
- [x] Testing locally
- [x] Testing in testnet  