### PR TITLE
funds-manager-server: handlers: include chain path param where relevant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target/
 /.gitattributes
 
 .env*
+**/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "abi"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#0c97508e81a6c3896ec9cf4ebe096827139a4225"
+dependencies = [
+ "alloy",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,9 +110,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f245ea9ef9be909776941c6c0ce829fb6b79cd6bfafa43762af7a702c4eb8ee4"
+checksum = "6c47941be7b270d671841b0cf5e94e05fc358e0b79c88e68bc1ad08dc066be3f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -130,19 +138,19 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "num_enum",
  "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
+checksum = "5af9455152b18b9efc329120c85006705862a21786449e425eb714d0c04bbfda"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -153,6 +161,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
+ "secp256k1 0.30.0",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -160,13 +169,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
+checksum = "9256691696deb28fd71ca6b698d958e80abe5dd0ed95f8e96ac55076b4a70e95"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -174,20 +183,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5084cf42388dff75b255308194f9d3e67ae2a93ce7e24262a512cc4043ac1838"
+checksum = "bf6fec63b92c6cd0410450d38c671cc52f1c1eed6327ce6ba42e965c00b53bf3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types-eth",
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
  "alloy-transport",
  "futures",
  "futures-util",
@@ -202,21 +211,21 @@ checksum = "9d020a85ae8cf79b9c897a86d617357817bbc9a7d159dd7e6fedf1bc90f64d35"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
 ]
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884a5d4560f7e5e34ec3c5e54a60223c56352677dd049b495fbb59384cf72a90"
+checksum = "4f90b63261b7744642f6075ed17db6de118eecbe9516ea6c6ffd444b80180b75"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-sol-type-parser",
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
  "const-hex",
  "derive_more 2.0.1",
  "itoa",
@@ -231,7 +240,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "crc",
  "serde",
@@ -244,7 +253,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "serde",
 ]
@@ -255,7 +264,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "serde",
  "thiserror 2.0.12",
@@ -263,14 +272,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609515c1955b33af3d78d26357540f68c5551a90ef58fd53def04f2aa074ec43"
+checksum = "7a3ecb56e34e1c3dca4aa06b653c96f0f381a67e0d353271949c683fba5ecbd4"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
@@ -283,12 +292,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
+checksum = "664371ee21be794e77a1be0e1ea989fd66a43a3539532361f007935f20cc8ece"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-serde",
  "alloy-trie",
  "serde",
@@ -296,11 +305,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -308,12 +317,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
+checksum = "0b22b5e5872d5ece9df2411a65637af3bfc5ce868ddf392cb91ce9a0c7cb1b30"
 dependencies = [
- "alloy-primitives 1.0.0",
- "alloy-sol-types 1.0.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-types 1.1.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -322,21 +331,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be3aa020a6d3aa7601185b4c1a7d6f3a5228cb5424352db63064b29a455c891"
+checksum = "be8a707ccae2aaca8fb64cec54904c1fdce6be5c5d5be24a7ae04e6a393cb62e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
  "async-trait",
  "auto_impl",
  "derive_more 2.0.1",
@@ -348,13 +357,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
+checksum = "2d27be7a0d29a77b2568c105e5418736da5555026a4b054ea2e3b549a0a9645b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-serde",
  "serde",
 ]
@@ -377,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -404,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6ba76d476f475668925f858cc4db51781f12abdaa4e0274eb57a09f574e869"
+checksum = "064d72578caba01fc1d04e8119dbfac36f7cc3b0b9c65804f2282482d55c4904"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -414,14 +423,14 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-signer",
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ws",
@@ -447,12 +456,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04135d2fd7fa1fba3afe9f79ec2967259dbc0948e02fa0cd0e33a4a812e2cb0a"
+checksum = "071721a7fbe5fa0b7e0391c4ff8b5919a9f9866944cd8608dcb893d846e7087d"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-transport",
  "bimap",
  "futures",
@@ -490,12 +499,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
+checksum = "8cb00c4260ca83980422fc4a44658aafe50ad7b7ad43fb21523bd53453cfd202"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -517,11 +526,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
+checksum = "eac9e3abe5083df822304ac63664873c988e427a27215b2ce328ee5a2a51bfbd"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-serde",
@@ -530,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1a40595b927dfb07218459037837dbc8de8500a26024bb6ff0548dd2ccc13e0"
+checksum = "5b8740d1e374cf177f5e94ee694cbbca5d0435c3e8a6d4e908841e9cfc5247e2"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -541,28 +550,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05525519bd7f37f98875354f0b3693d3ad3c7a7f067e3b8946777920be15cb5b"
+checksum = "5db15952f375ba2295124c52bcf893c72fd87091198a781b2bf10c4dd8c79249"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "serde",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a9f64e0f69cfb6029e2a044519a1bdd44ce9fc334d5315a7b9837f7a6748e5"
+checksum = "dfc2bbc0385aac988551f747c050d5bd1b2b9dd59eabaebf063edbb6a41b2ccb"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "alloy-serde",
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -571,11 +580,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bccbe4594eaa2d69d21fa0b558c44e36202e599eb209da70b405415cb37a354"
+checksum = "fc1029148c57853ec9a69e0a5b1f041253a9b3ff0ee7a8c006f243bfc1dc1671"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -585,22 +594,22 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
+checksum = "071c74effe6ad192dde40cbd4da49784c946561dec6679f73665337c6cf72316"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-signer"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
+checksum = "5e920bcbaf28af4c3edf6dac128a5d04185582bf496b031add01de909b4cb153"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "async-trait",
  "auto_impl",
  "either",
@@ -611,13 +620,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
+checksum = "b98de10c8697f338c6a545a0fc6cd7cd2b250f62797479f7f30eac63765c78ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-signer",
  "async-trait",
  "k256",
@@ -641,12 +650,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+checksum = "5d3ef8e0d622453d969ba3cded54cf6800efdc85cb929fe22c5bdf8335666757"
 dependencies = [
- "alloy-sol-macro-expander 1.0.0",
- "alloy-sol-macro-input 1.0.0",
+ "alloy-sol-macro-expander 1.1.0",
+ "alloy-sol-macro-input 1.1.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -673,12 +682,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+checksum = "f0e84bd0693c69a8fbe3ec0008465e029c6293494df7cb07580bf4a33eff52e1"
 dependencies = [
  "alloy-json-abi",
- "alloy-sol-macro-input 1.0.0",
+ "alloy-sol-macro-input 1.1.0",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.9.0",
@@ -686,7 +695,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
- "syn-solidity 1.0.0",
+ "syn-solidity 1.1.0",
  "tiny-keccak",
 ]
 
@@ -707,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+checksum = "f3de663412dadf9b64f4f92f507f78deebcc92339d12cf15f88ded65d41c7935"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -720,14 +729,14 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.101",
- "syn-solidity 1.0.0",
+ "syn-solidity 1.1.0",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
+checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
 dependencies = [
  "serde",
  "winnow",
@@ -746,24 +755,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.0.0",
- "alloy-sol-macro 1.0.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-macro 1.1.0",
  "const-hex",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f1a55f9ff9a48aa0b4a8c616803754620010fbb266edae2f4548f4304373b"
+checksum = "1f5564661f166792da89d9a6785ff815e44853436637842c59ab48393c4c2fad"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-primitives 1.1.0",
  "base64 0.22.1",
  "derive_more 2.0.1",
  "futures",
@@ -781,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171b3d8824b6697d6c8325373ec410d230b6c59ce552edfbfabe4e7b8a26aac3"
+checksum = "14c2bba49856a38b54b9134f1fc218fc67d1b1313c16a310514f3b10110559fc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -796,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.14.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdde5b241745076bcbf2fcad818f2c42203bd2c5f4b50ea43b628ccbd2147ad6"
+checksum = "802de53990270861acf00044837794ea2450ccc3d9795e824a5d865633241a23"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -818,7 +828,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -915,15 +925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
 ]
 
 [[package]]
@@ -1370,8 +1371,8 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "alloy",
- "alloy-primitives 1.0.0",
- "alloy-sol-types 1.0.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-types 1.1.0",
  "async-trait",
  "atomic_float 1.1.0",
  "auth-server-api",
@@ -1421,7 +1422,7 @@ dependencies = [
 name = "auth-server-api"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "external-api",
  "serde",
  "uuid 1.16.0",
@@ -2134,6 +2135,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,11 +2432,10 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
+checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
 dependencies = [
- "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -2588,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2599,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2630,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2818,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2881,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2954,7 +2970,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3263,12 +3279,13 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
+ "abi",
  "alloy",
  "alloy-contract",
- "alloy-primitives 1.0.0",
- "alloy-sol-types 1.0.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-types 1.1.0",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.4.2",
@@ -3404,17 +3421,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -4199,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4419,8 +4425,8 @@ dependencies = [
  "alloy",
  "alloy-dyn-abi",
  "alloy-json-rpc",
- "alloy-primitives 1.0.0",
- "alloy-sol-types 1.0.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-types 1.1.0",
  "aws-config",
  "aws-sdk-s3",
  "aws-sdk-secretsmanager",
@@ -4467,7 +4473,7 @@ dependencies = [
 name = "funds-manager-api"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives 1.0.0",
+ "alloy-primitives 1.1.0",
  "common",
  "external-api",
  "http 0.2.12",
@@ -4709,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -4912,6 +4918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -5547,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7166,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7789,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7839,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -8565,7 +8580,19 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.4.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -8573,6 +8600,15 @@ name = "secp256k1-sys"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -9246,9 +9282,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
+checksum = "3d0f0d4760f4c2a0823063b2c70e97aa2ad185f57be195172ccc0e23c4b787c4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -9297,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "bus",
  "common",
@@ -9309,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10231,7 +10267,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/chain-remap#4d4ae957f0285573616f4dd5931643d41cb9d82e"
+source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -10579,7 +10615,7 @@ dependencies = [
  "pin-project",
  "reqwest 0.11.27",
  "rlp",
- "secp256k1",
+ "secp256k1 0.21.3",
  "serde",
  "serde_json",
  "soketto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,26 +23,26 @@ lto = true
 [workspace.dependencies]
 # === Renegade Dependencies === #
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap"}
-renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap", features = [
+renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", features = [
     "auth",
 ] }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap", features = ["metered-channels"] }
-renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
-renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git", branch = "sehyun/chain-remap" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = ["metered-channels"] }
+renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git" }
 
 # === Blockchain Dependencies === #
-alloy-sol-types = "1.0.0"
-alloy-dyn-abi = "1.0.0"
-alloy-json-rpc = "0.14"
-alloy-primitives = "1.0.0"
-alloy = "0.14"
+alloy-sol-types = "1.0.1"
+alloy-dyn-abi = "1.0.1"
+alloy-json-rpc = "1.0.1"
+alloy-primitives = "1.0.1"
+alloy = "1.0.1"
 
 # === Database Dependencies === #
 diesel = { version = "2.1" }

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -40,7 +40,7 @@ alloy = { workspace = true }
 ethers = "2"
 
 # === Renegade Dependencies === #
-renegade-darkpool-client = { package = "darkpool-client", workspace = true, features = [ "arbitrum" ] }
+renegade-darkpool-client = { package = "darkpool-client", workspace = true, features = [ "all-chains" ] }
 renegade-api = { package = "external-api", workspace = true }
 renegade-common = { package = "common", workspace = true }
 renegade-config = { package = "config", workspace = true }
@@ -64,4 +64,4 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 tracing = "0.1"
-uuid = "1.8"
+uuid = "1.16"

--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::Address;
 use aws_config::SdkConfig;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use renegade_circuit_types::elgamal::DecryptionKey;
 use renegade_common::types::{chain::Chain, hmac::HmacKey};
 use renegade_darkpool_client::{client::DarkpoolClientConfig, DarkpoolClient};
@@ -34,8 +34,15 @@ const BLOCK_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 
 /// A type alias for a map of chain configs
 type ChainConfigsMap = HashMap<Chain, ChainConfig>;
-/// A type alias for a map of chain clients
-type ChainClientsMap = HashMap<Chain, ChainClients>;
+
+/// The (chain-agnostic) environment the server is running in.
+#[derive(Clone, ValueEnum)]
+pub enum Environment {
+    /// The production environment
+    Production,
+    /// The development environment
+    Development,
+}
 
 /// The cli for the fee sweeper
 #[rustfmt::skip]
@@ -53,6 +60,12 @@ pub struct Cli {
     /// Whether to disable authentication
     #[clap(long, conflicts_with = "hmac_key")]
     pub disable_auth: bool,
+
+    // --- Chain-Agnostic Config --- //
+
+    /// The environment to run the server in
+    #[clap(long, env = "ENVIRONMENT")]
+    pub environment: Environment,
 
     // --- Chain-Specific Config --- //
 
@@ -131,7 +144,7 @@ impl Cli {
         aws_config: &SdkConfig,
     ) -> Result<ChainConfigsMap, FundsManagerError> {
         let json_str = if let Some(bucket) = &self.chain_configs_bucket {
-            fetch_s3_object(bucket, CHAIN_CONFIGS_OBJECT_NAME, &aws_config).await
+            fetch_s3_object(bucket, CHAIN_CONFIGS_OBJECT_NAME, aws_config).await
         } else {
             read_to_string(self.chain_configs_path.as_ref().expect("no chain configs file path"))
                 .await
@@ -194,6 +207,7 @@ impl ChainConfig {
             private_key,
             block_polling_interval: BLOCK_POLLING_INTERVAL,
         };
+        // TODO: Use separate `DarkpoolClientInner` for the given chain
         let darkpool_client = DarkpoolClient::new(conf).map_err(FundsManagerError::custom)?;
         let chain_id = darkpool_client.chain_id().await.map_err(FundsManagerError::arbitrum)?;
 
@@ -243,9 +257,14 @@ impl ChainConfig {
             custody_client.clone(),
         );
 
+        let relayer_client = Arc::new(relayer_client);
+        let custody_client = Arc::new(custody_client);
+        let execution_client = Arc::new(execution_client);
+        let metrics_recorder = Arc::new(metrics_recorder);
+        let fee_indexer = Arc::new(fee_indexer);
+
         Ok(ChainClients {
             relayer_client,
-            darkpool_client,
             custody_client,
             execution_client,
             metrics_recorder,
@@ -256,20 +275,18 @@ impl ChainConfig {
 
 /// Chain-specific clients used by the funds manager, parsed from a
 /// configuration object
-// TODO: Do I need to wrap these in `Arc`s?
 #[derive(Clone)]
 pub struct ChainClients {
     /// The client for the relayer deployed for the given chain
-    relayer_client: RelayerClient,
-    /// The client for the darkpool contract deployed onto the given chain
-    darkpool_client: DarkpoolClient,
+    pub(crate) relayer_client: Arc<RelayerClient>,
     /// The custody client for managing funds on the given chain
-    custody_client: CustodyClient,
+    pub(crate) custody_client: Arc<CustodyClient>,
     /// The execution client for executing swaps on the given chain
-    execution_client: ExecutionClient,
+    pub(crate) execution_client: Arc<ExecutionClient>,
     /// The metrics recorder for the given chain
-    // TODO: Have the `ExecutionClient` subsume this
-    metrics_recorder: MetricsRecorder,
+    // TODO: Turn into top-level chain-agnostic struct that holds references to
+    // necessary chain-specific clients
+    pub(crate) metrics_recorder: Arc<MetricsRecorder>,
     /// The fee indexer for the given chain
-    fee_indexer: Indexer,
+    pub(crate) fee_indexer: Arc<Indexer>,
 }

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -191,7 +191,7 @@ impl CustodyClient {
     /// Get the Fireblocks blockchain ID for the current chain
     async fn get_current_blockchain_id(&self) -> Result<String, FundsManagerError> {
         let list_blockchains_params = ListBlockchainsParams::builder()
-            .test(matches!(self.chain, Chain::Testnet))
+            .test(matches!(self.chain, Chain::ArbitrumSepolia | Chain::BaseSepolia))
             .deprecated(false)
             .build();
 
@@ -254,7 +254,7 @@ impl CustodyClient {
     /// Get an instance of a signer with the http provider attached
     fn get_signing_provider(&self, wallet: PrivateKeySigner) -> DynProvider {
         let provider =
-            ProviderBuilder::new().wallet(wallet).on_provider(self.arbitrum_provider.clone());
+            ProviderBuilder::new().wallet(wallet).connect_provider(self.arbitrum_provider.clone());
 
         DynProvider::new(provider)
     }

--- a/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
@@ -40,10 +40,14 @@ const ETH_ACCOUNTS_METHOD: &str = "eth_accounts";
 /// The method name for the `eth_signTypedData_v4` JSON-RPC method.
 const ETH_SIGN_TYPED_DATA_V4_METHOD: &str = "eth_signTypedData_v4";
 
-/// The Fireblocks asset ID for ETH on Arbitrum mainnet
-const ARB_MAINNET_ETH_ASSET_ID: &str = "ETH-AETH";
-/// The Fireblocks asset ID for ETH on Arbitrum testnet
-const ARB_TESTNET_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
+/// The Fireblocks asset ID for ETH on Arbitrum One
+const ARB_ONE_ETH_ASSET_ID: &str = "ETH-AETH";
+/// The Fireblocks asset ID for ETH on Arbitrum Sepolia
+const ARB_SEPOLIA_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
+/// The Fireblocks asset ID for ETH on Base mainnet
+const BASE_MAINNET_ETH_ASSET_ID: &str = "BASECHAIN_ETH";
+/// The Fireblocks asset ID for ETH on Base Sepolia
+const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
 /// The name of the Fireblocks vault custodying the Hyperliquid keypair
 const HYPERLIQUID_VAULT_NAME: &str = "Hyperliquid";
 /// The EIP-712 domain name for Hyperliquid L1 actions
@@ -242,8 +246,10 @@ impl CustodyClient {
     /// chain.
     fn get_native_eth_asset_id(&self) -> Result<String, FundsManagerError> {
         match self.chain {
-            Chain::Mainnet => Ok(ARB_MAINNET_ETH_ASSET_ID.to_string()),
-            Chain::Testnet => Ok(ARB_TESTNET_ETH_ASSET_ID.to_string()),
+            Chain::ArbitrumOne => Ok(ARB_ONE_ETH_ASSET_ID.to_string()),
+            Chain::ArbitrumSepolia => Ok(ARB_SEPOLIA_ETH_ASSET_ID.to_string()),
+            Chain::BaseMainnet => Ok(BASE_MAINNET_ETH_ASSET_ID.to_string()),
+            Chain::BaseSepolia => Ok(BASE_SEPOLIA_ETH_ASSET_ID.to_string()),
             _ => Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
         }
     }

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -38,6 +38,8 @@ const HYPERLIQUID_USDC_BUFFER: f64 = 0.000001;
 const ERR_HYPERLIQUID_BRIDGE_NOT_FOUND: &str = "Hyperliquid bridge not found";
 /// The error message for when the USDC asset is not found in Fireblocks
 const ERR_USDC_ASSET_NOT_FOUND: &str = "USDC asset not found";
+/// The error message for when the chain is not supported
+const ERR_UNSUPPORTED_CHAIN: &str = "Unsupported chain";
 
 // ---------------
 // | Client impl |
@@ -162,8 +164,9 @@ impl CustodyClient {
         let hot_wallet = self.get_quoter_hot_wallet().await?;
 
         let usdc_mint = match self.chain {
-            Chain::Mainnet => &Token::from_ticker(USDC_TICKER).addr,
-            _ => TESTNET_HYPERLIQUID_USDC_ADDRESS,
+            Chain::ArbitrumOne => &Token::from_ticker(USDC_TICKER).addr,
+            Chain::ArbitrumSepolia => TESTNET_HYPERLIQUID_USDC_ADDRESS,
+            _ => return Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
         };
 
         let hl_bal = self.get_erc20_balance(usdc_mint, &hyperliquid_address).await?;
@@ -253,9 +256,9 @@ impl CustodyClient {
     /// to allow ERC20 transfers to it.
     async fn get_hyperliquid_bridge_id(&self) -> Result<String, FundsManagerError> {
         let bridge_address = match self.chain {
-            Chain::Mainnet => MAINNET_HYPERLIQUID_BRIDGE_ADDRESS,
-            Chain::Testnet => TESTNET_HYPERLIQUID_BRIDGE_ADDRESS,
-            _ => return Err(FundsManagerError::Custom("Unsupported chain".to_string())),
+            Chain::ArbitrumOne => MAINNET_HYPERLIQUID_BRIDGE_ADDRESS,
+            Chain::ArbitrumSepolia => TESTNET_HYPERLIQUID_BRIDGE_ADDRESS,
+            _ => return Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
         };
 
         let whitelisted_wallets = self

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -85,7 +85,8 @@ impl ExecutionClient {
 
     /// Get an instance of a signer with the http provider attached
     fn get_signing_provider(&self, wallet: PrivateKeySigner) -> DynProvider {
-        let provider = ProviderBuilder::new().wallet(wallet).on_provider(self.rpc_provider.clone());
+        let provider =
+            ProviderBuilder::new().wallet(wallet).connect_provider(self.rpc_provider.clone());
         DynProvider::new(provider)
     }
 }

--- a/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
@@ -3,7 +3,6 @@
 use aws_config::SdkConfig as AwsConfig;
 use renegade_circuit_types::elgamal::DecryptionKey;
 use renegade_common::types::chain::Chain;
-use renegade_darkpool_client::DarkpoolClient;
 use renegade_util::err_str;
 use renegade_util::hex::jubjub_from_hex_string;
 use std::sync::Arc;
@@ -11,6 +10,7 @@ use std::sync::Arc;
 use crate::custody_client::CustodyClient;
 use crate::db::{DbConn, DbPool};
 use crate::error::FundsManagerError;
+use crate::mux_darkpool_client::MuxDarkpoolClient;
 use crate::relayer_client::RelayerClient;
 
 pub mod fee_balances;
@@ -28,7 +28,7 @@ pub(crate) struct Indexer {
     /// A client for interacting with the relayer
     pub relayer_client: RelayerClient,
     /// The darkpool client
-    pub darkpool_client: DarkpoolClient,
+    pub darkpool_client: MuxDarkpoolClient,
     /// The decryption key
     pub decryption_keys: Vec<DecryptionKey>,
     /// The database connection pool
@@ -46,7 +46,7 @@ impl Indexer {
         chain_id: u64,
         chain: Chain,
         aws_config: AwsConfig,
-        darkpool_client: DarkpoolClient,
+        darkpool_client: MuxDarkpoolClient,
         decryption_keys: Vec<DecryptionKey>,
         db_pool: Arc<DbPool>,
         relayer_client: RelayerClient,

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -1,5 +1,6 @@
 //! Route handlers for the funds manager
 
+use crate::cli::Environment;
 use crate::custody_client::rpc_shim::JsonRpcRequest;
 use crate::custody_client::DepositWithdrawSource;
 use crate::error::ApiError;
@@ -19,6 +20,7 @@ use funds_manager_api::quoters::{
     WithdrawFundsRequest, WithdrawToHyperliquidRequest,
 };
 use itertools::Itertools;
+use renegade_common::types::chain::Chain;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -42,41 +44,51 @@ pub const MIN_HYPERLIQUID_DEPOSIT_AMOUNT: f64 = 5.0; // USDC
 // --- Fee Indexing --- //
 
 /// Handler for indexing fees
-pub(crate) async fn index_fees_handler(server: Arc<Server>) -> Result<Json, warp::Rejection> {
-    let indexer = server.build_indexer();
+pub(crate) async fn index_fees_handler(
+    chain: Chain,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let indexer = server.get_fee_indexer(&chain)?;
     indexer
         .index_fees()
         .await
         .map_err(|e| warp::reject::custom(ApiError::IndexingError(e.to_string())))?;
+
     Ok(warp::reply::json(&"Fees indexed successfully"))
 }
 
 /// Handler for redeeming fees
-pub(crate) async fn redeem_fees_handler(server: Arc<Server>) -> Result<Json, warp::Rejection> {
-    let indexer = server.build_indexer();
+pub(crate) async fn redeem_fees_handler(
+    chain: Chain,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let indexer = server.get_fee_indexer(&chain)?;
     indexer
         .redeem_fees()
         .await
         .map_err(|e| warp::reject::custom(ApiError::RedemptionError(e.to_string())))?;
+
     Ok(warp::reply::json(&"Fees redeemed successfully"))
 }
 
 /// Handler for getting fee wallets
 pub(crate) async fn get_fee_wallets_handler(
+    chain: Chain,
     _body: Bytes, // no body
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let indexer = server.build_indexer();
+    let indexer = server.get_fee_indexer(&chain)?;
     let wallets = indexer.fetch_fee_wallets().await?;
     Ok(warp::reply::json(&FeeWalletsResponse { wallets }))
 }
 
 /// Handler for withdrawing a fee balance
 pub(crate) async fn withdraw_fee_balance_handler(
+    chain: Chain,
     req: WithdrawFeeBalanceRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let indexer = server.build_indexer();
+    let indexer = server.get_fee_indexer(&chain)?;
     indexer
         .withdraw_fee_balance(req.wallet_id, req.mint)
         .await
@@ -89,15 +101,14 @@ pub(crate) async fn withdraw_fee_balance_handler(
 
 /// Handler for withdrawing funds from custody
 pub(crate) async fn quoter_withdraw_handler(
+    chain: Chain,
     withdraw_request: WithdrawFundsRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
     // Get the price of the token
-    let maybe_price = server
-        .relayer_client
-        .get_binance_price(&withdraw_request.mint)
-        .await
-        .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+    // TODO: Replace w/ price reporter client
+    let relayer_client = server.get_relayer_client(&chain)?;
+    let maybe_price = relayer_client.get_binance_price(&withdraw_request.mint).await?;
 
     if let Some(price) = maybe_price {
         // If a price was found, check that the withdrawal value is less than the
@@ -115,8 +126,10 @@ pub(crate) async fn quoter_withdraw_handler(
         warn!("No price found for {}, allowing withdrawal", withdraw_request.mint);
     }
 
-    server
-        .custody_client
+    // Withdraw the funds
+    let custody_client = server.get_custody_client(&chain)?;
+
+    custody_client
         .withdraw_from_hot_wallet(
             DepositWithdrawSource::Quoter,
             &withdraw_request.address,
@@ -131,26 +144,30 @@ pub(crate) async fn quoter_withdraw_handler(
 
 /// Handler for retrieving the address to deposit custody funds to
 pub(crate) async fn get_deposit_address_handler(
+    chain: Chain,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let address = server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+    let address = custody_client
         .get_deposit_address(DepositWithdrawSource::Quoter)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+
     let resp = DepositAddressResponse { address };
     Ok(warp::reply::json(&resp))
 }
 
 /// Handler for getting an execution quote
 pub(crate) async fn get_execution_quote_handler(
+    chain: Chain,
     _body: Bytes, // no body
     query_params: HashMap<String, String>,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
+    let execution_client = server.get_execution_client(&chain)?;
+
     // Forward the query parameters to the execution client
-    let quote = server
-        .execution_client
+    let quote = execution_client
         .get_quote(query_params)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
@@ -163,9 +180,14 @@ pub(crate) async fn get_execution_quote_handler(
 
 /// Handler for executing a swap
 pub(crate) async fn execute_swap_handler(
+    chain: Chain,
     req: ExecuteSwapRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
+    let execution_client = server.get_execution_client(&chain)?;
+    let custody_client = server.get_custody_client(&chain)?;
+    let metrics_recorder = server.get_metrics_recorder(&chain)?;
+
     // Verify the signature
     let hmac_key = server.quote_hmac_key;
     let provided = hex::decode(&req.signature)
@@ -178,15 +200,14 @@ pub(crate) async fn execute_swap_handler(
     }
     let quote_clone = req.quote.clone();
 
-    let hot_wallet = server.custody_client.get_quoter_hot_wallet().await?;
-    let wallet = server.custody_client.get_hot_wallet_private_key(&hot_wallet.address).await?;
-    let receipt = server.execution_client.execute_swap(req.quote, &wallet).await?;
+    let hot_wallet = custody_client.get_quoter_hot_wallet().await?;
+    let wallet = custody_client.get_hot_wallet_private_key(&hot_wallet.address).await?;
+    let receipt = execution_client.execute_swap(req.quote, &wallet).await?;
     let tx_hash = receipt.transaction_hash;
 
     // Record swap cost metrics
-    let server_clone = server.clone();
     tokio::spawn(async move {
-        server_clone.metrics_recorder.record_swap_cost(&receipt, &quote_clone).await;
+        metrics_recorder.record_swap_cost(&receipt, &quote_clone).await;
     });
 
     let resp = ExecuteSwapResponse { tx_hash: format!("{:#x}", tx_hash) };
@@ -198,13 +219,22 @@ pub(crate) async fn withdraw_to_hyperliquid_handler(
     req: WithdrawToHyperliquidRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
+    // TODO: Separate out chain-agnostic hedging client from custody client
+    let chain = match server.environment {
+        Environment::Production => Chain::Mainnet,
+        Environment::Development => Chain::Testnet,
+    };
+
     if req.amount < MIN_HYPERLIQUID_DEPOSIT_AMOUNT {
         return Err(warp::reject::custom(ApiError::BadRequest(format!(
             "Requested amount {} USDC is less than the minimum allowed deposit of {} USDC",
             req.amount, MIN_HYPERLIQUID_DEPOSIT_AMOUNT
         ))));
     }
-    server.custody_client.withdraw_to_hyperliquid(req.amount).await?;
+
+    let custody_client = server.get_custody_client(&chain)?;
+    custody_client.withdraw_to_hyperliquid(req.amount).await?;
+
     Ok(warp::reply::json(&"Withdrawal to Hyperliquid complete"))
 }
 
@@ -212,6 +242,7 @@ pub(crate) async fn withdraw_to_hyperliquid_handler(
 
 /// Handler for withdrawing gas from custody
 pub(crate) async fn withdraw_gas_handler(
+    chain: Chain,
     withdraw_request: WithdrawGasRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
@@ -222,16 +253,18 @@ pub(crate) async fn withdraw_gas_handler(
         ))));
     }
 
-    server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+    custody_client
         .withdraw_gas(withdraw_request.amount, &withdraw_request.destination_address)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+
     Ok(warp::reply::json(&"Withdrawal complete"))
 }
 
 /// Handler for refilling gas for all active wallets
 pub(crate) async fn refill_gas_handler(
+    chain: Chain,
     req: RefillGasRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
@@ -243,46 +276,55 @@ pub(crate) async fn refill_gas_handler(
         ))));
     }
 
-    server.custody_client.refill_gas_wallets(req.amount).await?;
+    let custody_client = server.get_custody_client(&chain)?;
+    custody_client.refill_gas_wallets(req.amount).await?;
+
     let resp = json!({});
     Ok(warp::reply::json(&resp))
 }
 
 /// Handler for creating a new gas wallet
 pub(crate) async fn create_gas_wallet_handler(
+    chain: Chain,
     _body: Bytes, // no body
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let address = server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+
+    let address = custody_client
         .create_gas_wallet()
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+
     let resp = CreateGasWalletResponse { address };
     Ok(warp::reply::json(&resp))
 }
 
 /// Handler for registering a gas wallet for a peer
 pub(crate) async fn register_gas_wallet_handler(
+    chain: Chain,
     req: RegisterGasWalletRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let key = server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+
+    let key = custody_client
         .register_gas_wallet(&req.peer_id)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
+
     let resp = RegisterGasWalletResponse { key };
     Ok(warp::reply::json(&resp))
 }
 
 /// Handler for reporting active peers
 pub(crate) async fn report_active_peers_handler(
+    chain: Chain,
     req: ReportActivePeersRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+    custody_client
         .record_active_gas_wallet(req.peers)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
@@ -293,10 +335,13 @@ pub(crate) async fn report_active_peers_handler(
 
 /// Handler for refilling gas for the gas sponsor contract
 pub(crate) async fn refill_gas_sponsor_handler(
+    chain: Chain,
     _body: Bytes, // no body
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    server.custody_client.refill_gas_sponsor().await?;
+    let custody_client = server.get_custody_client(&chain)?;
+    custody_client.refill_gas_sponsor().await?;
+
     let resp = json!({});
     Ok(warp::reply::json(&resp))
 }
@@ -305,11 +350,13 @@ pub(crate) async fn refill_gas_sponsor_handler(
 
 /// Handler for creating a hot wallet
 pub(crate) async fn create_hot_wallet_handler(
+    chain: Chain,
     req: CreateHotWalletRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let address = server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+
+    let address = custody_client
         .create_hot_wallet(req.vault, req.internal_wallet_id)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
@@ -320,17 +367,19 @@ pub(crate) async fn create_hot_wallet_handler(
 
 /// Handler for getting hot wallet balances
 pub(crate) async fn get_hot_wallet_balances_handler(
+    chain: Chain,
     _body: Bytes, // unused
     query_params: HashMap<String, String>,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
+    let custody_client = server.get_custody_client(&chain)?;
+
     let mints = query_params
         .get(MINTS_QUERY_PARAM)
         .map(|s| s.split(',').map(String::from).collect_vec())
         .unwrap_or_default();
 
-    let wallets = server
-        .custody_client
+    let wallets = custody_client
         .get_hot_wallet_balances(&mints)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
@@ -341,11 +390,13 @@ pub(crate) async fn get_hot_wallet_balances_handler(
 
 /// Handler for transferring funds from a hot wallet to its backing vault
 pub(crate) async fn transfer_to_vault_handler(
+    chain: Chain,
     req: TransferToVaultRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+
+    custody_client
         .transfer_from_hot_wallet_to_vault(&req.hot_wallet_address, &req.mint, req.amount)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
@@ -355,11 +406,13 @@ pub(crate) async fn transfer_to_vault_handler(
 
 /// Handler for withdrawing funds from a vault to its hot wallet
 pub(crate) async fn withdraw_from_vault_handler(
+    chain: Chain,
     req: WithdrawToHotWalletRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    server
-        .custody_client
+    let custody_client = server.get_custody_client(&chain)?;
+
+    custody_client
         .transfer_from_vault_to_hot_wallet(&req.vault, &req.mint, req.amount)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
@@ -373,6 +426,14 @@ pub(crate) async fn rpc_handler(
     req: JsonRpcRequest,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
-    let rpc_response = server.custody_client.handle_rpc_request(req).await;
+    // TODO: Have chain-agnostic hedging client subsume this
+    let chain = match server.environment {
+        Environment::Production => Chain::Mainnet,
+        Environment::Development => Chain::Testnet,
+    };
+
+    let custody_client = server.get_custody_client(&chain)?;
+    let rpc_response = custody_client.handle_rpc_request(req).await;
+
     Ok(warp::reply::json(&rpc_response))
 }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -27,6 +27,8 @@ use std::sync::Arc;
 use tracing::warn;
 use warp::reply::Json;
 
+// --- Constants --- //
+
 /// The "mints" query param
 pub const MINTS_QUERY_PARAM: &str = "mints";
 /// The asset used for gas (ETH)
@@ -79,6 +81,7 @@ pub(crate) async fn get_fee_wallets_handler(
 ) -> Result<Json, warp::Rejection> {
     let indexer = server.get_fee_indexer(&chain)?;
     let wallets = indexer.fetch_fee_wallets().await?;
+
     Ok(warp::reply::json(&FeeWalletsResponse { wallets }))
 }
 
@@ -221,8 +224,8 @@ pub(crate) async fn withdraw_to_hyperliquid_handler(
 ) -> Result<Json, warp::Rejection> {
     // TODO: Separate out chain-agnostic hedging client from custody client
     let chain = match server.environment {
-        Environment::Production => Chain::Mainnet,
-        Environment::Development => Chain::Testnet,
+        Environment::Mainnet => Chain::ArbitrumOne,
+        Environment::Testnet => Chain::ArbitrumSepolia,
     };
 
     if req.amount < MIN_HYPERLIQUID_DEPOSIT_AMOUNT {
@@ -428,8 +431,8 @@ pub(crate) async fn rpc_handler(
 ) -> Result<Json, warp::Rejection> {
     // TODO: Have chain-agnostic hedging client subsume this
     let chain = match server.environment {
-        Environment::Production => Chain::Mainnet,
-        Environment::Development => Chain::Testnet,
+        Environment::Mainnet => Chain::ArbitrumOne,
+        Environment::Testnet => Chain::ArbitrumSepolia,
     };
 
     let custody_client = server.get_custody_client(&chain)?;

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -11,6 +11,7 @@ use alloy::{
 use aws_config::SdkConfig;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::client::Client as SecretsManagerClient;
+use renegade_common::types::chain::Chain;
 use renegade_util::err_str;
 
 use crate::error::FundsManagerError;
@@ -47,7 +48,7 @@ pub fn build_provider(url: &str) -> Result<DynProvider, FundsManagerError> {
         .filler(ChainIdFiller::default())
         .filler(GasFiller)
         .filler(BlobGasFiller)
-        .on_http(url);
+        .connect_http(url);
 
     Ok(DynProvider::new(provider))
 }
@@ -55,6 +56,17 @@ pub fn build_provider(url: &str) -> Result<DynProvider, FundsManagerError> {
 // -----------------------
 // | AWS Secrets Manager |
 // -----------------------
+
+/// Get the prefix for a chain-specific secret
+pub fn get_secret_prefix(chain: Chain) -> Result<String, FundsManagerError> {
+    match chain {
+        Chain::ArbitrumOne => Ok("/arbitrum/one/".to_string()),
+        Chain::ArbitrumSepolia => Ok("/arbitrum/sepolia/".to_string()),
+        Chain::BaseMainnet => Ok("/base/mainnet/".to_string()),
+        Chain::BaseSepolia => Ok("/base/mainnet/".to_string()),
+        _ => Err(FundsManagerError::custom("Unsupported chain")),
+    }
+}
 
 /// Get a secret from AWS Secrets Manager
 pub async fn get_secret(

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -52,7 +52,8 @@ use handlers::{
     transfer_to_vault_handler, withdraw_fee_balance_handler, withdraw_from_vault_handler,
     withdraw_gas_handler, withdraw_to_hyperliquid_handler,
 };
-use middleware::{identity, with_hmac_auth, with_json_body};
+use middleware::{identity, with_chain_and_json_body, with_hmac_auth, with_json_body};
+use renegade_common::types::chain::Chain;
 use server::Server;
 
 use renegade_util::telemetry::configure_telemetry;
@@ -101,6 +102,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let index_fees = warp::post()
         .and(warp::path("fees"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path(INDEX_FEES_ROUTE))
         .and(with_server(server.clone()))
         .and_then(index_fees_handler);
@@ -108,11 +110,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let redeem_fees = warp::post()
         .and(warp::path("fees"))
         .and(warp::path(REDEEM_FEES_ROUTE))
+        .and(warp::path::param::<Chain>())
         .and(with_server(server.clone()))
         .and_then(redeem_fees_handler);
 
     let get_balances = warp::get()
         .and(warp::path("fees"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path(GET_FEE_WALLETS_ROUTE))
         .and(with_hmac_auth(server.clone()))
         .and(with_server(server.clone()))
@@ -120,10 +124,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let withdraw_fee_balance = warp::post()
         .and(warp::path("fees"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path(WITHDRAW_FEE_BALANCE_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawFeeBalanceRequest>)
+        .map(with_chain_and_json_body::<WithdrawFeeBalanceRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(withdraw_fee_balance_handler);
 
@@ -131,16 +137,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let withdraw_custody = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("quoters"))
         .and(warp::path(WITHDRAW_CUSTODY_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawFundsRequest>)
+        .map(with_chain_and_json_body::<WithdrawFundsRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(quoter_withdraw_handler);
 
     let get_deposit_address = warp::get()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("quoters"))
         .and(warp::path(GET_DEPOSIT_ADDRESS_ROUTE))
         .and(with_server(server.clone()))
@@ -148,6 +157,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let get_execution_quote = warp::get()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("quoters"))
         .and(warp::path(GET_EXECUTION_QUOTE_ROUTE))
         .and(with_hmac_auth(server.clone()))
@@ -157,11 +167,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let execute_swap = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("quoters"))
         .and(warp::path(EXECUTE_SWAP_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<ExecuteSwapRequest>)
+        .map(with_chain_and_json_body::<ExecuteSwapRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(execute_swap_handler);
 
@@ -179,26 +191,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let withdraw_gas = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("gas"))
         .and(warp::path(WITHDRAW_GAS_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawGasRequest>)
+        .map(with_chain_and_json_body::<WithdrawGasRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(withdraw_gas_handler);
 
     let refill_gas = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("gas"))
         .and(warp::path(REFILL_GAS_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<RefillGasRequest>)
+        .map(with_chain_and_json_body::<RefillGasRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(refill_gas_handler);
 
     let add_gas_wallet = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("gas-wallets"))
         .and(with_hmac_auth(server.clone()))
         .and(with_server(server.clone()))
@@ -206,26 +223,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let register_gas_wallet = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("gas-wallets"))
         .and(warp::path(REGISTER_GAS_WALLET_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<RegisterGasWalletRequest>)
+        .map(with_chain_and_json_body::<RegisterGasWalletRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(register_gas_wallet_handler);
 
     let report_active_peers = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("gas-wallets"))
         .and(warp::path(REPORT_ACTIVE_PEERS_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<ReportActivePeersRequest>)
+        .map(with_chain_and_json_body::<ReportActivePeersRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(report_active_peers_handler);
 
     let refill_gas_sponsor = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("gas"))
         .and(warp::path(REFILL_GAS_SPONSOR_ROUTE))
         .and(with_hmac_auth(server.clone()))
@@ -236,15 +258,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let create_hot_wallet = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("hot-wallets"))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<CreateHotWalletRequest>)
+        .map(with_chain_and_json_body::<CreateHotWalletRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(create_hot_wallet_handler);
 
     let get_hot_wallet_balances = warp::get()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("hot-wallets"))
         .and(with_hmac_auth(server.clone()))
         .and(warp::query::<HashMap<String, String>>())
@@ -253,21 +278,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let transfer_to_vault = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("hot-wallets"))
         .and(warp::path(TRANSFER_TO_VAULT_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<TransferToVaultRequest>)
+        .map(with_chain_and_json_body::<TransferToVaultRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(transfer_to_vault_handler);
 
     let transfer_to_hot_wallet = warp::post()
         .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
         .and(warp::path("hot-wallets"))
         .and(warp::path(WITHDRAW_TO_HOT_WALLET_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawToHotWalletRequest>)
+        .map(with_chain_and_json_body::<WithdrawToHotWalletRequest>)
         .and_then(identity)
+        .untuple_one()
         .and(with_server(server.clone()))
         .and_then(withdraw_from_vault_handler);
 

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -17,11 +17,13 @@ pub mod handlers;
 pub mod helpers;
 pub mod metrics;
 pub mod middleware;
+pub mod mux_darkpool_client;
 pub mod relayer_client;
 pub mod server;
 
+use bytes::Bytes;
 use clap::Parser;
-use cli::Cli;
+use cli::{Cli, Environment};
 use custody_client::rpc_shim::JsonRpcRequest;
 use fee_indexer::Indexer;
 use funds_manager_api::fees::{
@@ -109,8 +111,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let redeem_fees = warp::post()
         .and(warp::path("fees"))
-        .and(warp::path(REDEEM_FEES_ROUTE))
         .and(warp::path::param::<Chain>())
+        .and(warp::path(REDEEM_FEES_ROUTE))
         .and(with_server(server.clone()))
         .and_then(redeem_fees_handler);
 
@@ -309,6 +311,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(rpc_handler);
 
+    let backwards_compatibility_routes = backwards_compatibility_routes(server.clone());
+
     let routes = ping
         .or(index_fees)
         .or(redeem_fees)
@@ -330,10 +334,240 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(get_hot_wallet_balances)
         .or(create_hot_wallet)
         .or(rpc)
+        .or(backwards_compatibility_routes)
         .recover(handle_rejection);
+
     warp::serve(routes).run(([0, 0, 0, 0], port)).await;
 
     Ok(())
+}
+
+/// Backwards-compatible route definitions, routing paths excluding the chain
+/// parameter to Arbitrum-specific handler invocations
+fn backwards_compatibility_routes(
+    server: Arc<Server>,
+) -> impl Filter<Extract: warp::Reply, Error = warp::Rejection> + Clone + Send {
+    // --- Fee Indexing --- //
+
+    let arb_chain = match server.environment {
+        Environment::Mainnet => Chain::ArbitrumOne,
+        Environment::Testnet => Chain::ArbitrumSepolia,
+    };
+
+    let index_fees = warp::post()
+        .and(warp::path("fees"))
+        .and(warp::path(INDEX_FEES_ROUTE))
+        .and(with_server(server.clone()))
+        .and_then(move |server: Arc<Server>| index_fees_handler(arb_chain, server));
+
+    let redeem_fees = warp::post()
+        .and(warp::path("fees"))
+        .and(warp::path(REDEEM_FEES_ROUTE))
+        .and(with_server(server.clone()))
+        .and_then(move |server: Arc<Server>| redeem_fees_handler(arb_chain, server));
+
+    let get_balances = warp::get()
+        .and(warp::path("fees"))
+        .and(warp::path(GET_FEE_WALLETS_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .and(with_server(server.clone()))
+        .and_then(move |body: Bytes, server: Arc<Server>| {
+            get_fee_wallets_handler(arb_chain, body, server)
+        });
+
+    let withdraw_fee_balance = warp::post()
+        .and(warp::path("fees"))
+        .and(warp::path(WITHDRAW_FEE_BALANCE_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<WithdrawFeeBalanceRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: WithdrawFeeBalanceRequest, server: Arc<Server>| {
+            withdraw_fee_balance_handler(arb_chain, req, server)
+        });
+
+    // --- Quoters --- //
+
+    let withdraw_custody = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("quoters"))
+        .and(warp::path(WITHDRAW_CUSTODY_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<WithdrawFundsRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: WithdrawFundsRequest, server: Arc<Server>| {
+            quoter_withdraw_handler(arb_chain, req, server)
+        });
+
+    let get_deposit_address = warp::get()
+        .and(warp::path("custody"))
+        .and(warp::path("quoters"))
+        .and(warp::path(GET_DEPOSIT_ADDRESS_ROUTE))
+        .and(with_server(server.clone()))
+        .and_then(move |server: Arc<Server>| get_deposit_address_handler(arb_chain, server));
+
+    let get_execution_quote = warp::get()
+        .and(warp::path("custody"))
+        .and(warp::path("quoters"))
+        .and(warp::path(GET_EXECUTION_QUOTE_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .and(warp::query::<HashMap<String, String>>())
+        .and(with_server(server.clone()))
+        .and_then(
+            move |body: Bytes, query_params: HashMap<String, String>, server: Arc<Server>| {
+                get_execution_quote_handler(arb_chain, body, query_params, server)
+            },
+        );
+
+    let execute_swap = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("quoters"))
+        .and(warp::path(EXECUTE_SWAP_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<ExecuteSwapRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: ExecuteSwapRequest, server: Arc<Server>| {
+            execute_swap_handler(arb_chain, req, server)
+        });
+
+    // --- Gas --- //
+
+    let withdraw_gas = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas"))
+        .and(warp::path(WITHDRAW_GAS_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<WithdrawGasRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: WithdrawGasRequest, server: Arc<Server>| {
+            withdraw_gas_handler(arb_chain, req, server)
+        });
+
+    let refill_gas = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas"))
+        .and(warp::path(REFILL_GAS_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<RefillGasRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: RefillGasRequest, server: Arc<Server>| {
+            refill_gas_handler(arb_chain, req, server)
+        });
+
+    let add_gas_wallet = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas-wallets"))
+        .and(with_hmac_auth(server.clone()))
+        .and(with_server(server.clone()))
+        .and_then(move |body: Bytes, server: Arc<Server>| {
+            create_gas_wallet_handler(arb_chain, body, server)
+        });
+
+    let register_gas_wallet = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas-wallets"))
+        .and(warp::path(REGISTER_GAS_WALLET_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<RegisterGasWalletRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: RegisterGasWalletRequest, server: Arc<Server>| {
+            register_gas_wallet_handler(arb_chain, req, server)
+        });
+
+    let report_active_peers = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas-wallets"))
+        .and(warp::path(REPORT_ACTIVE_PEERS_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<ReportActivePeersRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: ReportActivePeersRequest, server: Arc<Server>| {
+            report_active_peers_handler(arb_chain, req, server)
+        });
+
+    let refill_gas_sponsor = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("gas"))
+        .and(warp::path(REFILL_GAS_SPONSOR_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .and(with_server(server.clone()))
+        .and_then(move |body: Bytes, server: Arc<Server>| {
+            refill_gas_sponsor_handler(arb_chain, body, server)
+        });
+
+    // --- Hot Wallets --- //
+
+    let create_hot_wallet = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("hot-wallets"))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<CreateHotWalletRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: CreateHotWalletRequest, server: Arc<Server>| {
+            create_hot_wallet_handler(arb_chain, req, server)
+        });
+
+    let get_hot_wallet_balances = warp::get()
+        .and(warp::path("custody"))
+        .and(warp::path("hot-wallets"))
+        .and(with_hmac_auth(server.clone()))
+        .and(warp::query::<HashMap<String, String>>())
+        .and(with_server(server.clone()))
+        .and_then(
+            move |body: Bytes, query_params: HashMap<String, String>, server: Arc<Server>| {
+                get_hot_wallet_balances_handler(arb_chain, body, query_params, server)
+            },
+        );
+
+    let transfer_to_vault = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("hot-wallets"))
+        .and(warp::path(TRANSFER_TO_VAULT_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<TransferToVaultRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: TransferToVaultRequest, server: Arc<Server>| {
+            transfer_to_vault_handler(arb_chain, req, server)
+        });
+
+    let transfer_to_hot_wallet = warp::post()
+        .and(warp::path("custody"))
+        .and(warp::path("hot-wallets"))
+        .and(warp::path(WITHDRAW_TO_HOT_WALLET_ROUTE))
+        .and(with_hmac_auth(server.clone()))
+        .map(with_json_body::<WithdrawToHotWalletRequest>)
+        .and_then(identity)
+        .and(with_server(server.clone()))
+        .and_then(move |req: WithdrawToHotWalletRequest, server: Arc<Server>| {
+            withdraw_from_vault_handler(arb_chain, req, server)
+        });
+
+    index_fees
+        .or(redeem_fees)
+        .or(withdraw_custody)
+        .or(get_deposit_address)
+        .or(get_execution_quote)
+        .or(execute_swap)
+        .or(withdraw_gas)
+        .or(refill_gas)
+        .or(report_active_peers)
+        .or(refill_gas_sponsor)
+        .or(register_gas_wallet)
+        .or(add_gas_wallet)
+        .or(get_balances)
+        .or(withdraw_fee_balance)
+        .or(transfer_to_vault)
+        .or(transfer_to_hot_wallet)
+        .or(get_hot_wallet_balances)
+        .or(create_hot_wallet)
 }
 
 // -----------

--- a/funds-manager/funds-manager-server/src/middleware.rs
+++ b/funds-manager/funds-manager-server/src/middleware.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use funds_manager_api::auth::{get_request_bytes, X_SIGNATURE_HEADER};
 use http::{HeaderMap, Method};
 use renegade_api::auth::validate_expiring_auth;
+use renegade_common::types::chain::Chain;
 use serde::de::DeserializeOwned;
 use std::sync::Arc;
 use warp::filters::path::FullPath;
@@ -91,6 +92,15 @@ async fn verify_hmac(
     }
 
     Ok((body,))
+}
+
+/// Extract a JSON body from a request
+#[allow(clippy::needless_pass_by_value)]
+pub fn with_chain_and_json_body<T: DeserializeOwned + Send>(
+    chain: Chain,
+    body: Bytes,
+) -> Result<(Chain, T), warp::Rejection> {
+    with_json_body(body).map(|body| (chain, body))
 }
 
 /// Extract a JSON body from a request

--- a/funds-manager/funds-manager-server/src/mux_darkpool_client.rs
+++ b/funds-manager/funds-manager-server/src/mux_darkpool_client.rs
@@ -1,0 +1,110 @@
+//! A wrapper around the `DarkpoolClientInner` struct that muxes the
+//! implementation logic between an Arbitrum darkpool client and a Base darkpool
+//! client
+
+use std::fmt::{self, Display};
+
+use alloy::contract::Event;
+use alloy_primitives::ChainId;
+use alloy_sol_types::SolEvent;
+use renegade_circuit_types::wallet::Nullifier;
+use renegade_common::types::chain::Chain;
+use renegade_darkpool_client::{
+    arbitrum::ArbitrumDarkpool,
+    base::BaseDarkpool,
+    client::{DarkpoolClientConfig, DarkpoolClientInner, RenegadeProvider},
+    errors::DarkpoolClientError,
+};
+
+/// The error type returned by the MuxDarkpoolClient
+pub enum MuxDarkpoolClientError {
+    /// An error that occurred while interacting with the darkpool client
+    Client(DarkpoolClientError),
+    /// An error attempting to use an unsupported chain
+    UnsupportedChain,
+}
+
+impl From<DarkpoolClientError> for MuxDarkpoolClientError {
+    fn from(e: DarkpoolClientError) -> Self {
+        Self::Client(e)
+    }
+}
+
+impl Display for MuxDarkpoolClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Client(e) => write!(f, "{}", e),
+            Self::UnsupportedChain => write!(f, "Unsupported chain"),
+        }
+    }
+}
+
+/// A wrapper providing a unified interface to the Arbitrum and Base darkpool
+/// clients
+#[derive(Clone)]
+pub enum MuxDarkpoolClient {
+    /// An Arbitrum darkpool client
+    Arbitrum(DarkpoolClientInner<ArbitrumDarkpool>),
+    /// A Base darkpool client
+    Base(DarkpoolClientInner<BaseDarkpool>),
+}
+
+impl MuxDarkpoolClient {
+    /// Create a new darkpool client
+    pub fn new(chain: Chain, config: DarkpoolClientConfig) -> Result<Self, MuxDarkpoolClientError> {
+        match chain {
+            Chain::ArbitrumSepolia | Chain::ArbitrumOne => {
+                let client = DarkpoolClientInner::<ArbitrumDarkpool>::new(config)?;
+                Ok(Self::Arbitrum(client))
+            },
+            Chain::BaseSepolia | Chain::BaseMainnet => {
+                let client = DarkpoolClientInner::<BaseDarkpool>::new(config)?;
+                Ok(Self::Base(client))
+            },
+            _ => Err(MuxDarkpoolClientError::UnsupportedChain),
+        }
+    }
+
+    /// Get a reference to some underlying RPC client
+    pub fn provider(&self) -> &RenegadeProvider {
+        match self {
+            Self::Arbitrum(client) => client.provider(),
+            Self::Base(client) => client.provider(),
+        }
+    }
+
+    /// Get the chain ID
+    pub async fn chain_id(&self) -> Result<ChainId, MuxDarkpoolClientError> {
+        match self {
+            Self::Arbitrum(client) => client.chain_id().await,
+            Self::Base(client) => client.chain_id().await,
+        }
+        .map_err(Into::into)
+    }
+
+    /// Create an event filter
+    pub fn event_filter<E: SolEvent>(&self) -> Event<&RenegadeProvider, E> {
+        match self {
+            Self::Arbitrum(client) => client.event_filter::<E>(),
+            Self::Base(client) => client.event_filter::<E>(),
+        }
+    }
+
+    // ------------------------
+    // | Contract Interaction |
+    // ------------------------
+
+    /// Check whether the given nullifier is used
+    ///
+    /// Returns `true` if the nullifier is used, `false` otherwise
+    pub async fn check_nullifier_used(
+        &self,
+        nullifier: Nullifier,
+    ) -> Result<bool, MuxDarkpoolClientError> {
+        match self {
+            Self::Arbitrum(client) => client.check_nullifier_used(nullifier).await,
+            Self::Base(client) => client.check_nullifier_used(nullifier).await,
+        }
+        .map_err(Into::into)
+    }
+}


### PR DESCRIPTION
This PR has the funds manager's routes/handlers accept a `Chain` path parameter where relevant. This is in expectation of the `Chain` enum specifying `ArbitrumSepolia, ArbitrumOne, BaseSepolia, BaseMainnet` more directly than just `Mainnet, Testnet`. For this reason we also introduce an `Environment` enum that the server must be configured with, which will be used in e.g. the Hyperliquid functionality to select `Chain::ArbitrumSepolia, Chain::ArbitrumOne` as appropriate.