### PR TITLE
auth-server: telemetry: Record zero fill ratio for no quote

### DIFF
--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -65,8 +65,6 @@ pub const SETTLEMENT_STATUS_TAG: &str = "did_settle";
 pub const REQUEST_ID_METRIC_TAG: &str = "request_id";
 /// Metric tag for the base asset of an external order or match
 pub const BASE_ASSET_METRIC_TAG: &str = "base_asset";
-/// Metric tag to indicate data was recorded post decimal correction fix
-pub const DECIMAL_CORRECTION_FIXED_METRIC_TAG: &str = "post_decimal_fix";
 /// Metric tag for the path of the request
 pub const REQUEST_PATH_METRIC_TAG: &str = "request_path";
 /// Metric tag for the SDK version of the request

--- a/auth/auth-server/src/telemetry/mod.rs
+++ b/auth/auth-server/src/telemetry/mod.rs
@@ -3,3 +3,11 @@ pub mod helpers;
 pub mod labels;
 pub mod quote_comparison;
 pub mod sources;
+
+/// The threshold beyond which to ignore a quote's fill ratio
+///
+/// We ignore quotes beyond this value as they're likely to be spam, or are far
+/// beyond expected external match liquidity so as to be useless for telemetry.
+///
+/// Specified in USDC
+pub const QUOTE_FILL_RATIO_IGNORE_THRESHOLD: u128 = 100_000 * 10u128.pow(6u32); // $100,000 of USDC


### PR DESCRIPTION
### Purpose
This PR changes the auth server logic to record a fill ratio of zero in the case that a quote isn't found. 

### Testing
- [x] Testing in testnet