### PR TITLE
price-reporter: fix requires_quote_conversion

### DIFF
--- a/price-reporter/src/utils.rs
+++ b/price-reporter/src/utils.rs
@@ -141,8 +141,9 @@ impl Stream for PriceStream {
         };
 
         // Divide main price by conversion price
-        // Practically this will be [USDT / BASE] * [USDC / USDT] = USDC / BASE
-        let converted_price = main_price * conversion_price;
+        // Practically this will be [USDT / BASE] / [USDT / USDC] = USDC / BASE
+        let converted_price =
+            if conversion_price == 0.0 { 0.0 } else { main_price / conversion_price };
         Poll::Ready(Some(converted_price))
     }
 }

--- a/price-reporter/src/ws_server.rs
+++ b/price-reporter/src/ws_server.rs
@@ -228,6 +228,7 @@ impl GlobalPriceStreams {
         mut pair_info: PairInfo,
         config: ExchangeConnectionsConfig,
     ) -> Result<PriceStream, ServerError> {
+        let requires_quote_conversion = requires_quote_conversion(&pair_info.exchange);
         // Replace the `Renegade` exchange with `Binance`
         if pair_info.exchange == Exchange::Renegade {
             let exchange = Exchange::Binance;
@@ -237,7 +238,7 @@ impl GlobalPriceStreams {
 
         let exchange = pair_info.exchange;
         let price_rx = self.get_or_create_price_receiver(pair_info, config.clone()).await?;
-        let stream = if requires_quote_conversion(&exchange) {
+        let stream = if requires_quote_conversion {
             let conversion_rx = self.quote_conversion_stream(exchange, config).await?;
             PriceStream::new_with_conversion(price_rx.into(), conversion_rx.into())
         } else {


### PR DESCRIPTION
### Purpose
This PR ensures we properly check if a price stream required quote conversion.

Previously, we were checking after mutating the exchange to be Binance, causing `requires_quote_conversion` to always return `false` since `Binance !== Renegade`.

We also fix the actual quote conversion: we receive USDT / USDC from Binance, meaning we should divide the main price by this conversion price to get USDC / BASE.

### Testing
- [x] Tested locally
- [ ] Test in testnet