### PR TITLE
funds-manager-server: db: add `chain` columns

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/queries.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/queries.rs
@@ -6,9 +6,8 @@ use renegade_util::err_str;
 use tracing::info;
 use uuid::Uuid;
 
-use crate::db::models::{GasWallet, GasWalletStatus, HotWallet};
-use crate::db::schema::gas_wallets;
-use crate::db::schema::hot_wallets;
+use crate::db::models::{to_db_chain, GasWallet, GasWalletStatus, HotWallet};
+use crate::db::schema::{gas_wallets, hot_wallets};
 use crate::error::FundsManagerError;
 use crate::CustodyClient;
 
@@ -21,32 +20,35 @@ impl CustodyClient {
 
     // --- Getters --- //
 
-    /// Get all gas wallets
+    /// Get all gas wallets on the chain managed by the CustodyClient
     pub async fn get_all_gas_wallets(&self) -> Result<Vec<GasWallet>, FundsManagerError> {
         let mut conn = self.get_db_conn().await?;
         gas_wallets::table
+            .filter(gas_wallets::chain.eq(to_db_chain(self.chain)))
             .load::<GasWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))
     }
 
-    /// Get all active gas wallets
+    /// Get all active gas wallets on the chain managed by the CustodyClient
     pub async fn get_active_gas_wallets(&self) -> Result<Vec<GasWallet>, FundsManagerError> {
         let mut conn = self.get_db_conn().await?;
         let active = GasWalletStatus::Active.to_string();
         gas_wallets::table
             .filter(gas_wallets::status.eq(active))
+            .filter(gas_wallets::chain.eq(to_db_chain(self.chain)))
             .load::<GasWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))
     }
 
-    /// Find an inactive gas wallet
+    /// Find an inactive gas wallet on the chain managed by the CustodyClient
     pub async fn find_inactive_gas_wallet(&self) -> Result<GasWallet, FundsManagerError> {
         let mut conn = self.get_db_conn().await?;
         let inactive = GasWalletStatus::Inactive.to_string();
         gas_wallets::table
             .filter(gas_wallets::status.eq(inactive))
+            .filter(gas_wallets::chain.eq(to_db_chain(self.chain)))
             .first::<GasWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))
@@ -57,7 +59,7 @@ impl CustodyClient {
     /// Add a new gas wallet
     pub async fn add_gas_wallet(&self, address: &str) -> Result<(), FundsManagerError> {
         let mut conn = self.get_db_conn().await?;
-        let entry = GasWallet::new(address.to_string());
+        let entry = GasWallet::new(address.to_string(), self.chain);
         diesel::insert_into(gas_wallets::table)
             .values(entry)
             .execute(&mut conn)
@@ -76,11 +78,15 @@ impl CustodyClient {
             gas_wallets::peer_id.eq(None::<String>),
         );
 
-        diesel::update(gas_wallets::table.filter(gas_wallets::address.eq(address)))
-            .set(updates)
-            .execute(&mut conn)
-            .await
-            .map_err(err_str!(FundsManagerError::Db))?;
+        diesel::update(
+            gas_wallets::table
+                .filter(gas_wallets::address.eq(address))
+                .filter(gas_wallets::chain.eq(to_db_chain(self.chain))),
+        )
+        .set(updates)
+        .execute(&mut conn)
+        .await
+        .map_err(err_str!(FundsManagerError::Db))?;
 
         Ok(())
     }
@@ -90,11 +96,15 @@ impl CustodyClient {
         info!("Marking gas wallet as pending: {address}");
         let mut conn = self.get_db_conn().await?;
         let pending = GasWalletStatus::Pending.to_string();
-        diesel::update(gas_wallets::table.filter(gas_wallets::address.eq(address)))
-            .set(gas_wallets::status.eq(pending))
-            .execute(&mut conn)
-            .await
-            .map_err(err_str!(FundsManagerError::Db))?;
+        diesel::update(
+            gas_wallets::table
+                .filter(gas_wallets::address.eq(address))
+                .filter(gas_wallets::chain.eq(to_db_chain(self.chain))),
+        )
+        .set(gas_wallets::status.eq(pending))
+        .execute(&mut conn)
+        .await
+        .map_err(err_str!(FundsManagerError::Db))?;
 
         Ok(())
     }
@@ -109,11 +119,15 @@ impl CustodyClient {
         let mut conn = self.get_db_conn().await?;
         let active = GasWalletStatus::Active.to_string();
         let updates = (gas_wallets::status.eq(active), gas_wallets::peer_id.eq(peer_id));
-        diesel::update(gas_wallets::table.filter(gas_wallets::address.eq(address)))
-            .set(updates)
-            .execute(&mut conn)
-            .await
-            .map_err(err_str!(FundsManagerError::Db))?;
+        diesel::update(
+            gas_wallets::table
+                .filter(gas_wallets::address.eq(address))
+                .filter(gas_wallets::chain.eq(to_db_chain(self.chain))),
+        )
+        .set(updates)
+        .execute(&mut conn)
+        .await
+        .map_err(err_str!(FundsManagerError::Db))?;
 
         Ok(())
     }
@@ -124,10 +138,11 @@ impl CustodyClient {
 
     // --- Getters --- //
 
-    /// Get all hot wallets
+    /// Get all hot wallets on the chain managed by the CustodyClient
     pub async fn get_all_hot_wallets(&self) -> Result<Vec<HotWallet>, FundsManagerError> {
         let mut conn = self.get_db_conn().await?;
         let wallets = hot_wallets::table
+            .filter(hot_wallets::chain.eq(to_db_chain(self.chain)))
             .load::<HotWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))?;
@@ -143,6 +158,7 @@ impl CustodyClient {
         let mut conn = self.get_db_conn().await?;
         hot_wallets::table
             .filter(hot_wallets::address.eq(address))
+            .filter(hot_wallets::chain.eq(to_db_chain(self.chain)))
             .first::<HotWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))
@@ -156,6 +172,7 @@ impl CustodyClient {
         let mut conn = self.get_db_conn().await?;
         hot_wallets::table
             .filter(hot_wallets::vault.eq(vault))
+            .filter(hot_wallets::chain.eq(to_db_chain(self.chain)))
             .first::<HotWallet>(&mut conn)
             .await
             .map_err(err_str!(FundsManagerError::Db))
@@ -183,6 +200,7 @@ impl CustodyClient {
             vault.to_string(),
             address.to_string(),
             *internal_wallet_id,
+            self.chain,
         );
         diesel::insert_into(hot_wallets::table)
             .values(entry)

--- a/funds-manager/funds-manager-server/src/db/models.rs
+++ b/funds-manager/funds-manager-server/src/db/models.rs
@@ -7,11 +7,41 @@ use bigdecimal::BigDecimal;
 use diesel::prelude::*;
 use num_bigint::BigInt;
 use renegade_circuit_types::note::Note;
+use renegade_common::types::chain::Chain;
 use renegade_crypto::fields::scalar_to_bigint;
 use renegade_util::hex::{biguint_to_hex_addr, jubjub_to_hex_string};
 use uuid::Uuid;
 
-use crate::db::schema::fees;
+use crate::{cli::Environment, db::schema::fees};
+
+/// Convert a chain to its expected representation in the database,
+/// which is agnostic of the environment (testnet, mainnet)
+pub fn to_db_chain(chain: Chain) -> String {
+    match chain {
+        Chain::ArbitrumOne | Chain::ArbitrumSepolia => "arbitrum".to_string(),
+        Chain::BaseMainnet | Chain::BaseSepolia => "base".to_string(),
+        _ => chain.to_string(),
+    }
+}
+
+/// Convert a chain as specified in the database to the expected `Chain` enum,
+/// accounting for the environment (testnet, mainnet)
+pub fn from_db_chain(chain: &str, environment: Environment) -> Chain {
+    let arb_chain = match environment {
+        Environment::Mainnet => Chain::ArbitrumOne,
+        Environment::Testnet => Chain::ArbitrumSepolia,
+    };
+    let base_chain = match environment {
+        Environment::Mainnet => Chain::BaseMainnet,
+        Environment::Testnet => Chain::BaseSepolia,
+    };
+
+    match chain {
+        "arbitrum" => arb_chain,
+        "base" => base_chain,
+        _ => Chain::from_str(chain).unwrap(),
+    }
+}
 
 /// A fee that has been indexed by the indexer
 #[derive(Queryable, Selectable)]
@@ -26,6 +56,7 @@ pub struct Fee {
     pub blinder: BigDecimal,
     pub receiver: String,
     pub redeemed: bool,
+    pub chain: String,
 }
 
 /// A new fee inserted into the database
@@ -37,17 +68,20 @@ pub struct NewFee {
     pub amount: BigDecimal,
     pub blinder: BigDecimal,
     pub receiver: String,
+    pub chain: String,
 }
 
 impl NewFee {
     /// Construct a fee from a note
-    pub fn new_from_note(note: &Note, tx_hash: String) -> Self {
+    pub fn new_from_note(note: &Note, tx_hash: String, chain: Chain) -> Self {
         let mint = biguint_to_hex_addr(&note.mint);
         let amount = BigInt::from(note.amount).into();
         let blinder = scalar_to_bigint(&note.blinder).into();
         let receiver = jubjub_to_hex_string(&note.receiver);
 
-        NewFee { tx_hash, mint, amount, blinder, receiver }
+        let chain = to_db_chain(chain);
+
+        NewFee { tx_hash, mint, amount, blinder, receiver, chain }
     }
 }
 
@@ -59,6 +93,7 @@ impl NewFee {
 pub struct Metadata {
     pub key: String,
     pub value: String,
+    pub chain: String,
 }
 
 /// A metadata entry for a wallet managed by the indexer
@@ -70,12 +105,14 @@ pub struct RenegadeWalletMetadata {
     pub id: Uuid,
     pub mints: Vec<Option<String>>,
     pub secret_id: String,
+    pub chain: String,
 }
 
 impl RenegadeWalletMetadata {
     /// Construct a new wallet metadata entry
-    pub fn empty(id: Uuid, secret_id: String) -> Self {
-        RenegadeWalletMetadata { id, mints: vec![], secret_id }
+    pub fn empty(id: Uuid, secret_id: String, chain: Chain) -> Self {
+        let chain = to_db_chain(chain);
+        RenegadeWalletMetadata { id, mints: vec![], secret_id, chain }
     }
 }
 
@@ -89,6 +126,7 @@ pub struct HotWallet {
     pub vault: String,
     pub address: String,
     pub internal_wallet_id: Uuid,
+    pub chain: String,
 }
 
 impl HotWallet {
@@ -98,8 +136,10 @@ impl HotWallet {
         vault: String,
         address: String,
         internal_wallet_id: Uuid,
+        chain: Chain,
     ) -> Self {
-        HotWallet { id: Uuid::new_v4(), secret_id, vault, address, internal_wallet_id }
+        let chain = to_db_chain(chain);
+        HotWallet { id: Uuid::new_v4(), secret_id, vault, address, internal_wallet_id, chain }
     }
 }
 
@@ -163,13 +203,15 @@ pub struct GasWallet {
     pub peer_id: Option<String>,
     pub status: String,
     pub created_at: SystemTime,
+    pub chain: String,
 }
 
 impl GasWallet {
     /// Construct a new gas wallet
-    pub fn new(address: String) -> Self {
+    pub fn new(address: String, chain: Chain) -> Self {
         let id = Uuid::new_v4();
         let status = GasWalletStatus::Inactive.to_string();
-        GasWallet { id, address, peer_id: None, status, created_at: SystemTime::now() }
+        let chain = to_db_chain(chain);
+        GasWallet { id, address, peer_id: None, status, created_at: SystemTime::now(), chain }
     }
 }

--- a/funds-manager/funds-manager-server/src/db/schema.rs
+++ b/funds-manager/funds-manager-server/src/db/schema.rs
@@ -9,6 +9,7 @@ diesel::table! {
         blinder -> Numeric,
         receiver -> Text,
         redeemed -> Bool,
+        chain -> Text,
     }
 }
 
@@ -19,6 +20,7 @@ diesel::table! {
         peer_id -> Nullable<Text>,
         status -> Text,
         created_at -> Timestamp,
+        chain -> Text,
     }
 }
 
@@ -29,13 +31,15 @@ diesel::table! {
         vault -> Text,
         address -> Text,
         internal_wallet_id -> Uuid,
+        chain -> Text,
     }
 }
 
 diesel::table! {
-    indexing_metadata (key) {
+    indexing_metadata (key, chain) {
         key -> Text,
         value -> Text,
+        chain -> Text,
     }
 }
 
@@ -44,6 +48,7 @@ diesel::table! {
         id -> Uuid,
         mints -> Array<Nullable<Text>>,
         secret_id -> Text,
+        chain -> Text,
     }
 }
 

--- a/funds-manager/funds-manager-server/src/fee_indexer/index_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/index_fees.rs
@@ -98,7 +98,7 @@ impl Indexer {
         }
 
         // Otherwise, index the note
-        let fee = NewFee::new_from_note(&note, tx);
+        let fee = NewFee::new_from_note(&note, tx, self.chain);
         self.insert_fee(fee).await
     }
 

--- a/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
@@ -97,7 +97,7 @@ impl Indexer {
         let secret_name = self.store_wallet_secret(wallet_id, root_key).await?;
 
         // 3. Add an entry in the wallets table for the newly created wallet
-        let entry = RenegadeWalletMetadata::empty(wallet_id, secret_name);
+        let entry = RenegadeWalletMetadata::empty(wallet_id, secret_name, self.chain);
         self.insert_wallet(entry.clone()).await?;
 
         Ok(entry)

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -60,10 +60,10 @@ pub fn build_provider(url: &str) -> Result<DynProvider, FundsManagerError> {
 /// Get the prefix for a chain-specific secret
 pub fn get_secret_prefix(chain: Chain) -> Result<String, FundsManagerError> {
     match chain {
-        Chain::ArbitrumOne => Ok("/arbitrum/one/".to_string()),
-        Chain::ArbitrumSepolia => Ok("/arbitrum/sepolia/".to_string()),
-        Chain::BaseMainnet => Ok("/base/mainnet/".to_string()),
-        Chain::BaseSepolia => Ok("/base/mainnet/".to_string()),
+        Chain::ArbitrumOne => Ok("/arbitrum/one".to_string()),
+        Chain::ArbitrumSepolia => Ok("/arbitrum/sepolia".to_string()),
+        Chain::BaseMainnet => Ok("/base/mainnet".to_string()),
+        Chain::BaseSepolia => Ok("/base/mainnet".to_string()),
         _ => Err(FundsManagerError::custom("Unsupported chain")),
     }
 }

--- a/funds-manager/migrations/2025-05-15-010726_chain_columns/down.sql
+++ b/funds-manager/migrations/2025-05-15-010726_chain_columns/down.sql
@@ -1,0 +1,17 @@
+-- Remove the new `chain` column from all tables
+
+-- First revert the primary key changes
+ALTER TABLE "indexing_metadata" DROP CONSTRAINT IF EXISTS "indexing_metadata_pkey";
+ALTER TABLE "indexing_metadata" ADD PRIMARY KEY ("key");
+
+-- Then drop the chain columns
+ALTER TABLE "fees" DROP COLUMN "chain";
+
+ALTER TABLE "gas_wallets" DROP COLUMN "chain";
+
+ALTER TABLE "hot_wallets" DROP COLUMN "chain";
+
+ALTER TABLE "indexing_metadata" DROP COLUMN "chain";
+
+ALTER TABLE "renegade_wallets" DROP COLUMN "chain";
+

--- a/funds-manager/migrations/2025-05-15-010726_chain_columns/up.sql
+++ b/funds-manager/migrations/2025-05-15-010726_chain_columns/up.sql
@@ -1,0 +1,16 @@
+-- Add a `chain` column to all tables, defaulting to `arbitrum`
+-- (as we previously have only had the funds manager servicing our Arbitrum deployment)
+ALTER TABLE "fees" ADD COLUMN "chain" TEXT NOT NULL DEFAULT 'arbitrum';
+
+ALTER TABLE "gas_wallets" ADD COLUMN "chain" TEXT NOT NULL DEFAULT 'arbitrum';
+
+ALTER TABLE "hot_wallets" ADD COLUMN "chain" TEXT NOT NULL DEFAULT 'arbitrum';
+
+ALTER TABLE "indexing_metadata" ADD COLUMN "chain" TEXT NOT NULL DEFAULT 'arbitrum';
+
+-- Drop existing primary key first
+ALTER TABLE "indexing_metadata" DROP CONSTRAINT IF EXISTS "indexing_metadata_pkey";
+-- Add new composite primary key
+ALTER TABLE "indexing_metadata" ADD PRIMARY KEY ("key", "chain");
+
+ALTER TABLE "renegade_wallets" ADD COLUMN "chain" TEXT NOT NULL DEFAULT 'arbitrum';


### PR DESCRIPTION
This PR adds a `chain` column to all of the tables in the DB, backfilling all existing rows to set it to `arbitrum` and updating the queries appropriately.

Note that we use environment-agnostic chain names for this column, i.e. `arbitrum` and `base` as opposed to `arbitrum-sepolia`, `arbitrum-one`, `base-sepolia`, `base-mainnet`.

Since we already use separate DBs per environment, this captures all the necessary information, and makes the migration simpler (the same `up.sql` can be applied both to the testnet and mainnet DBs).

### Testing
- [x] Apply migration to testnet DB
- [x] Test getting hot wallet balances, fee indexing/redemption/withdrawal, and transfers to/from hot wallet using local admin panel