### PR TITLE
auth-server: handle_external_match: record metric for # quotes not found

### DIFF
--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -35,7 +35,8 @@ use crate::{
 
 use super::{
     labels::{
-        KEY_DESCRIPTION_METRIC_TAG, NUM_EXTERNAL_MATCH_REQUESTS, REQUEST_PATH_METRIC_TAG, SIDE_TAG,
+        KEY_DESCRIPTION_METRIC_TAG, NUM_EXTERNAL_MATCH_REQUESTS, QUOTE_NOT_FOUND_COUNT,
+        REQUEST_PATH_METRIC_TAG, SIDE_TAG,
     },
     quote_comparison::QuoteComparison,
 };
@@ -240,6 +241,20 @@ pub(crate) fn record_relayer_request_500(key_description: String, path: String) 
     ];
 
     metrics::counter!(UNSUCCESSFUL_RELAYER_REQUEST_COUNT, &labels).increment(1);
+}
+
+/// Record a counter metric for quote requests for which the relayer could not
+/// produce a quote
+pub(crate) fn record_quote_not_found(key_description: String, base_mint: &str) {
+    let base_token = Token::from_addr(base_mint);
+    let base_asset = base_token.get_ticker().unwrap_or(base_mint.to_string());
+
+    let labels = vec![
+        (KEY_DESCRIPTION_METRIC_TAG.to_string(), key_description),
+        (BASE_ASSET_METRIC_TAG.to_string(), base_asset),
+    ];
+
+    metrics::counter!(QUOTE_NOT_FOUND_COUNT, &labels).increment(1);
 }
 
 // --- Settlement Processing --- //

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -47,6 +47,8 @@ pub const GAS_SPONSORSHIP_VALUE: &str = "gas_sponsorship_value";
 
 /// Metric describing the number of unsuccessful relayer requests
 pub const UNSUCCESSFUL_RELAYER_REQUEST_COUNT: &str = "num_unsuccessful_relayer_requests";
+/// Metric describing the number of times a quote was not found
+pub const QUOTE_NOT_FOUND_COUNT: &str = "num_quotes_not_found";
 
 // ---------------
 // | METRIC TAGS |


### PR DESCRIPTION
This PR adds a counter metric that is incremented every time the relayer cannot produce a quote for a given quote request.

### Testing
- [x] Test in testnet