### PR TITLE
funds-manager-server: use chain-aware token methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#0c97508e81a6c3896ec9cf4ebe096827139a4225"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#7bc8ca6b5ed053ea510ba5add04816ea6ce621fd"
 dependencies = [
  "alloy",
 ]
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2970,7 +2970,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "abi",
  "alloy",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "bus",
  "common",
@@ -9345,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10267,7 +10267,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#7a8f9d8ff446ba85a5e2c9445d46ea8e057ec93d"
+source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -95,26 +95,6 @@ pub struct ExecutionQuote {
     pub gas_limit: U256,
 }
 
-impl ExecutionQuote {
-    /// Convert the quote to a canonical string representation for HMAC signing
-    pub fn to_canonical_string(&self) -> String {
-        format!(
-            "{}{}{}{}{}{}{}{}{}{}{}",
-            self.buy_token_address,
-            self.sell_token_address,
-            self.sell_amount,
-            self.buy_amount,
-            self.from,
-            self.to,
-            hex::encode(&self.data),
-            self.value,
-            self.gas_price,
-            self.estimated_gas,
-            self.gas_limit
-        )
-    }
-}
-
 /// An execution quote, augmented with additional contextual data
 #[derive(Clone, Debug)]
 pub struct AugmentedExecutionQuote {
@@ -128,6 +108,25 @@ impl AugmentedExecutionQuote {
     /// Create a new augmented execution quote
     pub fn new(quote: ExecutionQuote, chain: Chain) -> Self {
         Self { quote, chain }
+    }
+
+    /// Convert the quote to a canonical string representation for HMAC signing
+    pub fn to_canonical_string(&self) -> String {
+        format!(
+            "{}{}{}{}{}{}{}{}{}{}{}{}",
+            self.quote.buy_token_address,
+            self.quote.sell_token_address,
+            self.quote.sell_amount,
+            self.quote.buy_amount,
+            self.quote.from,
+            self.quote.to,
+            hex::encode(&self.quote.data),
+            self.quote.value,
+            self.quote.gas_price,
+            self.quote.estimated_gas,
+            self.quote.gas_limit,
+            self.chain,
+        )
     }
 
     /// Get the buy token address as a formatted string

--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -196,7 +196,7 @@ impl ChainConfig {
         usdc_mint: &str,
     ) -> Result<ChainClients, FundsManagerError> {
         // Build a relayer client
-        let relayer_client = RelayerClient::new(&self.relayer_url, usdc_mint);
+        let relayer_client = RelayerClient::new(&self.relayer_url, usdc_mint, chain);
 
         // Build a darkpool client
         let private_key = PrivateKeySigner::random();

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -100,7 +100,7 @@ impl CustodyClient {
                 continue;
             }
 
-            let token = Token::from_ticker(ticker);
+            let token = Token::from_ticker_on_chain(ticker, self.chain);
 
             // Get the gas sponsor's balance of the token
             let bal = self.get_erc20_balance(&token.addr, &gas_sponsor_address).await?;

--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -164,7 +164,7 @@ impl CustodyClient {
         let hot_wallet = self.get_quoter_hot_wallet().await?;
 
         let usdc_mint = match self.chain {
-            Chain::ArbitrumOne => &Token::from_ticker(USDC_TICKER).addr,
+            Chain::ArbitrumOne => &Token::from_ticker_on_chain(USDC_TICKER, self.chain).addr,
             Chain::ArbitrumSepolia => TESTNET_HYPERLIQUID_USDC_ADDRESS,
             _ => return Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
         };

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -175,9 +175,11 @@ pub(crate) async fn get_execution_quote_handler(
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
-    let signature = server.sign_quote(&quote)?;
+    let augmented_quote = AugmentedExecutionQuote::new(quote, chain);
 
-    let resp = GetExecutionQuoteResponse { quote, signature };
+    let signature = server.sign_quote(&augmented_quote)?;
+
+    let resp = GetExecutionQuoteResponse { quote: augmented_quote.quote, signature };
     Ok(warp::reply::json(&resp))
 }
 
@@ -196,12 +198,13 @@ pub(crate) async fn execute_swap_handler(
     let provided = hex::decode(&req.signature)
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
-    if !hmac_key.verify_mac(req.quote.to_canonical_string().as_bytes(), &provided) {
+    let augmented_quote = AugmentedExecutionQuote::new(req.quote.clone(), chain);
+
+    if !hmac_key.verify_mac(augmented_quote.to_canonical_string().as_bytes(), &provided) {
         return Err(warp::reject::custom(ApiError::Unauthenticated(
             "Invalid quote signature".to_string(),
         )));
     }
-    let augmented_quote = AugmentedExecutionQuote::new(req.quote.clone(), chain);
 
     let hot_wallet = custody_client.get_quoter_hot_wallet().await?;
     let wallet = custody_client.get_hot_wallet_private_key(&hot_wallet.address).await?;

--- a/funds-manager/funds-manager-server/src/relayer_client.rs
+++ b/funds-manager/funds-manager-server/src/relayer_client.rs
@@ -19,6 +19,7 @@ use renegade_api::{
     types::ApiKeychain,
 };
 use renegade_common::types::{
+    chain::Chain,
     exchange::PriceReporterState,
     hmac::HmacKey,
     token::Token,
@@ -50,12 +51,14 @@ pub struct RelayerClient {
     base_url: String,
     /// The mind of the USDC token
     usdc_mint: String,
+    /// The chain the relayer is targeting
+    pub chain: Chain,
 }
 
 impl RelayerClient {
     /// Create a new relayer client
-    pub fn new(base_url: &str, usdc_mint: &str) -> Self {
-        Self { base_url: base_url.to_string(), usdc_mint: usdc_mint.to_string() }
+    pub fn new(base_url: &str, usdc_mint: &str, chain: Chain) -> Self {
+        Self { base_url: base_url.to_string(), usdc_mint: usdc_mint.to_string(), chain }
     }
 
     /// Get the price for a given mint
@@ -65,8 +68,8 @@ impl RelayerClient {
         }
 
         let body = GetPriceReportRequest {
-            base_token: Token::from_addr(mint),
-            quote_token: Token::from_addr(&self.usdc_mint),
+            base_token: Token::from_addr_on_chain(mint, self.chain),
+            quote_token: Token::from_addr_on_chain(&self.usdc_mint, self.chain),
         };
         let response: GetPriceReportResponse = self.post_relayer(PRICE_REPORT_ROUTE, &body).await?;
 

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashMap, error::Error, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region};
-use funds_manager_api::quoters::ExecutionQuote;
+use funds_manager_api::quoters::AugmentedExecutionQuote;
 use renegade_common::types::{
     chain::Chain,
     hmac::HmacKey,
@@ -92,7 +92,7 @@ impl Server {
 
     /// Sign a quote using the quote HMAC key and returns the signature as a
     /// hex string
-    pub fn sign_quote(&self, quote: &ExecutionQuote) -> Result<String, FundsManagerError> {
+    pub fn sign_quote(&self, quote: &AugmentedExecutionQuote) -> Result<String, FundsManagerError> {
         let canonical_string = quote.to_canonical_string();
         let sig = self.quote_hmac_key.compute_mac(canonical_string.as_bytes());
         let signature = hex::encode(sig);

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -5,7 +5,11 @@ use std::{collections::HashMap, error::Error, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region};
 use funds_manager_api::quoters::ExecutionQuote;
-use renegade_common::types::{chain::Chain, hmac::HmacKey, token::Token};
+use renegade_common::types::{
+    chain::Chain,
+    hmac::HmacKey,
+    token::{Token, USDC_TICKER},
+};
 use renegade_config::setup_token_remaps;
 
 use crate::{
@@ -66,10 +70,9 @@ impl Server {
         let db_pool = create_db_pool(&args.db_url).await?;
         let arc_pool = Arc::new(db_pool);
 
-        let usdc_mint = Token::usdc().get_addr();
-
         let mut chain_clients = HashMap::new();
         for (chain, config) in chain_configs {
+            let usdc_mint = Token::from_ticker_on_chain(USDC_TICKER, chain).get_addr();
             let clients = config
                 .build_clients(
                     chain,


### PR DESCRIPTION
This PR ensures that we invoke chain-specific static methods on the `Token` struct, now that the funds manager is initializing multiple token remaps.

Unfortunately, all of these code paths are only hit on a mainnet deployment: either because they are part of the execution quote generation / settlement API, or in the case of withdrawals to hyperliquid, we only construct the USDC token on mainnet (HL has its own testnet USDC that we hardcode in the testnet case).

As such, testing will be deferred until a mainnet deployment is out. Still, I have confirmed that a testnet funds manager can run when configured with both arbitrum-sepolia and base-sepolia configs.