### PR TITLE
funds-manager-server: use chain-specific vault names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#0c97508e81a6c3896ec9cf4ebe096827139a4225"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#7bc8ca6b5ed053ea510ba5add04816ea6ce621fd"
 dependencies = [
  "alloy",
 ]
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2970,7 +2970,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "abi",
  "alloy",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "bus",
  "common",
@@ -9345,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10267,7 +10267,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -1,6 +1,9 @@
 //! API types for quoter management
 use alloy_primitives::{hex, Address, Bytes, U256};
-use renegade_common::types::token::{Token, USDC_TICKER};
+use renegade_common::types::{
+    chain::Chain,
+    token::{Token, USDC_TICKER},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{serialization::u256_string_serialization, u256_try_into_u128};
@@ -92,70 +95,85 @@ pub struct ExecutionQuote {
     pub gas_limit: U256,
 }
 
-impl ExecutionQuote {
+/// An execution quote, augmented with additional contextual data
+#[derive(Clone, Debug)]
+pub struct AugmentedExecutionQuote {
+    /// The quote
+    pub quote: ExecutionQuote,
+    /// The chain the quote is for
+    pub chain: Chain,
+}
+
+impl AugmentedExecutionQuote {
+    /// Create a new augmented execution quote
+    pub fn new(quote: ExecutionQuote, chain: Chain) -> Self {
+        Self { quote, chain }
+    }
+
     /// Convert the quote to a canonical string representation for HMAC signing
     pub fn to_canonical_string(&self) -> String {
         format!(
-            "{}{}{}{}{}{}{}{}{}{}{}",
-            self.buy_token_address,
-            self.sell_token_address,
-            self.sell_amount,
-            self.buy_amount,
-            self.from,
-            self.to,
-            hex::encode(&self.data),
-            self.value,
-            self.gas_price,
-            self.estimated_gas,
-            self.gas_limit
+            "{}{}{}{}{}{}{}{}{}{}{}{}",
+            self.quote.buy_token_address,
+            self.quote.sell_token_address,
+            self.quote.sell_amount,
+            self.quote.buy_amount,
+            self.quote.from,
+            self.quote.to,
+            hex::encode(&self.quote.data),
+            self.quote.value,
+            self.quote.gas_price,
+            self.quote.estimated_gas,
+            self.quote.gas_limit,
+            self.chain,
         )
     }
 
     /// Get the buy token address as a formatted string
     pub fn get_buy_token_address(&self) -> String {
-        format!("{:#x}", self.buy_token_address)
+        format!("{:#x}", self.quote.buy_token_address)
     }
 
     /// Get the sell token address as a formatted string
     pub fn get_sell_token_address(&self) -> String {
-        format!("{:#x}", self.sell_token_address)
+        format!("{:#x}", self.quote.sell_token_address)
     }
 
     /// Get the from address as a formatted string
     pub fn get_from_address(&self) -> String {
-        format!("{:#x}", self.from)
+        format!("{:#x}", self.quote.from)
     }
 
     /// Get the to address as a formatted string
     pub fn get_to_address(&self) -> String {
-        format!("{:#x}", self.to)
+        format!("{:#x}", self.quote.to)
     }
 
     /// Get the buy amount as a decimal-corrected string
     pub fn get_decimal_corrected_buy_amount(&self) -> Result<f64, String> {
-        let buy_amount = u256_try_into_u128(self.buy_amount)?;
+        let buy_amount = u256_try_into_u128(self.quote.buy_amount)?;
         Ok(self.get_buy_token().convert_to_decimal(buy_amount))
     }
 
     /// Get the sell amount as a decimal-corrected string
     pub fn get_decimal_corrected_sell_amount(&self) -> Result<f64, String> {
-        let sell_amount = u256_try_into_u128(self.sell_amount)?;
+        let sell_amount = u256_try_into_u128(self.quote.sell_amount)?;
         Ok(self.get_sell_token().convert_to_decimal(sell_amount))
     }
 
     /// Get the buy amount min as a decimal-corrected string
     pub fn get_decimal_corrected_buy_amount_min(&self) -> Result<f64, String> {
-        let buy_amount_min = u256_try_into_u128(self.buy_amount_min)?;
+        let buy_amount_min = u256_try_into_u128(self.quote.buy_amount_min)?;
         Ok(self.get_buy_token().convert_to_decimal(buy_amount_min))
     }
 }
 
-impl ExecutionQuote {
+impl AugmentedExecutionQuote {
     /// Get the price in units of USDC per base token.
     /// If a custom buy amount is provided, it is used in place of the standard
     /// buy amount.
     pub fn get_price(&self, buy_amount: Option<U256>) -> Result<f64, String> {
-        let buy_amount = u256_try_into_u128(buy_amount.unwrap_or(self.buy_amount))?;
+        let buy_amount = u256_try_into_u128(buy_amount.unwrap_or(self.quote.buy_amount))?;
         let decimal_buy_amount = self.get_buy_token().convert_to_decimal(buy_amount);
 
         let decimal_sell_amount = self.get_decimal_corrected_sell_amount()?;
@@ -179,18 +197,18 @@ impl ExecutionQuote {
 
     /// Return true if the sell token is USDC
     pub fn is_buy(&self) -> bool {
-        let usdc_mint = &Token::from_ticker(USDC_TICKER).get_alloy_address();
-        &self.sell_token_address == usdc_mint
+        let usdc_mint = &Token::from_ticker_on_chain(USDC_TICKER, self.chain).get_alloy_address();
+        &self.quote.sell_token_address == usdc_mint
     }
 
     /// Returns the token being bought
     pub fn get_buy_token(&self) -> Token {
-        Token::from_addr(&self.get_buy_token_address())
+        Token::from_addr_on_chain(&self.get_buy_token_address(), self.chain)
     }
 
     /// Returns the token being sold
     pub fn get_sell_token(&self) -> Token {
-        Token::from_addr(&self.get_sell_token_address())
+        Token::from_addr_on_chain(&self.get_sell_token_address(), self.chain)
     }
 
     /// Returns the volume in USDC

--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -196,7 +196,7 @@ impl ChainConfig {
         usdc_mint: &str,
     ) -> Result<ChainClients, FundsManagerError> {
         // Build a relayer client
-        let relayer_client = RelayerClient::new(&self.relayer_url, usdc_mint);
+        let relayer_client = RelayerClient::new(&self.relayer_url, usdc_mint, chain);
 
         // Build a darkpool client
         let private_key = PrivateKeySigner::random();

--- a/funds-manager/funds-manager-server/src/custody_client/deposit.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/deposit.rs
@@ -10,8 +10,8 @@ impl CustodyClient {
         &self,
         source: DepositWithdrawSource,
     ) -> Result<String, FundsManagerError> {
-        let vault_name = source.vault_name();
-        self.get_deposit_address_by_vault_name(vault_name).await
+        let vault_name = source.vault_name(self.chain);
+        self.get_deposit_address_by_vault_name(&vault_name).await
     }
 
     /// Get the deposit address given a vault name

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -170,8 +170,8 @@ impl CustodyClient {
         amount: f64,
     ) -> Result<TransactionReceipt, FundsManagerError> {
         // Get the gas hot wallet's private key
-        let source = DepositWithdrawSource::Gas.vault_name();
-        let gas_wallet = self.get_hot_wallet_by_vault(source).await?;
+        let source = DepositWithdrawSource::Gas.vault_name(self.chain);
+        let gas_wallet = self.get_hot_wallet_by_vault(&source).await?;
         let signer = self.get_hot_wallet_private_key(&gas_wallet.address).await?;
 
         // Check that the gas wallet has enough ETH to cover the refill

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -100,7 +100,7 @@ impl CustodyClient {
                 continue;
             }
 
-            let token = Token::from_ticker(ticker);
+            let token = Token::from_ticker_on_chain(ticker, self.chain);
 
             // Get the gas sponsor's balance of the token
             let bal = self.get_erc20_balance(&token.addr, &gas_sponsor_address).await?;

--- a/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
@@ -142,8 +142,8 @@ impl CustodyClient {
         wallets: Vec<(String, f64)>, // (address, fill amount)
     ) -> Result<(), FundsManagerError> {
         // Get the gas hot wallet's private key
-        let source = DepositWithdrawSource::Gas.vault_name();
-        let gas_wallet = self.get_hot_wallet_by_vault(source).await?;
+        let source = DepositWithdrawSource::Gas.vault_name(self.chain);
+        let gas_wallet = self.get_hot_wallet_by_vault(&source).await?;
         let signer = self.get_hot_wallet_private_key(&gas_wallet.address).await?;
 
         // Check that the gas wallet has enough ETH to cover the refill

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -114,7 +114,7 @@ impl CustodyClient {
         amount: f64,
     ) -> Result<(), FundsManagerError> {
         // Fetch the wallet info, then withdraw
-        let source = DepositWithdrawSource::from_vault_name(vault)?;
+        let source = DepositWithdrawSource::from_vault_name(vault, self.chain)?;
         self.withdraw_from_fireblocks(source, mint, amount).await
     }
 

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -59,7 +59,7 @@ impl CustodyClient {
         amount: f64,
     ) -> Result<(), FundsManagerError> {
         // Find the wallet for the given destination and check its balance
-        let wallet = self.get_hot_wallet_by_vault(source.vault_name()).await?;
+        let wallet = self.get_hot_wallet_by_vault(&source.vault_name(self.chain)).await?;
         let bal = self.get_erc20_balance(token_address, &wallet.address).await?;
         if bal < amount {
             return Err(FundsManagerError::Custom("Insufficient balance".to_string()));
@@ -85,12 +85,12 @@ impl CustodyClient {
         mint: &str,
         withdraw_amount: f64,
     ) -> Result<(), FundsManagerError> {
-        let vault_name = source.vault_name();
-        let hot_wallet = self.get_hot_wallet_by_vault(vault_name).await?;
+        let vault_name = source.vault_name(self.chain);
+        let hot_wallet = self.get_hot_wallet_by_vault(&vault_name).await?;
 
         // Get the vault account and asset to transfer from
         let vault = self
-            .get_vault_account(vault_name)
+            .get_vault_account(&vault_name)
             .await?
             .ok_or_else(|| FundsManagerError::Custom("Vault not found".to_string()))?;
         let asset_id = self.get_asset_id_for_address(mint).await?.ok_or_else(|| {
@@ -133,8 +133,8 @@ impl CustodyClient {
         to: &str,
     ) -> Result<(), FundsManagerError> {
         // Check the gas wallet's balance
-        let gas_vault_name = DepositWithdrawSource::Gas.vault_name();
-        let gas_wallet = self.get_hot_wallet_by_vault(gas_vault_name).await?;
+        let gas_vault_name = DepositWithdrawSource::Gas.vault_name(self.chain);
+        let gas_wallet = self.get_hot_wallet_by_vault(&gas_vault_name).await?;
         let bal = self.get_ether_balance(&gas_wallet.address).await?;
         if bal < amount {
             return Err(FundsManagerError::custom("Insufficient balance"));

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -164,7 +164,7 @@ impl CustodyClient {
         let hot_wallet = self.get_quoter_hot_wallet().await?;
 
         let usdc_mint = match self.chain {
-            Chain::ArbitrumOne => &Token::from_ticker(USDC_TICKER).addr,
+            Chain::ArbitrumOne => &Token::from_ticker_on_chain(USDC_TICKER, self.chain).addr,
             Chain::ArbitrumSepolia => TESTNET_HYPERLIQUID_USDC_ADDRESS,
             _ => return Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
         };

--- a/funds-manager/funds-manager-server/src/relayer_client.rs
+++ b/funds-manager/funds-manager-server/src/relayer_client.rs
@@ -19,6 +19,7 @@ use renegade_api::{
     types::ApiKeychain,
 };
 use renegade_common::types::{
+    chain::Chain,
     exchange::PriceReporterState,
     hmac::HmacKey,
     token::Token,
@@ -50,12 +51,14 @@ pub struct RelayerClient {
     base_url: String,
     /// The mind of the USDC token
     usdc_mint: String,
+    /// The chain the relayer is targeting
+    pub chain: Chain,
 }
 
 impl RelayerClient {
     /// Create a new relayer client
-    pub fn new(base_url: &str, usdc_mint: &str) -> Self {
-        Self { base_url: base_url.to_string(), usdc_mint: usdc_mint.to_string() }
+    pub fn new(base_url: &str, usdc_mint: &str, chain: Chain) -> Self {
+        Self { base_url: base_url.to_string(), usdc_mint: usdc_mint.to_string(), chain }
     }
 
     /// Get the price for a given mint
@@ -65,8 +68,8 @@ impl RelayerClient {
         }
 
         let body = GetPriceReportRequest {
-            base_token: Token::from_addr(mint),
-            quote_token: Token::from_addr(&self.usdc_mint),
+            base_token: Token::from_addr_on_chain(mint, self.chain),
+            quote_token: Token::from_addr_on_chain(&self.usdc_mint, self.chain),
         };
         let response: GetPriceReportResponse = self.post_relayer(PRICE_REPORT_ROUTE, &body).await?;
 

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -4,8 +4,12 @@
 use std::{collections::HashMap, error::Error, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region};
-use funds_manager_api::quoters::ExecutionQuote;
-use renegade_common::types::{chain::Chain, hmac::HmacKey, token::Token};
+use funds_manager_api::quoters::AugmentedExecutionQuote;
+use renegade_common::types::{
+    chain::Chain,
+    hmac::HmacKey,
+    token::{Token, USDC_TICKER},
+};
 use renegade_config::setup_token_remaps;
 
 use crate::{
@@ -66,10 +70,9 @@ impl Server {
         let db_pool = create_db_pool(&args.db_url).await?;
         let arc_pool = Arc::new(db_pool);
 
-        let usdc_mint = Token::usdc().get_addr();
-
         let mut chain_clients = HashMap::new();
         for (chain, config) in chain_configs {
+            let usdc_mint = Token::from_ticker_on_chain(USDC_TICKER, chain).get_addr();
             let clients = config
                 .build_clients(
                     chain,
@@ -89,7 +92,7 @@ impl Server {
 
     /// Sign a quote using the quote HMAC key and returns the signature as a
     /// hex string
-    pub fn sign_quote(&self, quote: &ExecutionQuote) -> Result<String, FundsManagerError> {
+    pub fn sign_quote(&self, quote: &AugmentedExecutionQuote) -> Result<String, FundsManagerError> {
         let canonical_string = quote.to_canonical_string();
         let sig = self.quote_hmac_key.compute_mac(canonical_string.as_bytes());
         let signature = hex::encode(sig);

--- a/funds-manager/migrations/2025-05-15-174324_per_chain_vaults/down.sql
+++ b/funds-manager/migrations/2025-05-15-174324_per_chain_vaults/down.sql
@@ -1,0 +1,5 @@
+-- Remove the "Arbitrum " prefix from the hot_wallets vault column
+
+UPDATE hot_wallets
+SET vault = SUBSTRING(vault FROM 10)
+WHERE vault LIKE 'Arbitrum %' AND vault != 'Arbitrum Gas';

--- a/funds-manager/migrations/2025-05-15-174324_per_chain_vaults/up.sql
+++ b/funds-manager/migrations/2025-05-15-174324_per_chain_vaults/up.sql
@@ -1,0 +1,7 @@
+-- Migrate the hot_wallets table to use chain-specific vault names.
+-- Currently, all vaults in the table are Arbitrum vaults,
+-- and the Arbitrum Gas vault is already correctly named.
+
+UPDATE hot_wallets
+SET vault = 'Arbitrum ' || vault
+WHERE vault != 'Arbitrum Gas';


### PR DESCRIPTION
This PR updates the funds manager to expect & use chain-specific vault names. Accordingly, I have created a database migration that renames the `vault` column values in the `hot_wallets` table to include the "Arbitrum " prefix (as currently all vaults are Arbitrum vaults).

I have also updated the names of the vaults in our testnet Fireblocks workspace.

### Testing
- [x] Test getting deposit address, indexing / redeeming / withdrawing fees, transferring to custody in local admin panel