### PR TITLE
price-reporter: use multiple remaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7858,6 +7858,7 @@ dependencies = [
  "async-trait",
  "common",
  "config",
+ "derivative",
  "external-api",
  "futures-util",
  "hyper 0.14.32",

--- a/price-reporter/Cargo.toml
+++ b/price-reporter/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # === Misc === #
+derivative = "2.2.0"
 itertools = "0.10"
 
 # === Renegade === #

--- a/price-reporter/src/http_server.rs
+++ b/price-reporter/src/http_server.rs
@@ -57,8 +57,7 @@ impl HttpServer {
                 REFRESH_TOKEN_MAPPING_ROUTE,
                 Box::new(RefreshTokenMappingHandler::new(
                     config.admin_key,
-                    config.token_remap_path.clone(),
-                    config.remap_chain,
+                    config.remap_chains.clone(),
                     price_streams,
                     config.exchange_conn_config.clone(),
                     config.disabled_exchanges.clone(),

--- a/price-reporter/src/http_server.rs
+++ b/price-reporter/src/http_server.rs
@@ -57,7 +57,8 @@ impl HttpServer {
                 REFRESH_TOKEN_MAPPING_ROUTE,
                 Box::new(RefreshTokenMappingHandler::new(
                     config.admin_key,
-                    config.remap_chains.clone(),
+                    config.token_remap_path.clone(),
+                    config.chains.clone(),
                     price_streams,
                     config.exchange_conn_config.clone(),
                     config.disabled_exchanges.clone(),

--- a/price-reporter/src/http_server/routes.rs
+++ b/price-reporter/src/http_server/routes.rs
@@ -11,7 +11,8 @@ use renegade_util::err_str;
 use crate::{
     errors::ServerError,
     init_default_price_streams,
-    utils::{parse_pair_info_from_topic, setup_all_token_remaps, UrlParams},
+    pair_info::PairInfo,
+    utils::{setup_all_token_remaps, UrlParams},
     ws_server::GlobalPriceStreams,
 };
 
@@ -74,7 +75,7 @@ impl PriceHandler {
     pub async fn get_price(&self, topic: &str) -> Result<Price, ServerError> {
         let self_clone = self.clone();
 
-        let pair_info = parse_pair_info_from_topic(topic)?;
+        let pair_info = PairInfo::from_topic(topic)?;
         let mut price_stream = self_clone
             .price_streams
             .get_or_create_price_stream(pair_info, self_clone.config.clone())

--- a/price-reporter/src/http_server/routes.rs
+++ b/price-reporter/src/http_server/routes.rs
@@ -5,14 +5,13 @@ use futures_util::StreamExt;
 use hyper::{body::to_bytes, Body, Request, Response, StatusCode};
 use renegade_api::auth::validate_expiring_auth;
 use renegade_common::types::{chain::Chain, exchange::Exchange, hmac::HmacKey, Price};
-use renegade_config::setup_token_remaps;
 use renegade_price_reporter::worker::ExchangeConnectionsConfig;
 use renegade_util::err_str;
 
 use crate::{
     errors::ServerError,
     init_default_price_streams,
-    utils::{parse_pair_info_from_topic, UrlParams},
+    utils::{parse_pair_info_from_topic, setup_all_token_remaps, UrlParams},
     ws_server::GlobalPriceStreams,
 };
 
@@ -120,10 +119,8 @@ pub const REFRESH_TOKEN_MAPPING_ROUTE: &str = "/refresh-token-mapping";
 pub struct RefreshTokenMappingHandler {
     /// The HMAC key for the admin API
     admin_key: Option<HmacKey>,
-    /// The path to the token remap file
-    token_remap_path: Option<String>,
-    /// The chain to use for the token remap
-    remap_chain: Chain,
+    /// The chains to use for the token remap
+    remap_chains: Vec<Chain>,
     /// The global price streams
     price_streams: GlobalPriceStreams,
     /// The configuration for the exchange connections
@@ -136,13 +133,12 @@ impl RefreshTokenMappingHandler {
     /// Create a new token mapping refresh handler
     pub fn new(
         admin_key: Option<HmacKey>,
-        token_remap_path: Option<String>,
-        remap_chain: Chain,
+        remap_chains: Vec<Chain>,
         price_streams: GlobalPriceStreams,
         config: ExchangeConnectionsConfig,
         disabled_exchanges: Vec<Exchange>,
     ) -> Self {
-        Self { admin_key, token_remap_path, remap_chain, price_streams, config, disabled_exchanges }
+        Self { admin_key, remap_chains, price_streams, config, disabled_exchanges }
     }
 
     /// Authenticate a token mapping refresh request using the admin HMAC key.
@@ -160,9 +156,8 @@ impl RefreshTokenMappingHandler {
 
     /// Refresh the token mapping from the remote source
     pub async fn refresh_token_mapping(&self) -> Result<(), ServerError> {
-        let token_remap_path = self.token_remap_path.clone();
-        let remap_chain = self.remap_chain;
-        tokio::task::spawn_blocking(move || setup_token_remaps(token_remap_path, remap_chain))
+        let remap_chains = self.remap_chains.clone();
+        tokio::task::spawn_blocking(move || setup_all_token_remaps(&remap_chains))
             .await
             .map_err(err_str!(ServerError::TokenRemap))
             .and_then(|res| res.map_err(err_str!(ServerError::TokenRemap)))?;

--- a/price-reporter/src/main.rs
+++ b/price-reporter/src/main.rs
@@ -7,28 +7,27 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::needless_pass_by_ref_mut)]
 
-use std::{
-    collections::{HashMap, HashSet},
-    net::SocketAddr,
-};
+use std::{collections::HashSet, net::SocketAddr};
 
 use errors::ServerError;
 use http_server::HttpServer;
+use pair_info::PairInfo;
 use renegade_common::types::{
     exchange::Exchange,
-    token::{default_exchange_stable, Token, USDC_TICKER, USDT_TICKER, USD_TICKER},
+    token::{default_exchange_stable, read_exchange_support, USDC_TICKER, USDT_TICKER, USD_TICKER},
 };
 use renegade_price_reporter::worker::ExchangeConnectionsConfig;
 use renegade_util::err_str;
 use tokio::{net::TcpListener, sync::mpsc::unbounded_channel};
 use tracing::{error, info};
 use utils::{
-    get_all_tokens_filtered, parse_config_env_vars, setup_all_token_remaps, setup_logging,
+    get_all_distinct_tickers, parse_config_env_vars, setup_all_token_remaps, setup_logging,
 };
 use ws_server::{handle_connection, GlobalPriceStreams};
 
 mod errors;
 mod http_server;
+mod pair_info;
 mod utils;
 mod ws_server;
 
@@ -102,31 +101,25 @@ pub fn init_default_price_streams(
 
     let disabled_exchanges_set: HashSet<Exchange> = disabled_exchanges.into_iter().collect();
 
-    // Get tokens with distinct tickers from the token remap
-    let distinct_tokens = get_all_tokens_filtered(&STABLECOIN_TICKERS).into_iter().fold(
-        HashMap::new(),
-        |mut m, token| {
-            if let Some(ticker) = token.get_ticker() {
-                m.entry(ticker.to_string()).or_insert(token);
-            }
-            m
-        },
-    );
-
+    // Get distinct tickers from the token remap(s)
+    let distinct_tickers = get_all_distinct_tickers();
     // Iterate over distinct tokens
-    for base_token in distinct_tokens.into_values() {
-        let supported_exchanges: Vec<Exchange> = get_supported_exchanges(&base_token, config)
+    for base_ticker in distinct_tickers {
+        if STABLECOIN_TICKERS.contains(&base_ticker.as_str()) {
+            continue;
+        }
+        let supported_exchanges: Vec<Exchange> = get_supported_exchanges(&base_ticker, config)
             .difference(&disabled_exchanges_set)
             .copied()
             .collect();
 
         for exchange in supported_exchanges {
-            let quote_token = default_exchange_stable(&exchange);
+            let quote_ticker = default_exchange_stable(&exchange).get_ticker().unwrap().to_string();
             // We assume that the exchange has a market between the base token
             // and its default stable token
             init_price_stream(
-                base_token.clone(),
-                quote_token,
+                base_ticker.clone(),
+                quote_ticker.clone(),
                 exchange,
                 global_price_streams,
                 config.clone(),
@@ -140,19 +133,22 @@ pub fn init_default_price_streams(
 /// Spawn a task to initialize a price stream for a given token pair
 #[allow(clippy::needless_pass_by_value)]
 fn init_price_stream(
-    base_token: Token,
-    quote_token: Token,
+    base_ticker: String,
+    quote_ticker: String,
     exchange: Exchange,
     global_price_streams: &GlobalPriceStreams,
     config: ExchangeConnectionsConfig,
 ) -> Result<(), ServerError> {
-    let pair_info = (exchange, base_token.clone(), quote_token.clone());
+    let pair_info = PairInfo::new(
+        exchange,
+        base_ticker.clone(),
+        quote_ticker.clone(),
+        None, // chain
+    );
     let streams = global_price_streams.clone();
     tokio::spawn(async move {
-        if let Err(e) = streams.get_or_create_price_stream(pair_info.clone(), config.clone()).await
-        {
-            let ticker = base_token.get_ticker().expect("Failed to get ticker");
-            error!("Error initializing price stream for {ticker}: {e}");
+        if let Err(e) = streams.get_or_create_price_stream(pair_info, config).await {
+            error!("Error initializing price stream for {base_ticker}/{quote_ticker}: {e}");
         }
     });
 
@@ -160,16 +156,17 @@ fn init_price_stream(
 }
 
 /// Get the listing exchanges for a given base token
-fn get_supported_exchanges(
-    base_token: &Token,
-    config: &ExchangeConnectionsConfig,
-) -> HashSet<Exchange> {
-    let mut supported_exchanges = base_token.supported_exchanges();
+fn get_supported_exchanges(ticker: &str, config: &ExchangeConnectionsConfig) -> HashSet<Exchange> {
+    let mut supported_exchanges: HashSet<Exchange> = read_exchange_support()
+        .get(ticker)
+        .map(|exchanges| exchanges.keys().copied().collect())
+        .unwrap_or_default();
+
     if !config.coinbase_configured() {
         supported_exchanges.remove(&Exchange::Coinbase);
     }
-    if !config.uniswap_v3_configured() {
-        supported_exchanges.remove(&Exchange::UniswapV3);
+    if config.uniswap_v3_configured() {
+        supported_exchanges.insert(Exchange::UniswapV3);
     }
 
     supported_exchanges

--- a/price-reporter/src/main.rs
+++ b/price-reporter/src/main.rs
@@ -18,12 +18,13 @@ use renegade_common::types::{
     exchange::Exchange,
     token::{default_exchange_stable, Token, USDC_TICKER, USDT_TICKER, USD_TICKER},
 };
-use renegade_config::setup_token_remaps;
 use renegade_price_reporter::worker::ExchangeConnectionsConfig;
 use renegade_util::err_str;
 use tokio::{net::TcpListener, sync::mpsc::unbounded_channel};
 use tracing::{error, info};
-use utils::{get_all_tokens_filtered, parse_config_env_vars, setup_logging};
+use utils::{
+    get_all_tokens_filtered, parse_config_env_vars, setup_all_token_remaps, setup_logging,
+};
 use ws_server::{handle_connection, GlobalPriceStreams};
 
 mod errors;
@@ -43,10 +44,9 @@ async fn main() -> Result<(), ServerError> {
     let price_reporter_config = parse_config_env_vars();
 
     // Set up the token remapping
-    let token_remap_path = price_reporter_config.token_remap_path.clone();
-    let remap_chain = price_reporter_config.remap_chain;
+    let remap_chains = price_reporter_config.remap_chains.clone();
     tokio::task::spawn_blocking(move || {
-        setup_token_remaps(token_remap_path, remap_chain).map_err(err_str!(ServerError::TokenRemap))
+        setup_all_token_remaps(&remap_chains).map_err(err_str!(ServerError::TokenRemap))
     })
     .await
     .unwrap()?;

--- a/price-reporter/src/main.rs
+++ b/price-reporter/src/main.rs
@@ -43,9 +43,10 @@ async fn main() -> Result<(), ServerError> {
     let price_reporter_config = parse_config_env_vars();
 
     // Set up the token remapping
-    let remap_chains = price_reporter_config.remap_chains.clone();
+    let token_remap_path = price_reporter_config.token_remap_path.clone();
+    let chains = price_reporter_config.chains.clone();
     tokio::task::spawn_blocking(move || {
-        setup_all_token_remaps(&remap_chains).map_err(err_str!(ServerError::TokenRemap))
+        setup_all_token_remaps(token_remap_path, &chains).map_err(err_str!(ServerError::TokenRemap))
     })
     .await
     .unwrap()?;

--- a/price-reporter/src/pair_info.rs
+++ b/price-reporter/src/pair_info.rs
@@ -1,0 +1,103 @@
+//! Types and utilities for PairInfo
+//!
+//! PairInfo is the ticker-based key we use to de-duplicate price streams. In
+//! contrast, `PriceTopic` is a tuple of (Exchange, Token, Token) that uses
+//! addresses for uniqueness. This is necessary in a multi-chain environment
+//! where multiple addresses can map to the same ticker.
+
+use std::str::FromStr;
+
+use derivative::Derivative;
+use renegade_common::types::token::{default_chain, USDC_TICKER};
+use renegade_common::types::{chain::Chain, exchange::Exchange, token::Token};
+use renegade_price_reporter::exchange::supports_pair;
+use renegade_util::err_str;
+
+use crate::errors::ServerError;
+use crate::utils::{get_token_and_chain, PriceTopic};
+
+/// Used to uniquely identify a price stream
+#[derive(Derivative, Clone, PartialEq, Eq, Hash)]
+pub struct PairInfo {
+    /// The exchange
+    pub exchange: Exchange,
+    /// The base ticker
+    pub base: String,
+    /// The quote ticker
+    pub quote: String,
+    /// The chain
+    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    pub chain: Chain,
+}
+
+impl PairInfo {
+    /// Create a new pair info
+    pub fn new(exchange: Exchange, base: String, quote: String, chain: Option<Chain>) -> Self {
+        Self { exchange, base, quote, chain: chain.unwrap_or(default_chain()) }
+    }
+
+    /// Get the base token for a given pair info
+    pub fn base_token(&self) -> Token {
+        Token::from_ticker_on_chain(self.base.as_str(), self.chain)
+    }
+
+    /// Get the quote token for a given pair info
+    pub fn quote_token(&self) -> Token {
+        Token::from_ticker_on_chain(self.quote.as_str(), self.chain)
+    }
+
+    /// Parse the pair info from a given topic
+    pub fn from_topic(topic: &str) -> Result<Self, ServerError> {
+        let parts: Vec<&str> = topic.split('-').collect();
+        let exchange =
+            Exchange::from_str(parts[0]).map_err(err_str!(ServerError::InvalidPairInfo))?;
+        let (base, chain) = get_token_and_chain(parts[1]).ok_or_else(|| {
+            ServerError::InvalidPairInfo(format!("invalid base token `{}`", parts[1]))
+        })?;
+        let quote = if exchange == Exchange::Renegade {
+            Token::from_ticker_on_chain(USDC_TICKER, chain)
+        } else {
+            Token::from_addr_on_chain(parts[2], chain)
+        };
+
+        Ok(Self {
+            exchange,
+            base: base.get_ticker().unwrap(),
+            quote: quote.get_ticker().unwrap(),
+            chain,
+        })
+    }
+
+    /// Get the topic name for a given pair info as a string
+    pub fn to_topic(&self) -> String {
+        format!("{}-{}-{}", self.exchange, self.base, self.quote)
+    }
+
+    /// Validate a pair info tuple, checking that the exchange supports the base
+    /// and quote tokens
+    pub async fn validate_subscription(&self) -> Result<(), ServerError> {
+        let (exchange, base, quote) = (self.exchange, self.base_token(), self.quote_token());
+
+        if exchange == Exchange::UniswapV3 {
+            return Err(ServerError::InvalidPairInfo("UniswapV3 is not supported".to_string()));
+        }
+
+        if !supports_pair(&exchange, &base, &quote)
+            .await
+            .map_err(ServerError::ExchangeConnection)?
+        {
+            return Err(ServerError::InvalidPairInfo(format!(
+                "{} does not support the pair ({}, {})",
+                self.exchange, base, quote
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+impl From<PairInfo> for PriceTopic {
+    fn from(pair_info: PairInfo) -> Self {
+        (pair_info.exchange, pair_info.base_token(), pair_info.quote_token())
+    }
+}

--- a/price-reporter/src/utils.rs
+++ b/price-reporter/src/utils.rs
@@ -8,6 +8,7 @@ use futures_util::StreamExt;
 use futures_util::{stream::SplitSink, Stream};
 use itertools::Itertools;
 use matchit::Router;
+use renegade_common::types::token::read_token_remaps;
 use renegade_common::types::{
     chain::Chain,
     exchange::Exchange,

--- a/price-reporter/src/ws_server.rs
+++ b/price-reporter/src/ws_server.rs
@@ -7,7 +7,7 @@ use futures_util::{SinkExt, StreamExt};
 use renegade_api::websocket::{SubscriptionResponse, WebsocketMessage};
 use renegade_common::types::{
     exchange::Exchange,
-    token::{Token, USDT_TICKER},
+    token::{USDC_TICKER, USDT_TICKER},
     Price,
 };
 use renegade_price_reporter::{
@@ -24,11 +24,12 @@ use tungstenite::Message;
 
 use crate::{
     errors::ServerError,
+    pair_info::PairInfo,
     utils::{
-        get_pair_info_topic, get_subscribed_topics, parse_pair_info_from_topic,
-        requires_quote_conversion, validate_subscription, ClosureSender, PairInfo, PriceMessage,
-        PriceReceiver, PriceSender, PriceStream, PriceStreamMap, SharedPriceStreams, WsWriteStream,
-        CONN_RETRY_DELAY_MS, KEEPALIVE_INTERVAL_MS, MAX_CONN_RETRIES, MAX_CONN_RETRY_WINDOW_MS,
+        get_price_topic_str, get_subscribed_topics, requires_quote_conversion, ClosureSender,
+        PriceMessage, PriceReceiver, PriceSender, PriceStream, PriceStreamMap, SharedPriceStreams,
+        WsWriteStream, CONN_RETRY_DELAY_MS, KEEPALIVE_INTERVAL_MS, MAX_CONN_RETRIES,
+        MAX_CONN_RETRY_WINDOW_MS,
     },
 };
 
@@ -69,9 +70,9 @@ impl GlobalPriceStreams {
         pair_info: PairInfo,
         config: ExchangeConnectionsConfig,
     ) -> Result<PriceReceiver, ServerError> {
-        validate_subscription(&pair_info).await?;
+        pair_info.validate_subscription().await?;
 
-        info!("Initializing price stream for {}", get_pair_info_topic(&pair_info));
+        info!("Initializing price stream for {}", pair_info.to_topic());
 
         // Create a shared channel into which we forward streamed prices
         let (price_tx, price_rx) = channel(Price::default());
@@ -145,10 +146,11 @@ impl GlobalPriceStreams {
         config: &ExchangeConnectionsConfig,
         retry_timestamps: &mut Vec<Instant>,
     ) -> Result<Box<dyn ExchangeConnection>, ServerError> {
-        let (exchange, base, quote) = pair_info;
+        let (exchange, base, quote) =
+            (pair_info.exchange, pair_info.base_token(), pair_info.quote_token());
 
         // Attempt to connect to the pair on the specified exchange
-        match connect_exchange(base, quote, config, *exchange)
+        match connect_exchange(&base, &quote, config, exchange)
             .await
             .map_err(ServerError::ExchangeConnection)
         {
@@ -165,7 +167,7 @@ impl GlobalPriceStreams {
         config: &ExchangeConnectionsConfig,
         retry_timestamps: &mut Vec<Instant>,
     ) -> Result<Box<dyn ExchangeConnection>, ServerError> {
-        let exchange = pair_info.0;
+        let exchange = pair_info.exchange;
         loop {
             prev_err = match Self::retry_connection(pair_info, config, retry_timestamps).await {
                 Ok(conn) => return Ok(conn),
@@ -192,9 +194,10 @@ impl GlobalPriceStreams {
         config: &ExchangeConnectionsConfig,
         retry_timestamps: &mut Vec<Instant>,
     ) -> Result<Box<dyn ExchangeConnection>, ServerError> {
-        warn!("Retrying connection for {}", get_pair_info_topic(pair_info));
+        warn!("Retrying connection for {}", pair_info.to_topic());
 
-        let (exchange, base, quote) = pair_info;
+        let (exchange, base, quote) =
+            (pair_info.exchange, pair_info.base_token(), pair_info.quote_token());
 
         // Increment the retry count and filter out old requests
         let now = Instant::now();
@@ -206,7 +209,7 @@ impl GlobalPriceStreams {
 
         if retry_timestamps.len() >= MAX_CONN_RETRIES {
             return Err(ServerError::ExchangeConnection(ExchangeConnectionError::MaxRetries(
-                *exchange,
+                exchange,
             )));
         }
 
@@ -214,7 +217,7 @@ impl GlobalPriceStreams {
         tokio::time::sleep(Duration::from_millis(CONN_RETRY_DELAY_MS)).await;
 
         // Reconnect
-        connect_exchange(base, quote, config, *exchange)
+        connect_exchange(&base, &quote, config, exchange)
             .await
             .map_err(ServerError::ExchangeConnection)
     }
@@ -226,11 +229,11 @@ impl GlobalPriceStreams {
         config: ExchangeConnectionsConfig,
     ) -> Result<PriceStream, ServerError> {
         // Replace the `Renegade` exchange with `Binance`
-        if pair_info.0 == Exchange::Renegade {
-            pair_info.0 = Exchange::Binance;
+        if pair_info.exchange == Exchange::Renegade {
+            pair_info.exchange = Exchange::Binance;
         }
 
-        let exchange = pair_info.0;
+        let exchange = pair_info.exchange;
         let price_rx = self.get_or_create_price_receiver(pair_info, config.clone()).await?;
         let stream = if requires_quote_conversion(&exchange) {
             let conversion_rx = self.quote_conversion_stream(exchange, config).await?;
@@ -251,9 +254,8 @@ impl GlobalPriceStreams {
         exchange: Exchange,
         config: ExchangeConnectionsConfig,
     ) -> Result<PriceReceiver, ServerError> {
-        let usdc = Token::usdc();
-        let usdt = Token::from_ticker(USDT_TICKER);
-        let conversion_pair = (exchange, usdc, usdt);
+        let conversion_pair =
+            PairInfo::new(exchange, USDC_TICKER.to_string(), USDT_TICKER.to_string(), None);
         let conversion_rx = self.get_or_create_price_receiver(conversion_pair, config).await?;
         Ok(conversion_rx)
     }
@@ -302,10 +304,10 @@ pub async fn handle_connection(
     loop {
         tokio::select! {
             // Send the next price to the client
-            Some((pair_info, price)) = subscriptions.next() => {
+            Some((topic, price)) = subscriptions.next() => {
                 // The potential error in `price_res` here is a `BroadcastStreamRecvError::Lagged`,
                 // meaning the stream lagged receiving price updates. We can safely ignore this.
-                let topic = get_pair_info_topic(&pair_info);
+                let topic = get_price_topic_str(&topic);
                 let message = PriceMessage { topic, price };
                 let message_ser = serde_json::to_string(&message).map_err(err_str!(ServerError::Serde))?;
                 write_stream
@@ -400,17 +402,17 @@ async fn handle_subscription_message(
     match message {
         WebsocketMessage::Subscribe { topic } => {
             info!("Subscribing {} to {}", peer_addr, &topic);
-            let pair_info = parse_pair_info_from_topic(&topic)?;
+            let pair_info = PairInfo::from_topic(&topic)?;
             let stream = global_price_streams
                 .get_or_create_price_stream(pair_info.clone(), config.clone())
                 .await?;
 
-            subscriptions.insert(pair_info, stream);
+            subscriptions.insert(pair_info.into(), stream);
         },
         WebsocketMessage::Unsubscribe { topic } => {
             info!("Unsubscribing {} from {}", peer_addr, &topic);
-            let pair_info = parse_pair_info_from_topic(&topic)?;
-            subscriptions.remove(&pair_info);
+            let pair_info = PairInfo::from_topic(&topic)?;
+            subscriptions.remove(&pair_info.into());
         },
     };
 


### PR DESCRIPTION
### Purpose
This PR allows specifying multiple chains when spinning up the price reporter. It removes the remap file path arg, opting instead to retrieve remaps from the default remote location.

### Testing
- [x] Tested locally
- [ ] Test in testnet