### PR TITLE
auth-server: use DarkpoolClient

### DIFF
--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -40,7 +40,7 @@ alloy-sol-types = { workspace = true }
 # === Renegade Dependencies === #
 auth-server-api = { path = "../auth-server-api" }
 contracts-common = { workspace = true }
-renegade-darkpool-client = { workspace = true }
+renegade-darkpool-client = { workspace = true, features = ["arbitrum"] }
 renegade-circuit-types = { workspace = true }
 renegade-common = { workspace = true }
 renegade-constants = { workspace = true }

--- a/auth/auth-server/src/chain_events/error.rs
+++ b/auth/auth-server/src/chain_events/error.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error, fmt::Display};
 
-use renegade_arbitrum_client::errors::ArbitrumClientError;
+use renegade_darkpool_client::errors::DarkpoolClientError;
 
 use crate::error::AuthServerError;
 
@@ -10,8 +10,8 @@ use crate::error::AuthServerError;
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum OnChainEventListenerError {
-    /// An error executing some method in the Arbitrum client
-    Arbitrum(String),
+    /// An error executing some method in the darkpool client
+    Darkpool(String),
     /// An RPC error with the provider
     Rpc(String),
     /// Error setting up the on-chain event listener
@@ -23,10 +23,10 @@ pub enum OnChainEventListenerError {
 }
 
 impl OnChainEventListenerError {
-    /// Create a new arbitrum error
+    /// Create a new darkpool error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn arbitrum<T: ToString>(e: T) -> Self {
-        OnChainEventListenerError::Arbitrum(e.to_string())
+    pub fn darkpool<T: ToString>(e: T) -> Self {
+        OnChainEventListenerError::Darkpool(e.to_string())
     }
 
     /// Create a new auth server error
@@ -43,9 +43,9 @@ impl Display for OnChainEventListenerError {
 }
 impl Error for OnChainEventListenerError {}
 
-impl From<ArbitrumClientError> for OnChainEventListenerError {
-    fn from(e: ArbitrumClientError) -> Self {
-        OnChainEventListenerError::arbitrum(e)
+impl From<DarkpoolClientError> for OnChainEventListenerError {
+    fn from(e: DarkpoolClientError) -> Self {
+        OnChainEventListenerError::darkpool(e)
     }
 }
 

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -47,9 +47,9 @@ pub enum AuthServerError {
     /// Price reporter error
     #[error("Price reporter error: {0}")]
     PriceReporter(#[from] PriceReporterError),
-    /// Arbitrum client error
-    #[error("Arbitrum client error: {0}")]
-    ArbitrumClient(String),
+    /// Darkpool client error
+    #[error("Darkpool client error: {0}")]
+    DarkpoolClient(String),
     /// Gas cost sampler error
     #[error("Gas cost sampler error: {0}")]
     GasCostSampler(String),
@@ -125,10 +125,10 @@ impl AuthServerError {
         Self::Custom(msg.to_string())
     }
 
-    /// Create a new arbitrum client error
+    /// Create a new darkpool client error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn arbitrum_client<T: ToString>(msg: T) -> Self {
-        Self::ArbitrumClient(msg.to_string())
+    pub fn darkpool_client<T: ToString>(msg: T) -> Self {
+        Self::DarkpoolClient(msg.to_string())
     }
 
     /// Create a new gas cost sampler error

--- a/auth/auth-server/src/helpers.rs
+++ b/auth/auth-server/src/helpers.rs
@@ -1,40 +1,24 @@
 //! Helper methods for the auth server
 use alloy::signers::local::PrivateKeySigner;
-use renegade_arbitrum_client::{
-    client::{ArbitrumClient, ArbitrumClientConfig},
-    constants::Chain,
-};
-use std::str::FromStr;
+use renegade_darkpool_client::{client::DarkpoolClientConfig, constants::Chain, DarkpoolClient};
+use std::time::Duration;
 
 /// The interval at which we poll filter updates
-const DEFAULT_BLOCK_POLLING_INTERVAL_MS: u64 = 100;
+const DEFAULT_BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 
-/// The dummy private key used to instantiate the arbitrum client
-///
-/// We don't need any client functionality using a real private key, so instead
-/// we use the key deployed by Arbitrum on local devnets
-const DUMMY_PRIVATE_KEY: &str =
-    "0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659";
-
-/// Create an Arbitrum client with the provided configuration
-pub async fn create_arbitrum_client(
+/// Create a darkpool client with the provided configuration
+pub async fn create_darkpool_client(
     darkpool_address: String,
     chain_id: Chain,
     rpc_url: String,
-) -> Result<ArbitrumClient, String> {
-    // Parse the wallet
-    let wallet = match PrivateKeySigner::from_str(DUMMY_PRIVATE_KEY) {
-        Ok(wallet) => wallet,
-        Err(e) => return Err(format!("Failed to parse wallet: {}", e)),
-    };
-
+) -> Result<DarkpoolClient, String> {
     // Create the client
-    ArbitrumClient::new(ArbitrumClientConfig {
+    DarkpoolClient::new(DarkpoolClientConfig {
         darkpool_addr: darkpool_address,
         chain: chain_id,
         rpc_url,
-        private_key: wallet,
-        block_polling_interval_ms: DEFAULT_BLOCK_POLLING_INTERVAL_MS,
+        private_key: PrivateKeySigner::random(),
+        block_polling_interval: DEFAULT_BLOCK_POLLING_INTERVAL,
     })
-    .map_err(|e| format!("Failed to create Arbitrum client: {e}"))
+    .map_err(|e| format!("Failed to create darkpool client: {e}"))
 }

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -26,7 +26,7 @@ mod server;
 mod store;
 mod telemetry;
 
-use renegade_arbitrum_client::constants::Chain;
+use renegade_darkpool_client::constants::Chain;
 use renegade_system_clock::SystemClock;
 
 use auth_server_api::API_KEYS_PATH;
@@ -95,7 +95,7 @@ pub struct Cli {
     /// The Ethereum RPC node websocket address to dial for on-chain data
     #[clap(long = "eth-websocket-url", value_parser, env = "ETH_WEBSOCKET_URL")]
     pub eth_websocket_addr: Option<String>,
-    /// The Arbitrum RPC url to use
+    /// The RPC url to use
     #[clap(short, long, env = "RPC_URL")]
     rpc_url: String,
     /// The address of the darkpool contract

--- a/auth/auth-server/src/server/gas_estimation/gas_cost_sampler.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_cost_sampler.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use alloy::primitives::{Address, U256};
 use alloy::sol;
 use rand::{thread_rng, RngCore};
-use renegade_arbitrum_client::client::RenegadeProvider;
+use renegade_darkpool_client::client::RenegadeProvider;
 use renegade_system_clock::{SystemClock, SystemClockError};
 use tokio::sync::RwLock;
 

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/contract_interaction.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/contract_interaction.rs
@@ -3,7 +3,7 @@
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_sol_types::{sol, SolCall};
 use renegade_api::http::external_match::{ExternalMatchResponse, MalleableExternalMatchResponse};
-use renegade_arbitrum_client::abi::Darkpool::{
+use renegade_darkpool_client::arbitrum::abi::Darkpool::{
     processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
     processMalleableAtomicMatchSettleCall, processMalleableAtomicMatchSettleWithReceiverCall,
 };

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -4,14 +4,14 @@
 use alloy_sol_types::SolCall;
 use contracts_common::types::MatchPayload;
 use renegade_api::http::external_match::{AtomicMatchApiBundle, ExternalOrder};
-use renegade_arbitrum_client::{
-    abi::Darkpool::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
-    helpers::deserialize_calldata,
-};
 use renegade_circuit_types::{fixed_point::FixedPoint, order::OrderSide, wallet::Nullifier};
 use renegade_common::types::token::Token;
 use renegade_constants::{
     Scalar, EXTERNAL_MATCH_RELAYER_FEE, NATIVE_ASSET_ADDRESS, NATIVE_ASSET_WRAPPER_TICKER,
+};
+use renegade_darkpool_client::arbitrum::{
+    abi::Darkpool::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
+    helpers::deserialize_calldata,
 };
 use renegade_util::hex::{biguint_from_hex_string, biguint_to_hex_addr};
 use tracing::warn;

--- a/auth/auth-server/src/telemetry/quote_comparison/handler.rs
+++ b/auth/auth-server/src/telemetry/quote_comparison/handler.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 use alloy::providers::Provider;
 use alloy_primitives::{utils::format_units, U256};
 use futures_util::future::join_all;
-use renegade_arbitrum_client::client::ArbitrumClient;
 use renegade_circuit_types::order::OrderSide;
 use renegade_common::types::token::Token;
+use renegade_darkpool_client::DarkpoolClient;
 
 use renegade_api::http::external_match::AtomicMatchApiBundle;
 use tracing::warn;
@@ -30,8 +30,8 @@ use crate::server::price_reporter_client::PriceReporterClient;
 pub struct QuoteComparisonHandler {
     /// The sources to compare quotes from
     sources: Vec<QuoteSource>,
-    /// The arbitrum client
-    arbitrum_client: ArbitrumClient,
+    /// The darkpool client
+    darkpool_client: DarkpoolClient,
     /// The price reporter client
     price_reporter_client: Arc<PriceReporterClient>,
 }
@@ -40,10 +40,10 @@ impl QuoteComparisonHandler {
     /// Create a new QuoteComparisonHandler with the given sources
     pub fn new(
         sources: Vec<QuoteSource>,
-        arbitrum_client: ArbitrumClient,
+        darkpool_client: DarkpoolClient,
         price_reporter_client: Arc<PriceReporterClient>,
     ) -> Self {
-        Self { sources, arbitrum_client, price_reporter_client }
+        Self { sources, darkpool_client, price_reporter_client }
     }
 
     /// Records metrics comparing quotes from different sources
@@ -119,7 +119,7 @@ impl QuoteComparisonHandler {
     async fn fetch_gas_price_eth(&self) -> Result<f64, AuthServerError> {
         // Fetch gas price in wei
         let gas_price: U256 = self
-            .arbitrum_client
+            .darkpool_client
             .provider()
             .get_gas_price()
             .await


### PR DESCRIPTION
This PR updates the `auth-server` crate to properly use the new `DarkpoolClient` exported from the relayer crates.

### Testing
- [x] Test sponsored external match, asserting it was successfully sponsored and the onchain event listener witnessed the nullifier spent event