### PR TITLE
auth-server: Migrate from `ethers` to `alloy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,9 @@ dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
  "alloy-signer",
  "alloy-sol-types 1.0.0",
  "alloy-transport",
@@ -483,7 +485,7 @@ checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -521,6 +523,7 @@ checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
 dependencies = [
  "alloy-primitives 1.0.0",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
  "alloy-serde",
  "serde",
 ]
@@ -534,6 +537,16 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-debug"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05525519bd7f37f98875354f0b3693d3ad3c7a7f067e3b8946777920be15cb5b"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -551,6 +564,20 @@ dependencies = [
  "alloy-serde",
  "alloy-sol-types 1.0.0",
  "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bccbe4594eaa2d69d21fa0b558c44e36202e599eb209da70b405415cb37a354"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -609,7 +636,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -623,7 +650,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -639,7 +666,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 0.7.7",
  "tiny-keccak",
 ]
@@ -658,7 +685,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 1.0.0",
  "tiny-keccak",
 ]
@@ -674,7 +701,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 0.7.7",
 ]
 
@@ -692,7 +719,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 1.0.0",
 ]
 
@@ -902,9 +929,10 @@ dependencies = [
 [[package]]
 name = "arbitrum-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "alloy",
+ "alloy-contract",
  "alloy-primitives 1.0.0",
  "alloy-sol-types 1.0.0",
  "ark-bn254",
@@ -914,7 +942,6 @@ dependencies = [
  "circuits",
  "common",
  "constants",
- "ethers",
  "itertools 0.12.1",
  "lazy_static",
  "mpc-relation",
@@ -1318,7 +1345,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1329,7 +1356,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1396,7 +1423,6 @@ dependencies = [
  "contracts-common",
  "diesel",
  "diesel-async",
- "ethers",
  "external-api",
  "futures-util",
  "http 0.2.12",
@@ -1442,7 +1468,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2106,7 +2132,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "which",
 ]
 
@@ -2265,7 +2291,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2288,7 +2314,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2371,9 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -2460,7 +2486,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2568,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2595,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2606,7 +2632,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2637,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2705,7 +2731,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2825,8 +2851,9 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
+ "alloy",
  "ark-mpc",
  "async-trait",
  "base64 0.22.1",
@@ -2837,7 +2864,6 @@ dependencies = [
  "crossbeam",
  "derivative",
  "ed25519-dalek 1.0.1",
- "ethers",
  "hmac",
  "indexmap 2.9.0",
  "itertools 0.10.5",
@@ -2888,8 +2914,9 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
+ "alloy",
  "arbitrum-client",
  "base64 0.13.1",
  "bimap",
@@ -2899,9 +2926,9 @@ dependencies = [
  "common",
  "constants",
  "ed25519-dalek 1.0.1",
- "ethers",
  "json",
  "libp2p",
+ "rand 0.8.5",
  "rand_core 0.5.1",
  "reqwest 0.11.27",
  "serde",
@@ -2960,7 +2987,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3263,7 +3290,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3287,7 +3314,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3298,7 +3325,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3338,7 +3365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3390,7 +3417,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3403,7 +3430,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3432,7 +3459,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3444,7 +3471,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3492,7 +3519,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3501,7 +3528,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3584,7 +3611,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3990,8 +4017,8 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.100",
- "toml 0.8.21",
+ "syn 2.0.101",
+ "toml 0.8.22",
  "walkdir",
 ]
 
@@ -4008,7 +4035,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4034,7 +4061,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.100",
+ "syn 2.0.101",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -4097,7 +4124,6 @@ dependencies = [
  "const-hex",
  "enr",
  "ethers-core",
- "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -4176,13 +4202,13 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
+ "alloy",
  "base64 0.22.1",
  "circuit-types",
  "common",
  "constants",
- "ethers",
  "hex 0.4.3",
  "http 0.2.12",
  "itertools 0.10.5",
@@ -4534,7 +4560,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4685,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5260,7 +5286,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5354,7 +5380,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5532,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -5932,7 +5958,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6427,7 +6453,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6527,7 +6553,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver 1.0.26",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6553,7 +6579,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6773,7 +6799,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6955,7 +6981,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6984,7 +7010,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7145,13 +7171,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7271,7 +7297,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7774,14 +7800,13 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal 0.3.1",
  "constants",
- "ethers-core",
  "itertools 0.10.5",
  "lazy_static",
  "num-bigint",
@@ -7825,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -7977,7 +8002,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
@@ -7998,7 +8023,7 @@ checksum = "d75b0eee96990cfb4c09545847385e89b2d2d2e571143d55264a05d77c713780"
 dependencies = [
  "anyhow",
  "async-trait",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "http 1.3.1",
  "matchit 0.8.6",
  "reqwest 0.12.15",
@@ -8446,7 +8471,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8664,7 +8689,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8687,7 +8712,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8738,7 +8763,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9154,7 +9179,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9167,7 +9192,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9209,9 +9234,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9227,7 +9252,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9239,7 +9264,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9277,13 +9302,13 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "bus",
  "common",
@@ -9295,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9427,7 +9452,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9438,7 +9463,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9576,7 +9601,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9703,7 +9728,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.8",
+ "webpki-roots 0.26.9",
 ]
 
 [[package]]
@@ -9747,9 +9772,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -9768,9 +9793,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -9782,9 +9807,9 @@ dependencies = [
 
 [[package]]
 name = "toml_write"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
@@ -9881,7 +9906,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10217,7 +10242,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#71f189f3073ca0324f727812ce2dcdec4bb1f3bd"
+source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -10226,7 +10251,6 @@ dependencies = [
  "circuit-types",
  "constants",
  "crossbeam",
- "ethers",
  "eyre",
  "futures",
  "hex 0.4.3",
@@ -10421,7 +10445,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -10456,7 +10480,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -10608,9 +10632,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10700,7 +10724,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10711,7 +10735,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11142,7 +11166,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -11172,7 +11196,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11183,7 +11207,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11203,7 +11227,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure 0.13.1",
 ]
 
@@ -11224,7 +11248,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11246,7 +11270,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -15,13 +15,18 @@ warp = "0.3"
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 
 # === Database === #
+diesel = { version = "2", features = ["postgres", "chrono", "uuid"] }
 bb8 = "0.8"
-diesel = { version = "2", features = ["postgres", "chrono", "uuid"], dependencies = { uuid = "1.15.1"} }
 diesel-async = { version = "0.4", features = ["postgres", "bb8"] }
 tokio-postgres = "0.7"
 postgres-native-tls = "0.5"
 native-tls = "0.2"
-redis = { version = "0.29", features = ["tokio-native-tls-comp", "connection-manager", "json", "uuid"] }
+redis = { version = "0.29", features = [
+    "tokio-native-tls-comp",
+    "connection-manager",
+    "json",
+    "uuid",
+] }
 
 # === Cryptography === #
 aes-gcm = "0.10.1"
@@ -31,7 +36,6 @@ rand = "0.8.5"
 alloy = { version = "0.14", features = ["provider-ws"] }
 alloy-primitives = { version = "1.0.0", features = ["serde", "k256"] }
 alloy-sol-types = "1.0.0"
-ethers = {version = "2", features = ["ws"] }
 
 # === Renegade Dependencies === #
 auth-server-api = { path = "../auth-server-api" }

--- a/auth/auth-server/src/helpers.rs
+++ b/auth/auth-server/src/helpers.rs
@@ -1,5 +1,5 @@
 //! Helper methods for the auth server
-use ethers::signers::LocalWallet;
+use alloy::signers::local::PrivateKeySigner;
 use renegade_arbitrum_client::{
     client::{ArbitrumClient, ArbitrumClientConfig},
     constants::Chain,
@@ -23,22 +23,18 @@ pub async fn create_arbitrum_client(
     rpc_url: String,
 ) -> Result<ArbitrumClient, String> {
     // Parse the wallet
-    let wallet = match LocalWallet::from_str(DUMMY_PRIVATE_KEY) {
+    let wallet = match PrivateKeySigner::from_str(DUMMY_PRIVATE_KEY) {
         Ok(wallet) => wallet,
         Err(e) => return Err(format!("Failed to parse wallet: {}", e)),
     };
 
     // Create the client
-    match ArbitrumClient::new(ArbitrumClientConfig {
+    ArbitrumClient::new(ArbitrumClientConfig {
         darkpool_addr: darkpool_address,
         chain: chain_id,
         rpc_url,
-        arb_priv_keys: vec![wallet],
+        private_key: wallet,
         block_polling_interval_ms: DEFAULT_BLOCK_POLLING_INTERVAL_MS,
     })
-    .await
-    {
-        Ok(client) => Ok(client),
-        Err(e) => Err(format!("Failed to create Arbitrum client: {}", e)),
-    }
+    .map_err(|e| format!("Failed to create Arbitrum client: {e}"))
 }

--- a/auth/auth-server/src/server/gas_estimation/constants.rs
+++ b/auth/auth-server/src/server/gas_estimation/constants.rs
@@ -2,8 +2,8 @@
 
 use std::time::Duration;
 
-use alloy_primitives::hex;
-use ethers::types::{Address, H160};
+use alloy::primitives::Address;
+use alloy_primitives::{hex, FixedBytes};
 
 /// A pessimistic overestimate of the gas cost of L2 execution for an external
 /// match, rounded up to the nearest 100k.
@@ -21,7 +21,8 @@ pub const ESTIMATED_L2_GAS: u64 = 3_600_000; // 3.6m
 pub const ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES: usize = 6_000;
 
 /// The address of the `NodeInterface` precompile
-pub const NODE_INTERFACE_ADDRESS: Address = H160(hex!("00000000000000000000000000000000000000c8"));
+pub const NODE_INTERFACE_ADDRESS: Address =
+    Address(FixedBytes(hex!("00000000000000000000000000000000000000c8")));
 
 /// The interval at which to sample the gas cost of an external match
 pub const GAS_COST_SAMPLING_INTERVAL: Duration = Duration::from_secs(10);

--- a/auth/auth-server/src/server/gas_estimation/mod.rs
+++ b/auth/auth-server/src/server/gas_estimation/mod.rs
@@ -1,6 +1,6 @@
 //! Gas estimation for external matches
 
-use ethers::types::U256;
+use alloy::primitives::U256;
 
 use crate::server::Server;
 

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
@@ -91,8 +91,10 @@ impl Server {
             )?
             .into();
 
-        external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
-        external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
+        let mut tx = external_match_resp.match_bundle.settlement_tx;
+        tx = tx.to(self.gas_sponsor_address);
+        tx = tx.input(gas_sponsor_calldata);
+        external_match_resp.match_bundle.settlement_tx = tx;
 
         // The `ExternalMatchResponse` from the relayer doesn't account for gas
         // sponsorship, so we need to update the match bundle to reflect the
@@ -131,8 +133,10 @@ impl Server {
             )?
             .into();
 
-        external_match_resp.match_bundle.settlement_tx.set_to(self.gas_sponsor_address);
-        external_match_resp.match_bundle.settlement_tx.set_data(gas_sponsor_calldata);
+        let mut tx = external_match_resp.match_bundle.settlement_tx;
+        tx = tx.to(self.gas_sponsor_address);
+        tx = tx.input(gas_sponsor_calldata);
+        external_match_resp.match_bundle.settlement_tx = tx;
 
         if gas_sponsorship_info.requires_match_result_update() {
             apply_gas_sponsorship_to_malleable_match_bundle(

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
@@ -13,10 +13,7 @@ use renegade_constants::NATIVE_ASSET_ADDRESS;
 use renegade_util::hex::biguint_to_hex_addr;
 use tracing::info;
 
-use crate::{
-    error::AuthServerError,
-    server::{helpers::ethers_u256_to_alloy_u256, Server},
-};
+use crate::{error::AuthServerError, server::Server};
 
 use super::WETH_TICKER;
 
@@ -47,7 +44,7 @@ impl Server {
         let conversion_rate =
             self.compute_conversion_rate_for_order(order, refund_native_eth).await?;
 
-        let estimated_gas_cost = ethers_u256_to_alloy_u256(self.get_gas_cost_estimate().await);
+        let estimated_gas_cost = self.get_gas_cost_estimate().await;
         let refund_amount = (estimated_gas_cost * conversion_rate) / ALLOY_WEI_IN_ETHER;
         Ok(refund_amount)
     }

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -25,6 +25,9 @@ use crate::{
     ApiError, Cli,
 };
 use aes_gcm::{Aes128Gcm, KeyInit};
+use alloy::hex;
+use alloy::signers::k256::ecdsa::SigningKey;
+use alloy_primitives::Address;
 use base64::{engine::general_purpose, Engine};
 use bb8::{Pool, PooledConnection};
 use bytes::Bytes;
@@ -34,7 +37,6 @@ use diesel_async::{
     pooled_connection::{AsyncDieselConnectionManager, ManagerConfig},
     AsyncPgConnection,
 };
-use ethers::{abi::Address, core::k256::ecdsa::SigningKey, utils::hex};
 use gas_estimation::gas_cost_sampler::GasCostSampler;
 use http::header::CONTENT_LENGTH;
 use http::{HeaderMap, Method, Response};
@@ -162,7 +164,7 @@ impl Server {
 
         let gas_cost_sampler = Arc::new(
             GasCostSampler::new(
-                arbitrum_client.client().clone(),
+                arbitrum_client.provider().clone(),
                 gas_sponsor_address,
                 system_clock,
             )
@@ -374,7 +376,7 @@ async fn set_external_match_fees(arbitrum_client: &ArbitrumClient) -> Result<(),
 
     for token in tokens {
         // Fetch the fee override from the contract
-        let addr = token.get_ethers_address();
+        let addr = token.get_alloy_address();
         let fee =
             arbitrum_client.get_external_match_fee(addr).await.map_err(AuthServerError::setup)?;
 

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -5,7 +5,7 @@ use alloy_sol_types::SolCall;
 use contracts_common::types::MatchPayload;
 use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalOrder};
 use renegade_arbitrum_client::{
-    abi::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
+    abi::Darkpool::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
     helpers::deserialize_calldata,
 };
 use renegade_circuit_types::{fixed_point::FixedPoint, order::OrderSide, wallet::Nullifier};
@@ -253,11 +253,7 @@ pub(crate) fn record_relayer_request_500(key_description: String, path: String) 
 pub fn extract_nullifier_from_match_bundle(
     match_bundle: &AtomicMatchApiBundle,
 ) -> Result<Nullifier, AuthServerError> {
-    let tx_data = match_bundle
-        .settlement_tx
-        .data()
-        .ok_or(AuthServerError::serde("No data in settlement tx"))?;
-
+    let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
     let selector = get_selector(tx_data)?;
 
     // Retrieve serialized match payload from the transaction data

--- a/auth/auth-server/src/telemetry/quote_comparison/handler.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/handler.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
-use ethers::utils::format_units;
-use ethers::{providers::Middleware, types::U256};
+use alloy::providers::Provider;
+use alloy_primitives::{utils::format_units, U256};
 use futures_util::future::join_all;
 use renegade_arbitrum_client::client::ArbitrumClient;
 use renegade_circuit_types::order::OrderSide;
@@ -120,9 +120,10 @@ impl QuoteComparisonHandler {
         // Fetch gas price in wei
         let gas_price: U256 = self
             .arbitrum_client
-            .client()
+            .provider()
             .get_gas_price()
             .await
+            .map(U256::from)
             .map_err(|e| AuthServerError::Custom(e.to_string()))?;
 
         // Convert wei to eth

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -98,7 +98,7 @@ impl QuoteResponse {
 /// Converts the `AtomicMatchApiBundle` into a `QuoteResponse`.
 impl From<&AtomicMatchApiBundle> for QuoteResponse {
     fn from(bundle: &AtomicMatchApiBundle) -> Self {
-        let gas = bundle.settlement_tx.gas().map_or(ESTIMATED_L2_GAS, |gas| gas.as_u64());
+        let gas = bundle.settlement_tx.gas.unwrap_or(ESTIMATED_L2_GAS);
         let fee_take = bundle.fees.total();
         Self {
             quote_mint: bundle.match_result.quote_mint.clone(),


### PR DESCRIPTION
### Purpose
This PR migrates the auth server from using `ethers` to `alloy`.

### Testing
- [x] Tested against a local relayer that has been migrated to `alloy`