### PR TITLE
funds-manager-server: cli: create chain-specific clients from config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2818,7 +2818,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2954,7 +2954,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4709,7 +4709,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5547,7 +5547,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7166,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7789,7 +7789,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9297,7 +9297,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "bus",
  "common",
@@ -9309,7 +9309,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10231,7 +10231,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#57b6271a915b6a2c856b7f5c4acaefbb934c07c4"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,19 +23,19 @@ lto = true
 [workspace.dependencies]
 # === Renegade Dependencies === #
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git"}
-renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
+renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap"}
+renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap", features = [
     "auth",
 ] }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = ["metered-channels"] }
-renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git" }
-renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap", features = ["metered-channels"] }
+renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
 
 # === Blockchain Dependencies === #
 alloy-sol-types = "1.0.0"

--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -1,0 +1,157 @@
+//! CLI argument definition & parsing for the funds manager server
+
+use aws_config::SdkConfig;
+use clap::Parser;
+use renegade_common::types::hmac::HmacKey;
+use renegade_darkpool_client::constants::Chain;
+use serde::Deserialize;
+use tokio::fs::read_to_string;
+
+use crate::{error::FundsManagerError, helpers::fetch_s3_object};
+
+// -------------
+// | Constants |
+// -------------
+
+/// The name of the chain configs object in S3
+const CHAIN_CONFIGS_OBJECT_NAME: &str = "chain_configs.json";
+
+// ---------
+// | Types |
+// ---------
+
+/// Chain-specific configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChainConfig {
+    // --- Relayer Params --- //
+    /// The URL of the relayer to use
+    pub relayer_url: String,
+    /// The fee decryption key to use
+    pub relayer_decryption_key: String,
+
+    // --- Darkpool Params --- //
+    /// The RPC url to use
+    pub rpc_url: String,
+    /// The chain to which the darkpool is deployed
+    pub chain: Chain,
+    /// The address of the darkpool contract
+    pub darkpool_address: String,
+    /// The address of the gas sponsor contract
+    pub gas_sponsor_address: String,
+    /// The fee decryption key to use for the protocol fees
+    ///
+    /// This argument is not necessary, protocol fee indexing is skipped if this
+    /// is omitted
+    pub protocol_decryption_key: Option<String>,
+
+    // --- Execution Venue Params --- //
+    /// The execution venue api key
+    pub execution_venue_api_key: String,
+    /// The execution venue base url
+    pub execution_venue_base_url: String,
+}
+
+/// The cli for the fee sweeper
+#[rustfmt::skip]
+#[derive(Parser)]
+#[clap(about = "Funds manager server")]
+pub struct Cli {
+    // --- Authentication --- //
+
+    /// The HMAC key to use for authentication
+    #[clap(long, conflicts_with = "disable_auth", env = "HMAC_KEY")]
+    pub hmac_key: Option<String>,
+    /// The HMAC key to use for signing quotes
+    #[clap(long, env = "QUOTE_HMAC_KEY")]
+    pub quote_hmac_key: String,
+    /// Whether to disable authentication
+    #[clap(long, conflicts_with = "hmac_key")]
+    pub disable_auth: bool,
+
+    // --- Chain-Specific Config --- //
+
+    /// Name of the S3 bucket from which to read chain-specific configs
+    #[clap(long, env = "CHAIN_CONFIGS_BUCKET")]
+    pub chain_configs_bucket: Option<String>,
+
+    /// Path to a file containing chain-specific configs
+    ///
+    /// This file should be a JSON array of chain-specific configs
+    #[clap(long, env = "CHAIN_CONFIGS_PATH", conflicts_with = "chain_configs_bucket")]
+    pub chain_configs_path: Option<String>,
+
+    //  --- Api Secrets --- //
+
+    /// The database url
+    #[clap(long, env = "DATABASE_URL")]
+    pub db_url: String,
+    /// The fireblocks api key
+    #[clap(long, env = "FIREBLOCKS_API_KEY")]
+    pub fireblocks_api_key: String,
+    /// The fireblocks api secret
+    #[clap(long, env = "FIREBLOCKS_API_SECRET")]
+    pub fireblocks_api_secret: String,
+
+    // --- Server Config --- //
+
+    /// The port to run the server on
+    #[clap(long, default_value = "3000")]
+    pub port: u16,
+
+    // --- Telemetry --- //
+
+    /// Whether to enable datadog formatted logs
+    #[clap(long, default_value = "false")]
+    pub datadog_logging: bool,
+    /// Whether or not to enable metrics collection
+    #[clap(long, env = "ENABLE_METRICS")]
+    pub metrics_enabled: bool,
+    /// The StatsD recorder host to send metrics to
+    #[clap(long, env = "STATSD_HOST", default_value = "127.0.0.1")]
+    pub statsd_host: String,
+    /// The StatsD recorder port to send metrics to
+    #[clap(long, env = "STATSD_PORT", default_value = "8125")]
+    pub statsd_port: u16,
+}
+
+impl Cli {
+    /// Validate the CLI arguments
+    pub fn validate(&self) -> Result<(), String> {
+        if self.hmac_key.is_none() && !self.disable_auth {
+            return Err("Either --hmac-key or --disable-auth must be provided".to_string());
+        }
+
+        if self.chain_configs_bucket.is_none() && self.chain_configs_path.is_none() {
+            return Err("Either --chain-configs-bucket or --chain-configs-path must be provided"
+                .to_string());
+        }
+
+        Ok(())
+    }
+
+    /// Get the HMAC key
+    pub fn get_hmac_key(&self) -> Option<HmacKey> {
+        self.hmac_key.as_ref().map(|key| HmacKey::from_hex_string(key).expect("Invalid HMAC key"))
+    }
+
+    /// Get the quote HMAC key
+    pub fn get_quote_hmac_key(&self) -> HmacKey {
+        HmacKey::from_hex_string(&self.quote_hmac_key).expect("Invalid quote HMAC key")
+    }
+
+    /// Parse the chain configs
+    pub async fn parse_chain_configs(
+        &self,
+        aws_config: &SdkConfig,
+    ) -> Result<Vec<ChainConfig>, FundsManagerError> {
+        let json_str = if let Some(bucket) = &self.chain_configs_bucket {
+            fetch_s3_object(bucket, CHAIN_CONFIGS_OBJECT_NAME, aws_config).await
+        } else {
+            read_to_string(self.chain_configs_path.as_ref().expect("no chain configs file path"))
+                .await
+                .map_err(FundsManagerError::custom)
+        }?;
+
+        serde_json::from_str(&json_str).map_err(FundsManagerError::parse)
+    }
+}

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -27,7 +27,7 @@ use fireblocks_sdk::{
     models::{TransactionResponse, VaultAccount},
     Client as FireblocksSdk, ClientBuilder as FireblocksClientBuilder,
 };
-use renegade_darkpool_client::constants::Chain;
+use renegade_common::types::chain::Chain;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;

--- a/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
@@ -12,7 +12,7 @@ use fireblocks_sdk::{
         TransactionRequest, TransactionStatus, UnsignedMessage,
     },
 };
-use renegade_darkpool_client::constants::Chain;
+use renegade_common::types::chain::Chain;
 use serde_json::Value;
 use tracing::error;
 

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -10,8 +10,10 @@ use fireblocks_sdk::{
         TransactionRequest, TransactionRequestAmount, TransactionStatus, TransferPeerPathType,
     },
 };
-use renegade_common::types::token::{Token, USDC_TICKER};
-use renegade_darkpool_client::constants::Chain;
+use renegade_common::types::{
+    chain::Chain,
+    token::{Token, USDC_TICKER},
+};
 use tracing::info;
 
 use super::{CustodyClient, DepositWithdrawSource};

--- a/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
@@ -2,7 +2,8 @@
 
 use aws_config::SdkConfig as AwsConfig;
 use renegade_circuit_types::elgamal::DecryptionKey;
-use renegade_darkpool_client::{constants::Chain, DarkpoolClient};
+use renegade_common::types::chain::Chain;
+use renegade_darkpool_client::DarkpoolClient;
 use renegade_util::err_str;
 use renegade_util::hex::jubjub_from_hex_string;
 use std::sync::Arc;
@@ -18,6 +19,7 @@ pub mod queries;
 pub mod redeem_fees;
 
 /// Stores the dependencies needed to index the chain
+#[derive(Clone)]
 pub(crate) struct Indexer {
     /// The id of the chain this indexer targets
     pub chain_id: u64,

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -1,164 +1,87 @@
 //! Defines the server which encapsulates all dependencies for funds manager
 //! execution
 
-use std::{error::Error, str::FromStr, sync::Arc, time::Duration};
+use std::{collections::HashMap, error::Error, sync::Arc};
 
-use alloy::signers::local::PrivateKeySigner;
-use alloy_primitives::Address;
 use aws_config::{BehaviorVersion, Region, SdkConfig};
 use funds_manager_api::quoters::ExecutionQuote;
-use renegade_circuit_types::elgamal::DecryptionKey;
-use renegade_common::types::hmac::HmacKey;
+use renegade_common::types::{chain::Chain, hmac::HmacKey, token::Token};
 use renegade_config::setup_token_remaps;
-use renegade_darkpool_client::{client::DarkpoolClientConfig, constants::Chain, DarkpoolClient};
-use renegade_util::raw_err_str;
 
 use crate::{
-    custody_client::CustodyClient,
+    cli::{ChainClients, Cli},
     db::{create_db_pool, DbPool},
     error::FundsManagerError,
-    execution_client::ExecutionClient,
-    fee_indexer::Indexer,
-    metrics::MetricsRecorder,
-    relayer_client::RelayerClient,
-    Cli,
 };
 
 // -------------
 // | Constants |
 // -------------
 
-/// The block polling interval for the darkpool client
-const BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 /// The default region in which to provision secrets manager secrets
 const DEFAULT_REGION: &str = "us-east-2";
 
 /// The server
 #[derive(Clone)]
 pub(crate) struct Server {
-    /// The id of the chain this indexer targets
-    pub chain_id: u64,
-    /// The chain this indexer targets
-    pub chain: Chain,
-    /// A client for interacting with the relayer
-    pub relayer_client: RelayerClient,
-    /// The darkpool client
-    pub darkpool_client: DarkpoolClient,
-    /// The decryption key
-    pub decryption_keys: Vec<DecryptionKey>,
     /// The database connection pool
     pub db_pool: Arc<DbPool>,
-    /// The custody client
-    pub custody_client: CustodyClient,
-    /// The execution client
-    pub execution_client: ExecutionClient,
     /// The AWS config
     pub aws_config: SdkConfig,
     /// The HMAC key for custody endpoint authentication
     pub hmac_key: Option<HmacKey>,
     /// The HMAC key for signing quotes
     pub quote_hmac_key: HmacKey,
-    /// The metrics recorder
-    pub metrics_recorder: MetricsRecorder,
+    /// The chain clients
+    pub chain_clients: HashMap<Chain, ChainClients>,
 }
 
 impl Server {
     /// Build a server from the CLI
     pub async fn build_from_cli(args: Cli) -> Result<Self, Box<dyn Error>> {
         // Parse an AWS config
-        let config = aws_config::defaults(BehaviorVersion::latest())
+        let aws_config = aws_config::defaults(BehaviorVersion::latest())
             .region(Region::new(DEFAULT_REGION))
             .load()
             .await;
 
-        let chain_configs = args.parse_chain_configs(&config).await?;
+        let chain_configs = args.parse_chain_configs(&aws_config).await?;
 
-        for chain_config in chain_configs {
+        for chain in chain_configs.keys() {
+            let chain = *chain;
             tokio::task::spawn_blocking(move || {
-                setup_token_remaps(None /* token_remap_file */, chain_config.chain)
+                setup_token_remaps(None /* token_remap_file */, chain)
             })
             .await
             .unwrap()?;
         }
 
-        todo!("instantiate chain-specific clients at request time");
-
-        // Build a darkpool client
-        let private_key = PrivateKeySigner::random();
-        let conf = DarkpoolClientConfig {
-            darkpool_addr: args.darkpool_address.clone(),
-            chain: args.chain,
-            rpc_url: args.rpc_url.clone(),
-            private_key,
-            block_polling_interval: BLOCK_POLLING_INTERVAL,
-        };
-        let client = DarkpoolClient::new(conf)?;
-        let chain_id =
-            client.chain_id().await.map_err(raw_err_str!("Error fetching chain ID: {}"))?;
-
-        // Build the indexer
-        let mut decryption_keys = vec![DecryptionKey::from_hex_str(&args.relayer_decryption_key)?];
-        if let Some(protocol_key) = &args.protocol_decryption_key {
-            decryption_keys.push(DecryptionKey::from_hex_str(protocol_key)?);
-        }
-
         let hmac_key = args.get_hmac_key();
         let quote_hmac_key = args.get_quote_hmac_key();
-        let relayer_client = RelayerClient::new(&args.relayer_url, &args.usdc_mint);
 
         // Create a database connection pool using bb8
         let db_pool = create_db_pool(&args.db_url).await?;
         let arc_pool = Arc::new(db_pool);
 
-        let gas_sponsor_address = Address::from_str(&args.gas_sponsor_address)?;
+        let usdc_mint = Token::usdc().get_addr();
 
-        let custody_client = CustodyClient::new(
-            args.chain,
-            chain_id,
-            args.fireblocks_api_key,
-            args.fireblocks_api_secret,
-            args.rpc_url.clone(),
-            arc_pool.clone(),
-            config.clone(),
-            gas_sponsor_address,
-        )?;
+        let mut chain_clients = HashMap::new();
+        for (chain, config) in chain_configs {
+            let clients = config
+                .build_clients(
+                    chain,
+                    args.fireblocks_api_key.clone(),
+                    args.fireblocks_api_secret.clone(),
+                    arc_pool.clone(),
+                    aws_config.clone(),
+                    &usdc_mint,
+                )
+                .await?;
 
-        let execution_client = ExecutionClient::new(
-            args.execution_venue_api_key,
-            args.execution_venue_base_url,
-            &args.rpc_url,
-        )?;
+            chain_clients.insert(chain, clients);
+        }
 
-        let metrics_recorder = MetricsRecorder::new(relayer_client.clone(), &args.rpc_url);
-
-        Ok(Server {
-            chain_id,
-            chain: args.chain,
-            relayer_client: relayer_client.clone(),
-            darkpool_client: client.clone(),
-            decryption_keys,
-            db_pool: arc_pool,
-            custody_client,
-            execution_client,
-            aws_config: config,
-            hmac_key,
-            quote_hmac_key,
-            metrics_recorder,
-        })
-    }
-
-    /// Build an indexer
-    pub fn build_indexer(&self) -> Indexer {
-        Indexer::new(
-            self.chain_id,
-            self.chain,
-            self.aws_config.clone(),
-            self.darkpool_client.clone(),
-            self.decryption_keys.clone(),
-            self.db_pool.clone(),
-            self.relayer_client.clone(),
-            self.custody_client.clone(),
-        )
+        Ok(Server { db_pool: arc_pool, aws_config, hmac_key, quote_hmac_key, chain_clients })
     }
 
     /// Sign a quote using the quote HMAC key and returns the signature as a


### PR DESCRIPTION
This PR updates the config pattern for the funds manager to parse chain-specific configuration parameters from a JSON file. This file can either be fetched from S3 at runtime, or provided locally (for easier local development).

Using these chain-specific configurations, we instantiate the various funds manager clients separately per-chain.

Basically all of the logic for these clients is chain-specific, and any chain-agnostic logic is cheap to replicate, making this a significantly simpler approach than splitting these clients into chain-agnostic and chain-specific constituents.

For example, while the `CustodyClient` does interact with a single, global DB, 1) pretty much every table will have a `chain` column along which to segment interaction, and 2) we use a DB pool anyway, so there is little overhead in having multiple `CustodyClient`s hold their own connections to the DB.

The server holds a mapping from `Chain -> ChainClients`, which we will index into in the API layer using a new `/:chain/` path parameter on each of the routes.

### TODO
- [ ] Access appropriate client in API according to `:chain` route param
- [ ] Test on Arbitrum Sepolia