### PR TITLE
funds-manager-server: use price reporter client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,6 +4457,7 @@ dependencies = [
  "native-tls",
  "num-bigint",
  "postgres-native-tls",
+ "price-reporter-client",
  "rand 0.8.5",
  "renegade-crypto",
  "reqwest 0.11.27",

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -13,6 +13,7 @@ use futures_util::StreamExt;
 use price_reporter_client::PriceReporterClient;
 use renegade_api::http::external_match::ApiExternalMatchResult;
 use renegade_circuit_types::wallet::Nullifier;
+use renegade_common::types::chain::Chain;
 use renegade_darkpool_client::{
     arbitrum::abi::Darkpool::NullifierSpent, conversion::u256_to_scalar, DarkpoolClient,
 };
@@ -79,6 +80,8 @@ pub struct OnChainEventListenerExecutor {
     config: OnChainEventListenerConfig,
     /// The bundle store to use for retrieving bundle contexts
     bundle_store: BundleStore,
+    /// The chain for which the executor is configured
+    pub(crate) chain: Chain,
     /// The rate limiter
     pub(crate) rate_limiter: AuthServerRateLimiter,
     /// The price reporter client with WebSocket streaming support
@@ -95,8 +98,9 @@ impl OnChainEventListenerExecutor {
         rate_limiter: AuthServerRateLimiter,
         price_reporter_client: Arc<PriceReporterClient>,
         gas_cost_sampler: Arc<GasCostSampler>,
+        chain: Chain,
     ) -> Self {
-        Self { config, bundle_store, rate_limiter, price_reporter_client, gas_cost_sampler }
+        Self { config, bundle_store, rate_limiter, price_reporter_client, gas_cost_sampler, chain }
     }
 
     /// Shorthand for fetching a reference to the darkpool client

--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -78,8 +78,10 @@ impl OnChainEventListenerExecutor {
                 OrderSide::Sell => Token::from_addr(&match_result.quote_mint),
             }
         };
-        let nominal_price =
-            self.price_reporter_client.get_nominal_price(&refund_asset.get_addr()).await?;
+        let nominal_price = self
+            .price_reporter_client
+            .get_nominal_price(&refund_asset.get_addr(), self.chain)
+            .await?;
 
         let nominal_amount = BigDecimal::from_u128(gas_sponsorship_info.refund_amount)
             .expect("u128 should be representable as BigDecimal");

--- a/auth/auth-server/src/chain_events/worker.rs
+++ b/auth/auth-server/src/chain_events/worker.rs
@@ -1,5 +1,6 @@
 //! The worker implementation for the on-chain event listener
 use price_reporter_client::PriceReporterClient;
+use renegade_common::types::chain::Chain;
 use std::{sync::Arc, thread::Builder};
 use tokio::runtime::Builder as RuntimeBuilder;
 use tracing::error;
@@ -24,6 +25,7 @@ impl OnChainEventListener {
         rate_limiter: AuthServerRateLimiter,
         price_reporter_client: Arc<PriceReporterClient>,
         gas_cost_sampler: Arc<GasCostSampler>,
+        chain: Chain,
     ) -> Result<Self, OnChainEventListenerError> {
         let executor = OnChainEventListenerExecutor::new(
             config,
@@ -31,6 +33,7 @@ impl OnChainEventListener {
             rate_limiter,
             price_reporter_client,
             gas_cost_sampler,
+            chain,
         );
         Ok(Self { executor: Some(executor), executor_handle: None })
     }

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/mod.rs
@@ -213,7 +213,7 @@ impl Server {
         let base_token = Token::from_addr(&base_mint);
         let base_amount_f64 = base_token.convert_to_decimal(base_amount);
 
-        let expected_price = self.price_reporter_client.get_price(&base_mint).await?;
+        let expected_price = self.price_reporter_client.get_price(&base_mint, self.chain).await?;
         Ok(expected_price * base_amount_f64)
     }
 }

--- a/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/handle_external_match/gas_sponsorship/refund_calculation.rs
@@ -79,7 +79,8 @@ impl Server {
         let eth_price = BigDecimal::from_f64(eth_price_f64)
             .ok_or(AuthServerError::gas_sponsorship(ERR_PRICE_BIGDECIMAL_CONVERSION))?;
 
-        let buy_token_price = self.price_reporter_client.get_nominal_price(&buy_mint).await?;
+        let buy_token_price =
+            self.price_reporter_client.get_nominal_price(&buy_mint, self.chain).await?;
 
         let conversion_rate = eth_price / buy_token_price;
 

--- a/auth/auth-server/src/server/handle_external_match/mod.rs
+++ b/auth/auth-server/src/server/handle_external_match/mod.rs
@@ -539,7 +539,11 @@ impl Server {
             record_quote_not_found(key.clone(), &base_mint);
 
             // Record a zero fill ratio
-            let price_f64 = self_clone.price_reporter_client.get_price(&base_mint).await.unwrap();
+            let price_f64 = self_clone
+                .price_reporter_client
+                .get_price(&base_mint, self_clone.chain)
+                .await
+                .unwrap();
             let price = FixedPoint::from_f64_round_down(price_f64);
             let relayer_fee = FixedPoint::zero();
             let quote_amt = order.get_quote_amount(price, relayer_fee);

--- a/auth/auth-server/src/server/mod.rs
+++ b/auth/auth-server/src/server/mod.rs
@@ -45,6 +45,7 @@ use rand::Rng;
 use rate_limiter::AuthServerRateLimiter;
 use redis::aio::ConnectionManager;
 use renegade_api::auth::add_expiring_auth_to_headers;
+use renegade_common::types::chain::Chain;
 use renegade_common::types::{
     hmac::HmacKey,
     token::{get_all_tokens, Token},
@@ -78,6 +79,8 @@ pub type ApiKeyCache = Arc<RwLock<UnboundCache<Uuid, ApiKey>>>;
 /// The server struct that holds all the necessary components
 #[derive(Clone)]
 pub struct Server {
+    /// The chain for which the server is configured
+    pub chain: Chain,
     /// The database connection pool
     pub db_pool: Arc<DbPool>,
     /// The Redis client
@@ -184,12 +187,14 @@ impl Server {
             rate_limiter.clone(),
             price_reporter_client.clone(),
             gas_cost_sampler.clone(),
+            args.chain_id,
         )
         .expect("failed to build on-chain event listener");
         chain_listener.start().expect("failed to start on-chain event listener");
         chain_listener.watch();
 
         Ok(Self {
+            chain: args.chain_id,
             db_pool,
             redis_client,
             relayer_url: args.relayer_url,

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -40,6 +40,7 @@ alloy = { workspace = true }
 ethers = "2"
 
 # === Renegade Dependencies === #
+price-reporter-client = { path = "../../price-reporter-client" }
 renegade-darkpool-client = { package = "darkpool-client", workspace = true, features = [ "all-chains" ] }
 renegade-api = { package = "external-api", workspace = true }
 renegade-common = { package = "common", workspace = true }

--- a/funds-manager/funds-manager-server/src/error.rs
+++ b/funds-manager/funds-manager-server/src/error.rs
@@ -2,6 +2,7 @@
 
 use std::{error::Error, fmt::Display};
 
+use price_reporter_client::error::PriceReporterClientError;
 use warp::reject::Reject;
 
 use fireblocks_sdk::{apis::Error as FireblocksApiError, FireblocksError};
@@ -25,6 +26,8 @@ pub enum FundsManagerError {
     S3(String),
     /// An error with a JSON-RPC request
     JsonRpc(String),
+    /// An error with the price reporter
+    PriceReporter(PriceReporterClientError),
     /// A miscellaneous error
     Custom(String),
 }
@@ -89,6 +92,7 @@ impl Display for FundsManagerError {
             FundsManagerError::JsonRpc(e) => write!(f, "JSON-RPC error: {}", e),
             FundsManagerError::Custom(e) => write!(f, "Uncategorized error: {}", e),
             FundsManagerError::Fireblocks(e) => write!(f, "Fireblocks error: {}", e),
+            FundsManagerError::PriceReporter(e) => write!(f, "Price reporter error: {}", e),
         }
     }
 }
@@ -104,6 +108,12 @@ impl<T> From<FireblocksApiError<T>> for FundsManagerError {
 impl From<FireblocksError> for FundsManagerError {
     fn from(error: FireblocksError) -> Self {
         FundsManagerError::Fireblocks(error.to_string())
+    }
+}
+
+impl From<PriceReporterClientError> for FundsManagerError {
+    fn from(error: PriceReporterClientError) -> Self {
+        FundsManagerError::PriceReporter(error)
     }
 }
 

--- a/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/mod.rs
@@ -1,6 +1,7 @@
 //! The indexer handles the indexing and redemption of fee notes
 
 use aws_config::SdkConfig as AwsConfig;
+use price_reporter_client::PriceReporterClient;
 use renegade_circuit_types::elgamal::DecryptionKey;
 use renegade_common::types::chain::Chain;
 use renegade_util::err_str;
@@ -25,6 +26,8 @@ pub(crate) struct Indexer {
     pub chain_id: u64,
     /// The chain this indexer targets
     pub chain: Chain,
+    /// The price reporter client
+    pub price_reporter: Arc<PriceReporterClient>,
     /// A client for interacting with the relayer
     pub relayer_client: RelayerClient,
     /// The darkpool client
@@ -51,6 +54,7 @@ impl Indexer {
         db_pool: Arc<DbPool>,
         relayer_client: RelayerClient,
         custody_client: CustodyClient,
+        price_reporter: Arc<PriceReporterClient>,
     ) -> Self {
         Indexer {
             chain_id,
@@ -61,6 +65,7 @@ impl Indexer {
             relayer_client,
             aws_config,
             custody_client,
+            price_reporter,
         }
     }
 

--- a/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
@@ -35,11 +35,14 @@ impl Indexer {
         // fees first
         let mut prices = HashMap::new();
         for mint in mints.into_iter() {
-            let maybe_price = self.relayer_client.get_binance_price(&mint).await?;
-            if let Some(price) = maybe_price {
-                prices.insert(mint, price);
-            } else {
-                warn!("{}: no price", mint);
+            let maybe_price = self.price_reporter.get_price(&mint, self.chain).await;
+            match maybe_price {
+                Ok(price) => {
+                    prices.insert(mint, price);
+                },
+                Err(e) => {
+                    warn!("{}: error getting price: {e}", mint);
+                },
             }
         }
 

--- a/funds-manager/funds-manager-server/src/metrics/mod.rs
+++ b/funds-manager/funds-manager-server/src/metrics/mod.rs
@@ -1,8 +1,11 @@
 //! General metrics recording functionality
 
-use alloy::providers::DynProvider;
+use std::sync::Arc;
 
-use crate::{helpers::build_provider, relayer_client::RelayerClient};
+use alloy::providers::DynProvider;
+use price_reporter_client::PriceReporterClient;
+
+use crate::helpers::build_provider;
 
 pub mod cost;
 pub mod labels;
@@ -11,17 +14,17 @@ pub mod labels;
 /// metrics.
 #[derive(Clone)]
 pub struct MetricsRecorder {
-    /// Client for interacting with the relayer
-    pub relayer_client: RelayerClient,
+    /// Client for interacting with the price reporter
+    pub price_reporter: Arc<PriceReporterClient>,
     /// Ethereum provider for querying chain events
     pub provider: DynProvider,
 }
 
 impl MetricsRecorder {
     /// Create a new metrics recorder
-    pub fn new(relayer_client: RelayerClient, rpc_url: &str) -> Self {
+    pub fn new(price_reporter: Arc<PriceReporterClient>, rpc_url: &str) -> Self {
         let provider = build_provider(rpc_url).expect("invalid RPC URL");
 
-        MetricsRecorder { relayer_client, provider }
+        MetricsRecorder { price_reporter, provider }
     }
 }

--- a/price-reporter-client/src/error.rs
+++ b/price-reporter-client/src/error.rs
@@ -3,7 +3,7 @@
 use thiserror::Error;
 
 /// Error type for price reporter operations
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Clone)]
 pub enum PriceReporterClientError {
     /// Setup error
     #[error("Setup error: {0}")]


### PR DESCRIPTION
This PR updates the funds manager to use the price reporter client instead of querying the relayer for prices.

### Testing
- [x] Run the funds manager, confirm that prices are streamed successfully, redeem fees to test getting a price from the client