### PR TITLE
price-reporter: read canonical exchange from file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2616,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2647,7 +2647,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2835,7 +2835,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2971,7 +2971,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3280,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "abi",
  "alloy",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5563,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7182,7 +7182,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7823,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7873,7 +7873,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9353,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "bus",
  "common",
@@ -9365,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10287,7 +10287,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#eb2ef7c87a4e1477675c86a6418b02526873586f"
+source = "git+https://github.com/renegade-fi/renegade.git?branch=sehyun/canonical-exchange#2684931a61103ca3947a8d4d5d9dc6c7233fcae7"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/price-reporter/src/utils/mod.rs
+++ b/price-reporter/src/utils/mod.rs
@@ -306,11 +306,12 @@ pub fn setup_all_token_remaps(
         )),
         // If a token remap path is provided, use it
         Some(path) => {
+            set_canonical_exchange_map(Some(path.clone()), chains[0])?;
             setup_token_remaps(Some(path), chains[0]).map_err(err_str!(ServerError::TokenRemap))
         },
         // Otherwise, fetch remap from default location
         None => chains.iter().try_for_each(|chain| {
-            set_canonical_exchange_map(*chain);
+            set_canonical_exchange_map(None /* remap file */, *chain)?;
             setup_token_remaps(None, *chain).map_err(err_str!(ServerError::TokenRemap))
         }),
     }


### PR DESCRIPTION
### Purpose
This PR adds the ability to read canonical exchanges from token remaps provided using a file path.

### Testing
- [x] Tested locally that specifying file path to remap works, canonical exchange is properly read
- [ ] Test in testnet