### PR TITLE
price-reporter: fix multi-chain stream init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2970,7 +2970,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3279,7 +3279,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "abi",
  "alloy",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5562,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "bus",
  "common",
@@ -9346,7 +9346,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10268,7 +10268,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#629b2a1830f9436692dc9cff34ff490d00372795"
+source = "git+https://github.com/renegade-fi/renegade.git#1c02a985bcce5f8feb8a8dbfd066f73e8254cd90"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/price-reporter/src/utils.rs
+++ b/price-reporter/src/utils.rs
@@ -1,6 +1,5 @@
 //! Miscellaneous utility types and helper functions.
 
-use std::collections::HashSet;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{collections::HashMap, env, str::FromStr, sync::Arc};
@@ -13,7 +12,7 @@ use renegade_common::types::{
     chain::Chain,
     exchange::Exchange,
     hmac::HmacKey,
-    token::{get_all_tokens, read_token_remaps, Token},
+    token::{read_token_remaps, Token},
     Price,
 };
 use renegade_config::setup_token_remaps;
@@ -281,24 +280,14 @@ pub fn get_subscribed_topics(subscriptions: &PriceStreamMap) -> Vec<String> {
     subscriptions.keys().map(get_price_topic_str).collect_vec()
 }
 
-/// Get all distinct tickers from configured token remap(s)
-pub fn get_all_distinct_tickers() -> Vec<String> {
-    let mut tickers = HashSet::new();
-    get_all_tokens().into_iter().for_each(|t| {
-        if let Some(ticker) = t.get_ticker() {
-            tickers.insert(ticker);
-        }
-    });
-
-    tickers.into_iter().collect_vec()
-}
-
 /// Given an address, search through the token remaps to find the token and
 /// chain it belongs to
 pub fn get_token_and_chain(addr: &str) -> Option<(Token, Chain)> {
-    for (chain, token_map) in read_token_remaps().iter() {
-        if token_map.get_by_left(addr).is_some() {
-            return Some((Token::from_addr_on_chain(addr, *chain), *chain));
+    let addr = addr.to_lowercase();
+    let remaps = read_token_remaps();
+    for (chain, token_map) in remaps.iter() {
+        if token_map.get_by_left(&addr).is_some() {
+            return Some((Token::from_addr_on_chain(&addr, *chain), *chain));
         }
     }
     None


### PR DESCRIPTION
### Purpose
This PR fixes bugs found while testing loading multiple token remaps:
- cannot rely on `default_chain()` since there are multiple
- improper usage of `derivative` crate leading to duplicate price streams 
- couldn't find tokens because we weren't lowecasing

### Testing
- [x] Tested loading arbitrum-sepolia, base-sepolia and fetching prices using WETH address on both
- [x] Test in testnet using script to make sure we get prices for all tokens (arbitrum + base)