### PR TITLE
funds-manager: api, server: begin migration to alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
+ "getrandom 0.3.2",
  "hashbrown 0.15.2",
  "indexmap 2.9.0",
  "itoa",
@@ -4468,10 +4469,9 @@ dependencies = [
 name = "funds-manager-api"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives 1.0.0",
  "common",
- "ethers",
  "external-api",
- "hex 0.4.3",
  "http 0.2.12",
  "itertools 0.13.0",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,7 +122,7 @@ checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
  "alloy-primitives 1.0.0",
  "num_enum",
- "strum 0.27.1",
+ "strum",
 ]
 
 [[package]]
@@ -387,7 +377,6 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "getrandom 0.3.2",
  "hashbrown 0.15.2",
  "indexmap 2.9.0",
  "itoa",
@@ -564,7 +553,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types 1.0.0",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -928,39 +917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrum-client"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
-dependencies = [
- "alloy",
- "alloy-contract",
- "alloy-primitives 1.0.0",
- "alloy-sol-types 1.0.0",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "circuit-types",
- "circuits",
- "common",
- "constants",
- "itertools 0.12.1",
- "lazy_static",
- "mpc-relation",
- "num-bigint",
- "num-traits",
- "postcard",
- "rand 0.8.5",
- "renegade-crypto",
- "renegade-metrics",
- "ruint",
- "serde",
- "serde_with",
- "tokio",
- "tracing",
- "util",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,15 +1275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1353,6 @@ dependencies = [
  "alloy",
  "alloy-primitives 1.0.0",
  "alloy-sol-types 1.0.0",
- "arbitrum-client",
  "async-trait",
  "atomic_float 1.1.0",
  "auth-server-api",
@@ -1422,6 +1368,7 @@ dependencies = [
  "config",
  "constants",
  "contracts-common",
+ "darkpool-client",
  "diesel",
  "diesel-async",
  "external-api",
@@ -1447,7 +1394,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid",
  "warp",
 ]
 
@@ -1458,7 +1405,7 @@ dependencies = [
  "alloy-primitives 1.0.0",
  "external-api",
  "serde",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1565,7 +1512,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2069,12 +2016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,27 +2080,12 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
-]
-
-[[package]]
-name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -2325,16 +2251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "sha2 0.10.8",
- "tinyvec",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2428,26 +2344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "c-kzg"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,38 +2399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62fd689c825a93386a2ac05a46f88342c6df9ec3e79416f665650614e92e7475"
 dependencies = [
  "crossbeam-channel",
-]
-
-[[package]]
-name = "camino"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2622,7 +2486,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2633,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2664,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2768,58 +2632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
-name = "coins-bip32"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6be4a5df2098cd811f3194f64ddb96c267606bffd9689ac7b0160097b01ad3"
-dependencies = [
- "bs58 0.5.1",
- "coins-core",
- "digest 0.10.7",
- "hmac",
- "k256",
- "serde",
- "sha2 0.10.8",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-bip39"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
-dependencies = [
- "bitvec 1.0.1",
- "coins-bip32",
- "hmac",
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "sha2 0.10.8",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "coins-core"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
-dependencies = [
- "base64 0.21.7",
- "bech32",
- "bs58 0.5.1",
- "digest 0.10.7",
- "generic-array 0.14.7",
- "hex 0.4.3",
- "ripemd",
- "serde",
- "serde_derive",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2852,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2884,7 +2696,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2915,10 +2727,9 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "alloy",
- "arbitrum-client",
  "base64 0.13.1",
  "bimap",
  "circuit-types",
@@ -2926,6 +2737,7 @@ dependencies = [
  "colored",
  "common",
  "constants",
+ "darkpool-client",
  "ed25519-dalek 1.0.1",
  "json",
  "libp2p",
@@ -2934,7 +2746,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml",
  "tracing",
  "url",
  "util",
@@ -2980,15 +2792,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3295,6 +3101,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darkpool-client"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+dependencies = [
+ "alloy",
+ "alloy-contract",
+ "alloy-primitives 1.0.0",
+ "alloy-sol-types 1.0.0",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "async-trait",
+ "circuit-types",
+ "circuits",
+ "common",
+ "constants",
+ "itertools 0.12.1",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "postcard",
+ "renegade-crypto",
+ "ruint",
+ "serde",
+ "serde_with",
+ "tracing",
+ "util",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,7 +3329,7 @@ dependencies = [
  "num-traits",
  "pq-sys",
  "r2d2",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3560,48 +3396,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -3778,15 +3572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3800,24 +3585,6 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
-name = "enr"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "hex 0.4.3",
- "k256",
- "log",
- "rand 0.8.5",
- "rlp",
- "serde",
- "sha3 0.10.8",
- "zeroize",
-]
 
 [[package]]
 name = "equivalent"
@@ -3841,55 +3608,16 @@ version = "0.4.0"
 source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.4.0#5abd890f79014a86db31286e1f3a529f161e69de"
 
 [[package]]
-name = "eth-keystore"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
-dependencies = [
- "aes",
- "ctr",
- "digest 0.10.7",
- "hex 0.4.3",
- "hmac",
- "pbkdf2 0.11.0",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "thiserror 1.0.69",
- "uuid 0.8.2",
-]
-
-[[package]]
 name = "ethabi"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
 dependencies = [
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex 0.4.3",
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "ethabi"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
-dependencies = [
- "ethereum-types 0.14.1",
- "hex 0.4.3",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3 0.10.8",
  "thiserror 1.0.69",
  "uint",
 ]
@@ -3903,22 +3631,7 @@ dependencies = [
  "crunchy",
  "fixed-hash 0.7.0",
  "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
-dependencies = [
- "crunchy",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "scale-info",
+ "impl-serde",
  "tiny-keccak",
 ]
 
@@ -3928,282 +3641,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom 0.11.1",
+ "ethbloom",
  "fixed-hash 0.7.0",
  "impl-rlp",
- "impl-serde 0.3.2",
+ "impl-serde",
  "primitive-types 0.10.1",
  "uint",
 ]
 
 [[package]]
-name = "ethereum-types"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
-dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
- "scale-info",
- "uint",
-]
-
-[[package]]
-name = "ethers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
-dependencies = [
- "ethers-addressbook",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
-dependencies = [
- "ethers-core",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
-dependencies = [
- "const-hex",
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
- "futures-util",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
-dependencies = [
- "Inflector",
- "const-hex",
- "dunce",
- "ethers-core",
- "ethers-etherscan",
- "eyre",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "syn 2.0.101",
- "toml 0.8.22",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
-dependencies = [
- "Inflector",
- "const-hex",
- "ethers-contract-abigen",
- "ethers-core",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "const-hex",
- "elliptic-curve 0.13.8",
- "ethabi 18.0.0",
- "generic-array 0.14.7",
- "k256",
- "num_enum",
- "once_cell",
- "open-fastrlp",
- "rand 0.8.5",
- "rlp",
- "serde",
- "serde_json",
- "strum 0.26.3",
- "syn 2.0.101",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
-dependencies = [
- "chrono",
- "ethers-core",
- "reqwest 0.11.27",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-contract",
- "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
- "futures-channel",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "const-hex",
- "enr",
- "ethers-core",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "http 0.2.12",
- "instant",
- "jsonwebtoken 8.3.0",
- "once_cell",
- "pin-project",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite 0.20.1",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "const-hex",
- "elliptic-curve 0.13.8",
- "eth-keystore",
- "ethers-core",
- "rand 0.8.5",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
-dependencies = [
- "cfg-if",
- "const-hex",
- "dirs",
- "dunce",
- "ethers-core",
- "glob",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
-]
-
-[[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4220,7 +3669,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "util",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4305,7 +3754,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.3.1",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "rand 0.8.5",
  "reqwest 0.12.15",
  "reqwest-middleware",
@@ -4321,7 +3770,7 @@ dependencies = [
  "tokio-util 0.7.15",
  "tracing",
  "url",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4346,22 +3795,6 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -4401,16 +3834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4420,10 +3843,11 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 name = "funds-manager"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-dyn-abi",
  "alloy-json-rpc",
+ "alloy-primitives 1.0.0",
  "alloy-sol-types 1.0.0",
- "arbitrum-client",
  "aws-config",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
@@ -4437,9 +3861,9 @@ dependencies = [
  "common",
  "config",
  "constants",
+ "darkpool-client",
  "diesel",
  "diesel-async",
- "ethers",
  "external-api",
  "fireblocks-sdk",
  "funds-manager-api",
@@ -4461,7 +3885,7 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid",
  "warp",
 ]
 
@@ -4478,7 +3902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4543,16 +3967,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-locks"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
-dependencies = [
- "futures-channel",
- "futures-task",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4580,10 +3994,6 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
 
 [[package]]
 name = "futures-util"
@@ -4608,15 +4018,6 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "generic-array"
@@ -4697,21 +4098,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -4724,7 +4113,7 @@ dependencies = [
  "sha2 0.10.8",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4834,15 +4223,6 @@ dependencies = [
  "equivalent",
  "foldhash",
  "serde",
-]
-
-[[package]]
-name = "hashers"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
-dependencies = [
- "fxhash",
 ]
 
 [[package]]
@@ -5364,15 +4744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5481,15 +4852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5498,7 +4860,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -5542,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -5558,7 +4920,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -5575,7 +4937,7 @@ dependencies = [
  "serde",
  "tokio",
  "util",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5617,20 +4979,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -5690,36 +5038,6 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "regex",
- "regex-syntax 0.8.5",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -5835,7 +5153,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276bb57e7af15d8f100d3c11cbdd32c6752b7eef4ba7a18ecf464972c07abcce"
 dependencies = [
- "bs58 0.4.0",
+ "bs58",
  "ed25519-dalek 2.1.1",
  "log",
  "multiaddr",
@@ -5880,16 +5198,6 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "void",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags 2.9.0",
- "libc",
 ]
 
 [[package]]
@@ -6134,7 +5442,7 @@ dependencies = [
 [[package]]
 name = "mpc-plonk"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -6166,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "mpc-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#7be2cb7e66e692e7555ec3f469bbb27adc407c52"
+source = "git+https://github.com/renegade-fi/mpc-jellyfish.git#03335708764064c0a56bcc3c5e58c2fd2ae6ac64"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -6324,12 +5632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6450,7 +5752,6 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -6495,31 +5796,6 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "open-fastrlp"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
- "ethereum-types 0.14.1",
- "open-fastrlp-derive",
-]
-
-[[package]]
-name = "open-fastrlp-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
-dependencies = [
- "bytes",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "openraft"
@@ -6711,12 +5987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6851,49 +6121,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.7",
- "hmac",
- "password-hash",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
 
 [[package]]
 name = "pem"
@@ -6932,16 +6163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset",
- "indexmap 2.9.0",
-]
-
-[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6957,31 +6178,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
  "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -7159,12 +6356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7190,7 +6381,7 @@ dependencies = [
  "hex 0.3.2",
  "itertools 0.11.0",
  "job-types",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "lazy_static",
  "reqwest 0.11.27",
  "serde",
@@ -7217,7 +6408,7 @@ dependencies = [
  "fixed-hash 0.7.0",
  "impl-codec 0.5.1",
  "impl-rlp",
- "impl-serde 0.3.2",
+ "impl-serde",
  "uint",
 ]
 
@@ -7229,9 +6420,6 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash 0.8.0",
  "impl-codec 0.6.0",
- "impl-rlp",
- "impl-serde 0.4.0",
- "scale-info",
  "uint",
 ]
 
@@ -7242,7 +6430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror 1.0.69",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -7315,8 +6503,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set 0.8.0",
- "bit-vec 0.8.0",
+ "bit-set",
+ "bit-vec",
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
@@ -7706,7 +6894,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-util 0.7.15",
  "url",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -7725,17 +6913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7800,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7830,7 +7007,7 @@ dependencies = [
  "renegade-dealer-api",
  "serde_json",
  "tokio",
- "uuid 1.16.0",
+ "uuid",
  "warp",
 ]
 
@@ -7844,13 +7021,13 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -7866,10 +7043,10 @@ dependencies = [
 name = "renegade-price-reporter"
 version = "0.1.0"
 dependencies = [
- "arbitrum-client",
  "async-trait",
  "common",
  "config",
+ "darkpool-client",
  "external-api",
  "futures-util",
  "hyper 0.14.32",
@@ -7902,7 +7079,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -7912,7 +7088,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -7921,7 +7096,6 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tokio-util 0.7.15",
  "tower-service",
  "url",
@@ -7929,7 +7103,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -8091,15 +7264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "rkyv"
 version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8114,7 +7278,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -8135,19 +7299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
- "rlp-derive",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlp-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8433,48 +7585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scale-info"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
-dependencies = [
- "cfg-if",
- "derive_more 1.0.0",
- "parity-scale-codec 3.7.4",
- "scale-info-derive",
-]
-
-[[package]]
-name = "scale-info-derive"
-version = "2.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
-dependencies = [
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8512,18 +7622,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scrypt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
-dependencies = [
- "hmac",
- "pbkdf2 0.11.0",
- "salsa20",
- "sha2 0.10.8",
-]
 
 [[package]]
 name = "sct"
@@ -8638,9 +7736,6 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "semver-parser"
@@ -8650,12 +7745,6 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -8713,15 +7802,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -9049,20 +8129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solang-parser"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
-dependencies = [
- "itertools 0.11.0",
- "lalrpop",
- "lalrpop-util",
- "phf",
- "thiserror 1.0.69",
- "unicode-xid",
-]
-
-[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9123,18 +8189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot 0.12.3",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9153,33 +8207,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
+ "strum_macros",
 ]
 
 [[package]]
@@ -9200,26 +8232,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svm-rs"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
-dependencies = [
- "dirs",
- "fs2",
- "hex 0.4.3",
- "once_cell",
- "reqwest 0.11.27",
- "semver 1.0.26",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "url",
- "zip",
-]
 
 [[package]]
 name = "syn"
@@ -9308,7 +8320,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "bus",
  "common",
@@ -9320,7 +8332,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9413,17 +8425,6 @@ dependencies = [
  "once_cell",
  "rustix 1.0.5",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -9580,7 +8581,7 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -9688,21 +8689,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
- "tungstenite 0.20.1",
- "webpki-roots 0.25.4",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
@@ -9728,7 +8714,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
- "webpki-roots 0.26.9",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -9771,25 +8757,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "toml_edit"
@@ -9798,18 +8769,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.9.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "toml_write",
  "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
@@ -10038,26 +9000,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls 0.21.12",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
@@ -10242,7 +9184,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fe047f2cf7c295b3cfdc46afff001043b7a264d4"
+source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -10276,16 +9218,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-serde 0.1.3",
  "tracing-subscriber 0.3.19",
-]
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom 0.2.16",
- "serde",
 ]
 
 [[package]]
@@ -10344,16 +9276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
 ]
 
 [[package]]
@@ -10576,8 +9498,8 @@ dependencies = [
  "base64 0.13.1",
  "bytes",
  "derive_more 0.99.20",
- "ethabi 16.0.0",
- "ethereum-types 0.12.1",
+ "ethabi",
+ "ethereum-types",
  "futures",
  "futures-timer",
  "headers",
@@ -10623,12 +9545,6 @@ dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -10687,15 +9603,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -11103,7 +10010,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version 0.4.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -11130,12 +10037,6 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"
@@ -11271,53 +10172,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2 0.11.0",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,7 @@ lto = true
 [workspace.dependencies]
 # === Renegade Dependencies === #
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-renegade-arbitrum-client = { package = "arbitrum-client", git = "https://github.com/renegade-fi/renegade.git", features = [
-    "rand",
-] }
+renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git"}
 renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
     "auth",
 ] }
@@ -38,6 +36,13 @@ renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
 renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = ["metered-channels"] }
 renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git" }
+
+# === Blockchain Dependencies === #
+alloy-sol-types = "1.0.0"
+alloy-dyn-abi = "1.0.0"
+alloy-json-rpc = "0.14"
+alloy-primitives = "1.0.0"
+alloy = "0.14"
 
 # === Database Dependencies === #
 diesel = { version = "2.1" }

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -33,14 +33,14 @@ aes-gcm = "0.10.1"
 rand = "0.8.5"
 
 # === Ethereum Libraries === #
-alloy = { version = "0.14", features = ["provider-ws"] }
-alloy-primitives = { version = "1.0.0", features = ["serde", "k256"] }
-alloy-sol-types = "1.0.0"
+alloy = { workspace = true, features = ["provider-ws"] }
+alloy-primitives = { workspace = true, features = ["serde", "k256"] }
+alloy-sol-types = { workspace = true }
 
 # === Renegade Dependencies === #
 auth-server-api = { path = "../auth-server-api" }
 contracts-common = { workspace = true }
-renegade-arbitrum-client = { workspace = true }
+renegade-darkpool-client = { workspace = true }
 renegade-circuit-types = { workspace = true }
 renegade-common = { workspace = true }
 renegade-constants = { workspace = true }

--- a/funds-manager/funds-manager-api/Cargo.toml
+++ b/funds-manager/funds-manager-api/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 renegade-api = { package = "external-api", workspace = true }
 renegade-common = { package = "common", workspace = true, default-features = false, features = ["hmac"] }
 
-alloy-primitives = { version = "1.0.0", features = ["serde", "getrandom"] }
+alloy-primitives = { version = "1.0.0", features = ["serde"] }
 http = "0.2.12"
 itertools = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/funds-manager/funds-manager-api/Cargo.toml
+++ b/funds-manager/funds-manager-api/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2021"
 renegade-api = { package = "external-api", workspace = true }
 renegade-common = { package = "common", workspace = true, default-features = false, features = ["hmac"] }
 
-ethers = "2"
-hex = "0.4.3"
+alloy-primitives = { version = "1.0.0", features = ["serde", "getrandom"] }
 http = "0.2.12"
 itertools = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/funds-manager/funds-manager-api/src/lib.rs
+++ b/funds-manager/funds-manager-api/src/lib.rs
@@ -6,3 +6,11 @@ pub mod auth;
 mod serialization;
 mod types;
 pub use types::*;
+
+use alloy_primitives::{ruint::FromUintError, U256};
+
+/// Helper to attempt to convert a U256 to a u128, returning a String error
+/// if it fails
+pub fn u256_try_into_u128(u256: U256) -> Result<u128, String> {
+    u256.try_into().map_err(|e: FromUintError<u128>| e.to_string())
+}

--- a/funds-manager/funds-manager-api/src/serialization.rs
+++ b/funds-manager/funds-manager-api/src/serialization.rs
@@ -1,27 +1,8 @@
 //! Serialization helpers for the funds manager API
 
-/// A module for serializing and deserializing addresses as strings
-pub(crate) mod address_string_serialization {
-    use std::str::FromStr;
-
-    use ethers::types::Address;
-    use serde::{de::Error, Deserialize, Deserializer, Serializer};
-
-    /// Serialize an address to a string
-    pub fn serialize<S: Serializer>(address: &Address, s: S) -> Result<S::Ok, S::Error> {
-        s.serialize_str(&format!("{address:#x}"))
-    }
-
-    /// Deserialize a string to an address
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Address, D::Error> {
-        let s = String::deserialize(d)?;
-        Address::from_str(&s).map_err(|_| D::Error::custom("Invalid address"))
-    }
-}
-
 /// A module for serializing and deserializing U256 as strings
 pub(crate) mod u256_string_serialization {
-    use ethers::types::U256;
+    use alloy_primitives::U256;
     use serde::{de::Error, Deserialize, Deserializer, Serializer};
 
     /// Serialize a U256 to a string
@@ -32,41 +13,21 @@ pub(crate) mod u256_string_serialization {
     /// Deserialize a string to a U256
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<U256, D::Error> {
         let s = String::deserialize(d)?;
-        U256::from_dec_str(&s).map_err(|_| D::Error::custom("Invalid U256 value"))
-    }
-}
-
-/// A module for serializing and deserializing bytes from a hex string
-pub(crate) mod bytes_string_serialization {
-    use ethers::types::Bytes;
-    use hex::FromHex;
-    use serde::{de::Error, Deserialize, Deserializer, Serializer};
-
-    /// Serialize bytes to a hex string
-    pub fn serialize<S: Serializer>(value: &Bytes, s: S) -> Result<S::Ok, S::Error> {
-        let hex = format!("{value:#x}");
-        s.serialize_str(&hex)
-    }
-
-    /// Deserialize a hex string to bytes
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Bytes, D::Error> {
-        let s = String::deserialize(d)?;
-        Bytes::from_hex(s).map_err(|_| D::Error::custom("Invalid bytes value"))
+        U256::from_str_radix(&s, 10).map_err(|_| D::Error::custom("Invalid U256 value"))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use ethers::types::{Address, Bytes, U256};
+    use super::u256_string_serialization;
+    use alloy_primitives::U256;
     use rand::{thread_rng, Rng};
+    use serde::{Deserialize, Serialize};
 
-    /// Test serialization and deserialization of an address
-    #[test]
-    fn test_address_serialization() {
-        let addr = Address::random();
-        let serialized = serde_json::to_string(&addr).unwrap();
-        let deserialized: Address = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(addr, deserialized);
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+    struct TestU256 {
+        #[serde(with = "u256_string_serialization")]
+        value: U256,
     }
 
     /// Test serialization and deserialization of a U256
@@ -75,22 +36,11 @@ mod tests {
         let mut rng = thread_rng();
         let mut bytes = [0u8; 32];
         rng.fill(&mut bytes);
-        let value = U256::from(bytes);
+        let value = U256::from_be_bytes(bytes);
+        let test_value = TestU256 { value };
 
-        let serialized = serde_json::to_string(&value).unwrap();
-        let deserialized: U256 = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(value, deserialized);
-    }
-
-    /// Test serialization and deserialization of bytes
-    #[test]
-    fn test_bytes_serialization() {
-        const N: usize = 32;
-        let mut rng = thread_rng();
-        let bytes: Bytes = (0..N).map(|_| rng.gen_range(0..=u8::MAX)).collect();
-
-        let serialized = serde_json::to_string(&bytes).unwrap();
-        let deserialized: Bytes = serde_json::from_str(&serialized).unwrap();
-        assert_eq!(bytes, deserialized);
+        let serialized = serde_json::to_string(&test_value).unwrap();
+        let deserialized: TestU256 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(test_value, deserialized);
     }
 }

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -1,9 +1,9 @@
 //! API types for quoter management
-use alloy_primitives::{hex, ruint::FromUintError, Address, Bytes, U256};
+use alloy_primitives::{hex, Address, Bytes, U256};
 use renegade_common::types::token::{Token, USDC_TICKER};
 use serde::{Deserialize, Serialize};
 
-use crate::serialization::u256_string_serialization;
+use crate::{serialization::u256_string_serialization, u256_try_into_u128};
 
 // --------------
 // | Api Routes |
@@ -247,14 +247,4 @@ pub struct ExecuteSwapResponse {
 pub struct WithdrawToHyperliquidRequest {
     /// The amount of USDC to withdraw, in decimal format (i.e., whole units)
     pub amount: f64,
-}
-
-// -----------
-// | Helpers |
-// -----------
-
-/// Helper to attempt to convert a U256 to a u128, returning a String error
-/// if it fails
-fn u256_try_into_u128(u256: U256) -> Result<u128, String> {
-    u256.try_into().map_err(|e: FromUintError<u128>| e.to_string())
 }

--- a/funds-manager/funds-manager-api/src/types/venue.rs
+++ b/funds-manager/funds-manager-api/src/types/venue.rs
@@ -1,6 +1,6 @@
 //! Types specific to execution venue (LiFi) integration
 //! as defined in https://apidocs.li.fi/reference/get_v1-quote
-use ethers::types::{Bytes, U256};
+use alloy_primitives::{hex, Bytes, U256};
 use serde::Deserialize;
 
 use super::quoters::ExecutionQuote;

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -32,15 +32,14 @@ postgres-native-tls = "0.5"
 tokio-postgres = "0.7.7"
 
 # === Blockchain Interaction === #
-alloy-sol-types = "1.0.0"
-alloy-dyn-abi = { version = "1.0.0", features = ["eip712"] }
-alloy-json-rpc = "0.14.0"
-ethers = "2"
+alloy-sol-types = { workspace = true }
+alloy-dyn-abi = { workspace = true, features = ["eip712"] }
+alloy-json-rpc = { workspace = true }
+alloy-primitives = { workspace = true, features = ["serde"] }
+alloy = { workspace = true }
 
 # === Renegade Dependencies === #
-renegade-arbitrum-client = { package = "arbitrum-client", workspace = true, features = [
-  "rand",
-] }
+renegade-darkpool-client = { package = "darkpool-client", workspace = true, features = [ "arbitrum" ] }
 renegade-api = { package = "external-api", workspace = true }
 renegade-common = { package = "common", workspace = true }
 renegade-config = { package = "config", workspace = true }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -43,9 +43,7 @@ pub const MIN_HYPERLIQUID_DEPOSIT_AMOUNT: f64 = 5.0; // USDC
 
 /// Handler for indexing fees
 pub(crate) async fn index_fees_handler(server: Arc<Server>) -> Result<Json, warp::Rejection> {
-    let indexer = server
-        .build_indexer()
-        .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+    let indexer = server.build_indexer();
     indexer
         .index_fees()
         .await
@@ -55,9 +53,7 @@ pub(crate) async fn index_fees_handler(server: Arc<Server>) -> Result<Json, warp
 
 /// Handler for redeeming fees
 pub(crate) async fn redeem_fees_handler(server: Arc<Server>) -> Result<Json, warp::Rejection> {
-    let indexer = server
-        .build_indexer()
-        .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+    let indexer = server.build_indexer();
     indexer
         .redeem_fees()
         .await
@@ -70,7 +66,7 @@ pub(crate) async fn get_fee_wallets_handler(
     _body: Bytes, // no body
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let indexer = server.build_indexer()?;
+    let indexer = server.build_indexer();
     let wallets = indexer.fetch_fee_wallets().await?;
     Ok(warp::reply::json(&FeeWalletsResponse { wallets }))
 }
@@ -80,7 +76,7 @@ pub(crate) async fn withdraw_fee_balance_handler(
     req: WithdrawFeeBalanceRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let indexer = server.build_indexer()?;
+    let indexer = server.build_indexer();
     indexer
         .withdraw_fee_balance(req.wallet_id, req.mint)
         .await

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -1,33 +1,27 @@
 //! Helpers for the funds manager server
 #![allow(missing_docs)]
 
+use alloy::sol;
 use aws_config::SdkConfig;
 use aws_sdk_secretsmanager::client::Client as SecretsManagerClient;
-use ethers::{contract::abigen, types::H256};
 use renegade_util::err_str;
 
 use crate::error::FundsManagerError;
-
-/// A readable type alias for a transaction hash
-pub type TransactionHash = H256;
 
 // ---------
 // | ERC20 |
 // ---------
 
 // The ERC20 interface
-abigen!(
-    ERC20,
-    r#"[
-        event Transfer(address indexed from, address indexed to, uint256 value)
-        function symbol() external view returns (string memory)
-        function decimals() external view returns (uint8)
-        function balanceOf(address account) external view returns (uint256)
-        function allowance(address owner, address spender) external view returns (uint256)
-        function approve(address spender, uint256 value) external returns (bool)
-        function transfer(address recipient, uint256 amount) external returns (bool)
-    ]"#
-);
+sol! {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    function symbol() external view returns (string memory);
+    function decimals() external view returns (uint8);
+    function balanceOf(address account) external view returns (uint256);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 value) external returns (bool);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+}
 
 // -----------------------
 // | AWS Secrets Manager |

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -57,7 +57,7 @@ use warp::Filter;
 use std::{collections::HashMap, error::Error, sync::Arc};
 
 use clap::Parser;
-use renegade_arbitrum_client::constants::Chain;
+use renegade_darkpool_client::constants::Chain;
 use tracing::{error, warn};
 
 use crate::custody_client::CustodyClient;

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -1,14 +1,15 @@
 //! Defines functionality to compute and record data for swap execution
 
-use ethers::types::{Address, TransactionReceipt, U256};
-use funds_manager_api::quoters::ExecutionQuote;
+use alloy::{contract::Event, rpc::types::TransactionReceipt};
+use alloy_primitives::{Address, TxHash, U256};
+use funds_manager_api::{quoters::ExecutionQuote, u256_try_into_u128};
 use serde::Serialize;
 use tracing::{info, warn};
 
 use super::MetricsRecorder;
 use crate::{
     error::FundsManagerError,
-    helpers::{TransactionHash, TransferFilter, ERC20},
+    helpers::Transfer,
     metrics::labels::{
         ASSET_TAG, HASH_TAG, SWAP_EXECUTION_COST_METRIC_NAME, SWAP_NOTIONAL_VOLUME_METRIC_NAME,
         SWAP_RELATIVE_SPREAD_METRIC_NAME, TRADE_SIDE_FACTOR_TAG,
@@ -96,23 +97,33 @@ impl MetricsRecorder {
         receipt: &TransactionReceipt,
         quote: &ExecutionQuote,
     ) -> Result<SwapExecutionData, FundsManagerError> {
-        let mint = quote.get_base_token().get_ethers_address();
+        let mint = quote.get_base_token().get_alloy_address();
 
         let binance_price = self.get_binance_price(&mint).await?;
         let buy_amount_actual = self.get_buy_amount_actual(receipt, mint, quote.from).await?;
 
-        let execution_price = quote.get_price(Some(buy_amount_actual));
-        let notional_volume_usdc = quote.notional_volume_usdc(buy_amount_actual);
+        let execution_price =
+            quote.get_price(Some(buy_amount_actual)).map_err(FundsManagerError::parse)?;
+        let notional_volume_usdc =
+            quote.notional_volume_usdc(buy_amount_actual).map_err(FundsManagerError::parse)?;
 
         let trade_side_factor = if quote.is_buy() { 1.0 } else { -1.0 };
         let relative_spread = trade_side_factor * (execution_price - binance_price) / binance_price;
         let execution_cost_usdc = notional_volume_usdc * relative_spread;
 
         // Calculate slippage metrics
-        let decimal_corrected_buy_amount_estimated = quote.get_decimal_corrected_buy_amount();
-        let decimal_corrected_buy_amount_min = quote.get_decimal_corrected_buy_amount_min();
+        let decimal_corrected_buy_amount_estimated =
+            quote.get_decimal_corrected_buy_amount().map_err(FundsManagerError::parse)?;
+        let decimal_corrected_buy_amount_min =
+            quote.get_decimal_corrected_buy_amount_min().map_err(FundsManagerError::parse)?;
+
+        let buy_amount_actual =
+            u256_try_into_u128(buy_amount_actual).map_err(FundsManagerError::parse)?;
         let decimal_corrected_buy_amount_actual =
-            quote.get_buy_token().convert_to_decimal(buy_amount_actual.as_u128());
+            quote.get_buy_token().convert_to_decimal(buy_amount_actual);
+
+        let sell_amount =
+            quote.get_decimal_corrected_sell_amount().map_err(FundsManagerError::parse)?;
 
         let slippage_budget =
             decimal_corrected_buy_amount_estimated - decimal_corrected_buy_amount_min;
@@ -126,7 +137,7 @@ impl MetricsRecorder {
             // Token information
             buy_token_address: quote.get_buy_token_address(),
             sell_token_address: quote.get_sell_token_address(),
-            sell_amount: quote.get_decimal_corrected_sell_amount().to_string(),
+            sell_amount: sell_amount.to_string(),
             buy_amount_estimated: decimal_corrected_buy_amount_estimated.to_string(),
             buy_amount_min: decimal_corrected_buy_amount_min.to_string(),
             from_address: quote.get_from_address(),
@@ -173,7 +184,7 @@ impl MetricsRecorder {
         quote: &ExecutionQuote,
         receipt: &TransactionReceipt,
     ) -> Vec<(String, String)> {
-        let mint = format!("{:#x}", quote.get_base_token().get_ethers_address());
+        let mint = format!("{:#x}", quote.get_base_token().get_alloy_address());
         let asset = quote.get_base_token().get_ticker().unwrap_or(mint);
         let side_label = if quote.is_buy() { "buy" } else { "sell" };
 
@@ -191,24 +202,22 @@ impl MetricsRecorder {
         mint: Address,
         recipient: Address,
     ) -> Result<U256, FundsManagerError> {
-        let block_number = receipt.block_number.unwrap_or_default().as_u64();
+        let block_number = receipt.block_number.unwrap_or_default();
 
-        let contract = ERC20::new(mint, self.provider.clone());
-        let filter = contract
-            .event::<TransferFilter>()
+        let filter = Event::<_, Transfer>::new_sol(&self.provider, &mint)
             .from_block(block_number)
             .to_block(block_number)
             .topic2(recipient);
 
         let events = filter
-            .query_with_meta()
+            .query()
             .await
             .map_err(|_| FundsManagerError::arbitrum("failed to create transfer stream"))?;
 
         // Find the transfer event that matches our transaction hash
         let transfer_event = events
             .iter()
-            .find(|(_, meta)| meta.transaction_hash == receipt.transaction_hash)
+            .find(|(_, meta)| meta.transaction_hash == Some(receipt.transaction_hash))
             .ok_or_else(|| FundsManagerError::custom("No matching transfer event found"))?;
 
         Ok(transfer_event.0.value)
@@ -221,7 +230,7 @@ impl MetricsRecorder {
     }
 
     /// Log swap cost data in a Datadog-compatible format
-    fn log_swap_cost_data(&self, cost_data: &SwapExecutionData, tx_hash: TransactionHash) {
+    fn log_swap_cost_data(&self, cost_data: &SwapExecutionData, tx_hash: TxHash) {
         info!(
             buy_token_address = %cost_data.buy_token_address,
             sell_token_address = %cost_data.sell_token_address,

--- a/funds-manager/funds-manager-server/src/metrics/mod.rs
+++ b/funds-manager/funds-manager-server/src/metrics/mod.rs
@@ -1,7 +1,6 @@
 //! General metrics recording functionality
 
-use ethers::prelude::*;
-use std::sync::Arc;
+use alloy::providers::{DynProvider, ProviderBuilder};
 
 use crate::relayer_client::RelayerClient;
 
@@ -15,15 +14,16 @@ pub struct MetricsRecorder {
     /// Client for interacting with the relayer
     pub relayer_client: RelayerClient,
     /// Ethereum provider for querying chain events
-    pub provider: Arc<Provider<Http>>,
+    pub provider: DynProvider,
 }
 
 impl MetricsRecorder {
     /// Create a new metrics recorder
     pub fn new(relayer_client: RelayerClient, rpc_url: String) -> Self {
-        let provider = Provider::<Http>::try_from(rpc_url).unwrap();
-        let provider = Arc::new(provider);
+        let url = rpc_url.parse().expect("invalid RPC URL");
+        let provider = ProviderBuilder::new().on_http(url);
+        let dyn_provider = DynProvider::new(provider);
 
-        MetricsRecorder { relayer_client, provider }
+        MetricsRecorder { relayer_client, provider: dyn_provider }
     }
 }

--- a/funds-manager/funds-manager-server/src/relayer_client.rs
+++ b/funds-manager/funds-manager-server/src/relayer_client.rs
@@ -2,8 +2,8 @@
 
 use std::time::Duration;
 
+use alloy::signers::local::PrivateKeySigner;
 use base64::engine::{general_purpose as b64_general_purpose, Engine};
-use ethers::signers::LocalWallet;
 use http::{HeaderMap, HeaderValue};
 use renegade_api::{
     http::{
@@ -101,7 +101,7 @@ impl RelayerClient {
         &self,
         wallet_id: WalletIdentifier,
         chain_id: u64,
-        eth_key: &LocalWallet,
+        eth_key: &PrivateKeySigner,
     ) -> Result<(), FundsManagerError> {
         let mut path = GET_WALLET_ROUTE.to_string();
         path = path.replace(":wallet_id", &wallet_id.to_string());
@@ -120,7 +120,7 @@ impl RelayerClient {
     async fn lookup_wallet(
         &self,
         chain_id: u64,
-        eth_key: &LocalWallet,
+        eth_key: &PrivateKeySigner,
     ) -> Result<(), FundsManagerError> {
         let path = FIND_WALLET_ROUTE.to_string();
         let wallet_id = derive_wallet_id(eth_key).unwrap();

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -1,18 +1,16 @@
 //! Defines the server which encapsulates all dependencies for funds manager
 //! execution
 
-use std::{error::Error, str::FromStr, sync::Arc};
+use std::{error::Error, str::FromStr, sync::Arc, time::Duration};
 
+use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::Address;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
-use ethers::{signers::LocalWallet, types::Address};
 use funds_manager_api::quoters::ExecutionQuote;
-use renegade_arbitrum_client::{
-    client::{ArbitrumClient, ArbitrumClientConfig},
-    constants::Chain,
-};
 use renegade_circuit_types::elgamal::DecryptionKey;
 use renegade_common::types::hmac::HmacKey;
 use renegade_config::setup_token_remaps;
+use renegade_darkpool_client::{client::DarkpoolClientConfig, constants::Chain, DarkpoolClient};
 use renegade_util::raw_err_str;
 
 use crate::{
@@ -30,16 +28,10 @@ use crate::{
 // | Constants |
 // -------------
 
-/// The block polling interval for the Arbitrum client
-const BLOCK_POLLING_INTERVAL_MS: u64 = 100;
+/// The block polling interval for the darkpool client
+const BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 /// The default region in which to provision secrets manager secrets
 const DEFAULT_REGION: &str = "us-east-2";
-/// The dummy private key used to instantiate the arbitrum client
-///
-/// We don't need any client functionality using a real private key, so instead
-/// we use the key deployed by Arbitrum on local devnets
-const DUMMY_PRIVATE_KEY: &str =
-    "0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659";
 
 /// The server
 #[derive(Clone)]
@@ -50,8 +42,8 @@ pub(crate) struct Server {
     pub chain: Chain,
     /// A client for interacting with the relayer
     pub relayer_client: RelayerClient,
-    /// The Arbitrum client
-    pub arbitrum_client: ArbitrumClient,
+    /// The darkpool client
+    pub darkpool_client: DarkpoolClient,
     /// The decryption key
     pub decryption_keys: Vec<DecryptionKey>,
     /// The database connection pool
@@ -85,16 +77,16 @@ impl Server {
             .load()
             .await;
 
-        // Build an Arbitrum client
-        let wallet = LocalWallet::from_str(DUMMY_PRIVATE_KEY)?;
-        let conf = ArbitrumClientConfig {
+        // Build a darkpool client
+        let private_key = PrivateKeySigner::random();
+        let conf = DarkpoolClientConfig {
             darkpool_addr: args.darkpool_address.clone(),
             chain: args.chain,
             rpc_url: args.rpc_url.clone(),
-            arb_priv_keys: vec![wallet],
-            block_polling_interval_ms: BLOCK_POLLING_INTERVAL_MS,
+            private_key,
+            block_polling_interval: BLOCK_POLLING_INTERVAL,
         };
-        let client = ArbitrumClient::new(conf).await?;
+        let client = DarkpoolClient::new(conf)?;
         let chain_id =
             client.chain_id().await.map_err(raw_err_str!("Error fetching chain ID: {}"))?;
 
@@ -137,7 +129,7 @@ impl Server {
             chain_id,
             chain: args.chain,
             relayer_client: relayer_client.clone(),
-            arbitrum_client: client.clone(),
+            darkpool_client: client.clone(),
             decryption_keys,
             db_pool: arc_pool,
             custody_client,
@@ -150,17 +142,17 @@ impl Server {
     }
 
     /// Build an indexer
-    pub fn build_indexer(&self) -> Result<Indexer, FundsManagerError> {
-        Ok(Indexer::new(
+    pub fn build_indexer(&self) -> Indexer {
+        Indexer::new(
             self.chain_id,
             self.chain,
             self.aws_config.clone(),
-            self.arbitrum_client.clone(),
+            self.darkpool_client.clone(),
             self.decryption_keys.clone(),
             self.db_pool.clone(),
             self.relayer_client.clone(),
             self.custody_client.clone(),
-        ))
+        )
     }
 
     /// Sign a quote using the quote HMAC key and returns the signature as a

--- a/price-reporter/Cargo.toml
+++ b/price-reporter/Cargo.toml
@@ -28,7 +28,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # === Renegade === #
 renegade-price-reporter = { package = "price-reporter", workspace = true }
 renegade-api = { package = "external-api", workspace = true }
-renegade-arbitrum-client = { package = "arbitrum-client", workspace = true }
+renegade-darkpool-client = { package = "darkpool-client", workspace = true }
 renegade-config = { package = "config", workspace = true }
 renegade-common = { package = "common", workspace = true }
 renegade-util = { package = "util", workspace = true }


### PR DESCRIPTION
This PR begins migrating the `funds-manager` crates to using `alloy` and the new `DarkpoolClient` as opposed to `ethers` and the old `ArbitrumClient`. In this PR, we migrate the `funds-manager-api` crate and some top-level modules of the `funds-manager-server` crate.

This is part of a larger effort to migrate the entire extensions repo to `alloy` and the `DarkpoolClient`.

The `funds-manager`, `auth`, and `price-reporter` crates are not expected to build until this refactor is complete.