### PR TITLE
price-reporter: fix renegade topic handling

### DIFF
--- a/price-reporter/src/ws_server.rs
+++ b/price-reporter/src/ws_server.rs
@@ -230,7 +230,9 @@ impl GlobalPriceStreams {
     ) -> Result<PriceStream, ServerError> {
         // Replace the `Renegade` exchange with `Binance`
         if pair_info.exchange == Exchange::Renegade {
-            pair_info.exchange = Exchange::Binance;
+            let exchange = Exchange::Binance;
+            let base_mint = pair_info.base_token().get_addr();
+            pair_info = PairInfo::new_default_stable(exchange, &base_mint);
         }
 
         let exchange = pair_info.exchange;


### PR DESCRIPTION
### Purpose
This PR fixes prices requested using the `renegade` exchange.

Previously, we were replacing the exchange but not the quote ticker before establishing a connection. This meant we were establishing connections for "binance-BASE-USDC" instead of "binance-BASE-USDT" and returning prices for those tokens with a BASE / USDC market on Binance (11/17 of our tokens). The prices would be wrong since the conversion would technically not be necessary (they're already in units of USDC / BASE).

### Testing
- [x] Tested locally that all tokens can be fetched using "renegade-BASE" topic
- [ ] Test in testnet