### PR TITLE
price-reporter: allow same token on multiple remaps to be found

### DIFF
--- a/price-reporter/src/main.rs
+++ b/price-reporter/src/main.rs
@@ -140,7 +140,7 @@ fn init_price_stream(
 ) -> Result<(), ServerError> {
     // We assume that the exchange has a market between the base token
     // and its default stable token
-    let pair_info = PairInfo::new_default_stable(exchange, &base_token.get_addr());
+    let pair_info = PairInfo::new_default_stable(exchange, &base_token.get_addr())?;
     let streams = global_price_streams.clone();
     tokio::spawn(async move {
         if let Err(e) = streams.get_or_create_price_stream(pair_info, config.clone()).await {

--- a/price-reporter/src/utils/mod.rs
+++ b/price-reporter/src/utils/mod.rs
@@ -8,6 +8,7 @@ use futures_util::StreamExt;
 use futures_util::{stream::SplitSink, Stream};
 use itertools::Itertools;
 use matchit::Router;
+use renegade_common::types::token::USDC_TICKER;
 use renegade_common::types::{
     chain::Chain,
     exchange::Exchange,
@@ -319,6 +320,9 @@ pub fn setup_all_token_remaps(
 
 /// Get the default stable token on the given chain
 pub fn default_exchange_stable(exchange: &Exchange, chain: Chain) -> Token {
+    if exchange == &Exchange::Renegade {
+        return Token::from_ticker_on_chain(USDC_TICKER, chain);
+    }
     let stable = _default_exchange_stable(exchange);
     let ticker = stable.get_ticker().unwrap();
     Token::from_ticker_on_chain(ticker.as_str(), chain)

--- a/price-reporter/src/ws_server.rs
+++ b/price-reporter/src/ws_server.rs
@@ -259,7 +259,7 @@ impl GlobalPriceStreams {
         pair_info: PairInfo,
         config: ExchangeConnectionsConfig,
     ) -> Result<PriceReceiver, ServerError> {
-        let conversion_pair = pair_info.get_conversion_pair();
+        let conversion_pair = pair_info.get_conversion_pair()?;
         let conversion_rx = self.get_or_create_price_receiver(conversion_pair, config).await?;
         Ok(conversion_rx)
     }


### PR DESCRIPTION
### Purpose
This PR ensures that when a price is requested of a token that exists on multiple token lists, we find the right pair. 

Previously we used the `Token` on the default chain which would error when a pair that existed on a non-default chain was requested. 

### Testing
- [x] Tested locally that renegade topic of base mint that exists on two maps with unique quote returns correct subscription lit
- [x] Test in testnet