### PR TITLE
funds-manager-server: use original query for v2 auth, no query for v1 auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,7 +4455,6 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "tokio",
  "tokio-postgres",
  "tracing",

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -63,6 +63,5 @@ rand = "0.8"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
-serde_urlencoded = "0.7"
 tracing = "0.1"
 uuid = "1.8"


### PR DESCRIPTION
This PR fixes the funds manager's auth stack in the following 2 ways:
1. We use the raw query string for v2 auth. Previously, query parameters were liable to getting reordered when parsing into a `HashMap`
2. We discard the query string for v1 auth, as it is not expected there

### Testing
- [x] Test getting & executing a quote using an updated client (v2 auth)
- [ ] Test getting & executing a quote using an un-updated client (v1 auth)