### PR TITLE
funds-manager-server: fee_indexer: use alloy & darkpoolclient

### DIFF
--- a/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/fee_balances.rs
@@ -3,18 +3,12 @@
 use crate::custody_client::DepositWithdrawSource;
 use crate::db::models::RenegadeWalletMetadata;
 use crate::error::FundsManagerError;
-use ethers::{
-    core::k256::ecdsa::SigningKey,
-    types::{Signature, U256},
-    utils::keccak256,
-};
+use alloy::signers::k256::ecdsa::SigningKey;
+use alloy_primitives::{keccak256, Signature};
 use num_bigint::BigUint;
 use renegade_api::{
     http::wallet::{WalletUpdateAuthorization, WithdrawBalanceRequest},
     types::ApiWallet,
-};
-use renegade_arbitrum_client::{
-    conversion::to_contract_external_transfer, helpers::serialize_calldata,
 };
 use renegade_circuit_types::{
     keychain::SecretSigningKey,
@@ -22,6 +16,9 @@ use renegade_circuit_types::{
     Amount,
 };
 use renegade_common::types::wallet::{derivation::derive_wallet_keychain, Wallet};
+use renegade_darkpool_client::arbitrum::{
+    contract_types::conversion::to_contract_external_transfer, helpers::serialize_calldata,
+};
 use renegade_util::hex::biguint_from_hex_string;
 use uuid::Uuid;
 
@@ -132,16 +129,14 @@ impl Indexer {
             dest_bigint.clone(),
         )?;
 
-        let update_auth = WalletUpdateAuthorization {
-            statement_sig: commitment_sig.to_vec(),
-            new_root_key: None,
-        };
+        let update_auth =
+            WalletUpdateAuthorization { statement_sig: commitment_sig.into(), new_root_key: None };
 
         Ok(WithdrawBalanceRequest {
             destination_addr: dest_bigint,
             amount: BigUint::from(bal.amount),
             update_auth,
-            external_transfer_sig: transfer_sig.to_vec(),
+            external_transfer_sig: transfer_sig.into(),
         })
     }
 
@@ -167,13 +162,10 @@ impl Indexer {
             to_contract_external_transfer(&transfer).map_err(FundsManagerError::custom)?;
         let buf = serialize_calldata(&contract_transfer).map_err(FundsManagerError::custom)?;
         let digest = keccak256(&buf);
-        let (sig, recovery_id) =
-            converted_key.sign_prehash_recoverable(&digest).map_err(FundsManagerError::custom)?;
+        let recoverable_sig = converted_key
+            .sign_prehash_recoverable(digest.as_slice())
+            .map_err(FundsManagerError::custom)?;
 
-        Ok(Signature {
-            r: U256::from_big_endian(&sig.r().to_bytes()),
-            s: U256::from_big_endian(&sig.s().to_bytes()),
-            v: recovery_id.to_byte() as u64,
-        })
+        Ok(recoverable_sig.into())
     }
 }

--- a/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
@@ -1,8 +1,8 @@
 //! The indexer handles the indexing and redemption of fee notes
 
 use aws_config::SdkConfig as AwsConfig;
-use renegade_arbitrum_client::{client::ArbitrumClient, constants::Chain};
 use renegade_circuit_types::elgamal::DecryptionKey;
+use renegade_darkpool_client::{constants::Chain, DarkpoolClient};
 use renegade_util::err_str;
 use renegade_util::hex::jubjub_from_hex_string;
 use std::sync::Arc;
@@ -25,8 +25,8 @@ pub(crate) struct Indexer {
     pub chain: Chain,
     /// A client for interacting with the relayer
     pub relayer_client: RelayerClient,
-    /// The Arbitrum client
-    pub arbitrum_client: ArbitrumClient,
+    /// The darkpool client
+    pub darkpool_client: DarkpoolClient,
     /// The decryption key
     pub decryption_keys: Vec<DecryptionKey>,
     /// The database connection pool
@@ -44,7 +44,7 @@ impl Indexer {
         chain_id: u64,
         chain: Chain,
         aws_config: AwsConfig,
-        arbitrum_client: ArbitrumClient,
+        darkpool_client: DarkpoolClient,
         decryption_keys: Vec<DecryptionKey>,
         db_pool: Arc<DbPool>,
         relayer_client: RelayerClient,
@@ -53,7 +53,7 @@ impl Indexer {
         Indexer {
             chain_id,
             chain,
-            arbitrum_client,
+            darkpool_client,
             decryption_keys,
             db_pool,
             relayer_client,

--- a/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
@@ -3,11 +3,9 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::TxHash;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
-use ethers::core::rand::thread_rng;
-use ethers::signers::LocalWallet;
-use ethers::types::TxHash;
-use ethers::utils::hex;
 use renegade_api::http::wallet::RedeemNoteRequest;
 use renegade_circuit_types::note::Note;
 use renegade_common::types::wallet::derivation::{
@@ -108,8 +106,8 @@ impl Indexer {
     /// Create a new Renegade wallet on-chain
     async fn create_renegade_wallet(
         &self,
-    ) -> Result<(WalletIdentifier, LocalWallet), FundsManagerError> {
-        let root_key = LocalWallet::new(&mut thread_rng());
+    ) -> Result<(WalletIdentifier, PrivateKeySigner), FundsManagerError> {
+        let root_key = PrivateKeySigner::random();
 
         let wallet_id = derive_wallet_id(&root_key).map_err(FundsManagerError::custom)?;
         let blinder_seed = derive_blinder_seed(&root_key).map_err(FundsManagerError::custom)?;
@@ -167,7 +165,7 @@ impl Indexer {
     ) -> Result<(), FundsManagerError> {
         let nullifier = note.nullifier();
         if !self
-            .arbitrum_client
+            .darkpool_client
             .check_nullifier_used(nullifier)
             .await
             .map_err(err_str!(FundsManagerError::Arbitrum))?
@@ -191,13 +189,13 @@ impl Indexer {
     async fn store_wallet_secret(
         &self,
         id: WalletIdentifier,
-        wallet: LocalWallet,
+        wallet: PrivateKeySigner,
     ) -> Result<String, FundsManagerError> {
         let secret_name = format!("redemption-wallet-{}-{id}", self.chain);
-        let secret_val = hex::encode(wallet.signer().to_bytes());
+        let secret_val = hex::encode(wallet.to_bytes());
 
-        // Check that the `LocalWallet` recovers the same
-        debug_assert_eq!(LocalWallet::from_str(&secret_val).unwrap(), wallet);
+        // Check that the `PrivateKeySigner` recovers the same
+        debug_assert_eq!(PrivateKeySigner::from_str(&secret_val).unwrap(), wallet);
         create_secrets_manager_entry_with_description(
             &secret_name,
             &secret_val,
@@ -212,7 +210,7 @@ impl Indexer {
     pub(crate) async fn get_wallet_private_key(
         &self,
         metadata: &RenegadeWalletMetadata,
-    ) -> Result<LocalWallet, FundsManagerError> {
+    ) -> Result<PrivateKeySigner, FundsManagerError> {
         let client = SecretsManagerClient::new(&self.aws_config);
         let secret_name = format!("redemption-wallet-{}-{}", self.chain, metadata.id);
 
@@ -225,7 +223,7 @@ impl Indexer {
 
         let secret_str = secret.secret_string().unwrap();
         let wallet =
-            LocalWallet::from_str(secret_str).map_err(err_str!(FundsManagerError::Parse))?;
+            PrivateKeySigner::from_str(secret_str).map_err(err_str!(FundsManagerError::Parse))?;
         Ok(wallet)
     }
 }

--- a/funds-manager/funds-manager-server/src/relayer_client.rs
+++ b/funds-manager/funds-manager-server/src/relayer_client.rs
@@ -343,6 +343,7 @@ fn reqwest_client() -> Result<Client, FundsManagerError> {
 }
 
 /// Build authentication headers for a request
+// TODO: Use v2 auth helpers from renegade-api
 fn build_auth_headers(key: &HmacKey, req_bytes: &[u8]) -> Result<HeaderMap, String> {
     let mut headers = HeaderMap::new();
     let expiration = get_current_time_millis() + SIG_EXPIRATION_BUFFER_MS;


### PR DESCRIPTION
This PR upgrades the `fee_indexer` module of the `funds-manager-server` crate to use `alloy` instead of `ethers`, and use the new `DarkpoolClient` helpers from the relayer repo.