### PR TITLE
auth-server: server: external-match: Use contexts in quote handler

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -11,51 +11,54 @@ pub enum AuthServerError {
     /// API key inactive
     #[error("API key inactive")]
     ApiKeyInactive,
+    /// Bundle store error
+    #[error("Bundle store error: {0}")]
+    BundleStore(String),
+    /// A miscellaneous error
+    #[error("Error: {0}")]
+    Custom(String),
+    /// Darkpool client error
+    #[error("Darkpool client error: {0}")]
+    DarkpoolClient(String),
     /// Database connection error
     #[error("Database connection error: {0}")]
     DatabaseConnection(String),
-    /// Redis connection error
-    #[error("Redis connection error: {0}")]
-    RedisConnection(String),
-    /// Encryption error
-    #[error("Encryption error: {0}")]
-    Encryption(String),
     /// Decryption error
     #[error("Decryption error: {0}")]
     Decryption(String),
+    /// Encryption error
+    #[error("Encryption error: {0}")]
+    Encryption(String),
+    /// Gas cost sampler error
+    #[error("Gas cost sampler error: {0}")]
+    GasCostSampler(String),
+    /// Gas sponsorship error
+    #[error("Gas sponsorship error: {0}")]
+    GasSponsorship(String),
+    /// Price reporter error
+    #[error("Price reporter error: {0}")]
+    PriceReporter(#[from] PriceReporterClientError),
+    /// An error comparing quotes
+    #[error("Quote comparison error: {0}")]
+    QuoteComparison(String),
+    /// A rate limit error
+    #[error("Rate limited")]
+    RateLimit,
+    /// Redis connection error
+    #[error("Redis connection error: {0}")]
+    RedisConnection(String),
     /// Error serializing or deserializing a stored value
     #[error("Error serializing/deserializing a stored value: {0}")]
     Serde(String),
     /// Error setting up the auth server
     #[error("Error setting up the auth server: {0}")]
     Setup(String),
-    /// Unauthorized
-    #[error("Unauthorized: {0}")]
-    Unauthorized(String),
-    /// Gas sponsorship error
-    #[error("Gas sponsorship error: {0}")]
-    GasSponsorship(String),
     /// An error signing a message
     #[error("Signing error: {0}")]
     Signing(String),
-    /// An error comparing quotes
-    #[error("Quote comparison error: {0}")]
-    QuoteComparison(String),
-    /// A miscellaneous error
-    #[error("Error: {0}")]
-    Custom(String),
-    /// Price reporter error
-    #[error("Price reporter error: {0}")]
-    PriceReporter(#[from] PriceReporterClientError),
-    /// Darkpool client error
-    #[error("Darkpool client error: {0}")]
-    DarkpoolClient(String),
-    /// Gas cost sampler error
-    #[error("Gas cost sampler error: {0}")]
-    GasCostSampler(String),
-    /// Bundle store error
-    #[error("Bundle store error: {0}")]
-    BundleStore(String),
+    /// Unauthorized
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
 }
 
 impl AuthServerError {

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -246,7 +246,7 @@ async fn main() {
         .and(with_query_string())
         .and(with_server(server.clone()))
         .and_then(|path, headers, body, query_str, server: Arc<Server>| async move {
-            server.handle_external_quote_request(path, headers, body, query_str).await
+            server.handle_quote_request(path, headers, body, query_str).await
         });
 
     let external_quote_assembly_path = warp::path("v0")
@@ -259,7 +259,7 @@ async fn main() {
         .and(with_query_string())
         .and(with_server(server.clone()))
         .and_then(|path, headers, body, query_str, server: Arc<Server>| async move {
-            server.handle_external_quote_assembly_request(path, headers, body, query_str).await
+            server.handle_assemble_quote_request(path, headers, body, query_str).await
         });
 
     let external_malleable_assembly_path = warp::path("v0")
@@ -272,9 +272,7 @@ async fn main() {
         .and(with_query_string())
         .and(with_server(server.clone()))
         .and_then(|path, headers, body, query_str, server: Arc<Server>| async move {
-            server
-                .handle_external_malleable_quote_assembly_request(path, headers, body, query_str)
-                .await
+            server.handle_assemble_malleable_quote_request(path, headers, body, query_str).await
         });
 
     let atomic_match_path = warp::path("v0")

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 use http::{Method, StatusCode};
 use renegade_api::http::external_match::AssembleExternalMatchRequest;
-use tracing::{instrument, warn};
+use tracing::instrument;
 use warp::{reject::Rejection, reply::Reply};
 
 use crate::{
@@ -50,7 +50,7 @@ impl Server {
             record_relayer_request_500(key_desc.clone(), path_str.to_string());
         }
         if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &req_body, &headers);
+            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &headers);
             return Ok(res);
         }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
@@ -1,0 +1,67 @@
+//! Assemble malleable quote endpoint handler
+
+use bytes::Bytes;
+use http::{Method, StatusCode};
+use renegade_api::http::external_match::AssembleExternalMatchRequest;
+use tracing::{instrument, warn};
+use warp::{reject::Rejection, reply::Reply};
+
+use crate::{
+    error::AuthServerError,
+    http_utils::overwrite_response_body,
+    server::{api_handlers::log_unsuccessful_relayer_request, Server},
+    telemetry::helpers::record_relayer_request_500,
+};
+
+impl Server {
+    /// Handle an external malleable quote assembly request
+    #[instrument(skip(self, path, headers, body))]
+    pub async fn handle_assemble_malleable_quote_request(
+        &self,
+        path: warp::path::FullPath,
+        headers: warp::hyper::HeaderMap,
+        body: Bytes,
+        query_str: String,
+    ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        let path_str = path.as_str();
+        let key_desc = self.authorize_request(path_str, &query_str, &headers, &body).await?;
+
+        // Check the bundle rate limit
+        let mut req: AssembleExternalMatchRequest =
+            serde_json::from_slice(&body).map_err(AuthServerError::serde)?;
+        self.check_bundle_rate_limit(key_desc.clone(), req.allow_shared).await?;
+
+        // Update the request to remove the effects of gas sponsorship, if
+        // necessary
+        let gas_sponsorship_info =
+            self.maybe_update_assembly_request_with_gas_sponsorship(&mut req).await?;
+
+        // Serialize the potentially updated request body
+        let req_body = serde_json::to_vec(&req).map_err(AuthServerError::serde)?;
+
+        // Send the request to the relayer
+        let mut res = self
+            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
+            .await?;
+
+        let status = res.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_desc.clone(), path_str.to_string());
+        }
+        if status != StatusCode::OK {
+            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &req_body, &headers);
+            return Ok(res);
+        }
+
+        // Apply gas sponsorship to the resulting bundle, if necessary
+        let sponsored_match_resp = self.maybe_apply_gas_sponsorship_to_malleable_match_bundle(
+            res.body(),
+            gas_sponsorship_info,
+        )?;
+        overwrite_response_body(&mut res, sponsored_match_resp.clone())?;
+
+        // TODO: record bundle metrics
+        Ok(res)
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -1,0 +1,87 @@
+//! Assemble quote endpoint handler
+
+use bytes::Bytes;
+use http::{Method, StatusCode};
+use renegade_api::http::external_match::AssembleExternalMatchRequest;
+use tracing::{instrument, warn};
+use warp::{reject::Rejection, reply::Reply};
+
+use crate::{
+    error::AuthServerError,
+    http_utils::overwrite_response_body,
+    server::{api_handlers::log_unsuccessful_relayer_request, Server},
+    telemetry::helpers::record_relayer_request_500,
+};
+
+impl Server {
+    /// Handle an external quote-assembly request
+    #[instrument(skip(self, path, headers, body))]
+    pub async fn handle_assemble_quote_request(
+        &self,
+        path: warp::path::FullPath,
+        headers: warp::hyper::HeaderMap,
+        body: Bytes,
+        query_str: String,
+    ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        let path_str = path.as_str();
+        let key_desc = self.authorize_request(path_str, &query_str, &headers, &body).await?;
+
+        // Check the bundle rate limit
+        let mut req: AssembleExternalMatchRequest =
+            serde_json::from_slice(&body).map_err(AuthServerError::serde)?;
+        self.check_bundle_rate_limit(key_desc.clone(), req.allow_shared).await?;
+
+        // Update the request to remove the effects of gas sponsorship, if
+        // necessary
+        let gas_sponsorship_info =
+            self.maybe_update_assembly_request_with_gas_sponsorship(&mut req).await?;
+
+        // Serialize the potentially updated request body
+        let req_body = serde_json::to_vec(&req).map_err(AuthServerError::serde)?;
+
+        // Send the request to the relayer
+        let mut res = self
+            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
+            .await?;
+
+        let status = res.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_desc.clone(), path_str.to_string());
+        }
+        if status != StatusCode::OK {
+            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &req_body, &headers);
+            return Ok(res);
+        }
+
+        // Apply gas sponsorship to the resulting bundle, if necessary
+        let sponsored_match_resp =
+            self.maybe_apply_gas_sponsorship_to_match_response(res.body(), gas_sponsorship_info)?;
+        overwrite_response_body(&mut res, sponsored_match_resp.clone())?;
+
+        // Record the bundle context in the store
+        let bundle_id = self
+            .write_bundle_context(
+                &sponsored_match_resp,
+                &headers,
+                key_desc.clone(),
+                req.allow_shared,
+            )
+            .await?;
+
+        let server_clone = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = server_clone.handle_quote_assembly_bundle_response(
+                &key_desc,
+                &req,
+                &headers,
+                &sponsored_match_resp,
+                &bundle_id,
+            ) {
+                warn!("Error handling bundle: {e}");
+            };
+        });
+
+        Ok(res)
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -50,7 +50,7 @@ impl Server {
             record_relayer_request_500(key_desc.clone(), path_str.to_string());
         }
         if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &req_body, &headers);
+            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &headers);
             return Ok(res);
         }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -1,0 +1,95 @@
+//! Direct match endpoint handler
+
+use bytes::Bytes;
+use http::{Method, StatusCode};
+use renegade_api::http::external_match::AssembleExternalMatchRequest;
+use tracing::{instrument, warn};
+use warp::{reject::Rejection, reply::Reply};
+
+use crate::{
+    error::AuthServerError,
+    http_utils::overwrite_response_body,
+    server::{api_handlers::log_unsuccessful_relayer_request, Server},
+    telemetry::helpers::record_relayer_request_500,
+};
+
+impl Server {
+    /// Handle an external match request
+    #[instrument(skip(self, path, headers, body))]
+    pub async fn handle_external_match_request(
+        &self,
+        path: warp::path::FullPath,
+        headers: warp::hyper::HeaderMap,
+        body: Bytes,
+        query_str: String,
+    ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        let path_str = path.as_str();
+        let key_description = self.authorize_request(path_str, &query_str, &headers, &body).await?;
+
+        // Direct matches are always shared
+        self.check_bundle_rate_limit(key_description.clone(), true /* shared */).await?;
+
+        let (external_match_req, gas_sponsorship_info) = self
+            .maybe_apply_gas_sponsorship_to_match_request(
+                key_description.clone(),
+                &body,
+                &query_str,
+            )
+            .await?;
+
+        let req_body = serde_json::to_vec(&external_match_req).map_err(AuthServerError::serde)?;
+
+        // Send the request to the relayer, potentially sponsoring the gas costs
+
+        let mut resp = self
+            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
+            .await?;
+
+        let status = resp.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_description.clone(), path_str.to_string());
+        }
+        if status != StatusCode::OK {
+            log_unsuccessful_relayer_request(
+                &resp,
+                &key_description,
+                path_str,
+                &req_body,
+                &headers,
+            );
+            return Ok(resp);
+        }
+
+        let sponsored_match_resp =
+            self.maybe_apply_gas_sponsorship_to_match_response(resp.body(), gas_sponsorship_info)?;
+
+        overwrite_response_body(&mut resp, sponsored_match_resp.clone())?;
+
+        // Record the bundle context in the store
+        let bundle_id = self
+            .write_bundle_context(
+                &sponsored_match_resp,
+                &headers,
+                key_description.clone(),
+                true, // shared
+            )
+            .await?;
+
+        // Watch the bundle for settlement
+        let server_clone = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = server_clone.handle_direct_match_bundle_response(
+                &key_description,
+                &external_match_req,
+                &headers,
+                &sponsored_match_resp,
+                &bundle_id,
+            ) {
+                warn!("Error handling bundle: {e}");
+            };
+        });
+
+        Ok(resp)
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -2,7 +2,6 @@
 
 use bytes::Bytes;
 use http::{Method, StatusCode};
-use renegade_api::http::external_match::AssembleExternalMatchRequest;
 use tracing::{instrument, warn};
 use warp::{reject::Rejection, reply::Reply};
 
@@ -51,13 +50,7 @@ impl Server {
             record_relayer_request_500(key_description.clone(), path_str.to_string());
         }
         if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(
-                &resp,
-                &key_description,
-                path_str,
-                &req_body,
-                &headers,
-            );
+            log_unsuccessful_relayer_request(&resp, &key_description, path_str, &headers);
             return Ok(resp);
         }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -1,0 +1,6 @@
+//! Handlers for external match endpoints
+
+mod assemble_malleable_quote;
+mod assemble_quote;
+mod direct_match;
+mod quote;

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -1,6 +1,247 @@
 //! Handlers for external match endpoints
 
+use auth_server_api::GasSponsorshipInfo;
+use bytes::Bytes;
+use http::{HeaderMap, Method, Response, StatusCode};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    error::AuthServerError, server::Server, telemetry::helpers::record_relayer_request_500,
+    ApiError,
+};
+
+use super::{get_sdk_version, log_unsuccessful_relayer_request};
+
 mod assemble_malleable_quote;
 mod assemble_quote;
 mod direct_match;
 mod quote;
+
+// --------------------
+// | Request Contexts |
+// --------------------
+
+// --- Request Context --- //
+
+/// Context for an external match request
+///
+/// This struct handles the common logic for request context helpers used in
+#[derive(Debug, Clone)]
+pub struct RequestContext<Req: Serialize + for<'de> Deserialize<'de>> {
+    /// The path of the request
+    pub path: String,
+    /// The query string of the request
+    pub query_str: String,
+    /// The API user description for the request
+    ///
+    /// Derived from the API key
+    pub user: String,
+    /// The version of the SDK used to make the request
+    pub sdk_version: String,
+    /// The headers of the request
+    pub headers: HeaderMap,
+    /// The body of the request
+    pub body: Req,
+    /// The gas sponsorship info for the request
+    pub sponsorship_info: Option<GasSponsorshipInfo>,
+    /// Unique ID for this request
+    pub request_id: Uuid,
+}
+
+impl<Req: Serialize + for<'de> Deserialize<'de>> RequestContext<Req> {
+    /// Get the user description for the request
+    pub fn user(&self) -> String {
+        self.user.to_string()
+    }
+
+    /// Get a reference to the query string
+    pub fn query(&self) -> String {
+        self.query_str.to_string()
+    }
+
+    /// Get a reference to the path
+    pub fn path(&self) -> String {
+        self.path.to_string()
+    }
+
+    /// Get a mutable reference to the request body
+    pub fn body_mut(&mut self) -> &mut Req {
+        &mut self.body
+    }
+
+    /// Get the json encoded body bytes
+    pub fn body_bytes(&self) -> Result<Vec<u8>, AuthServerError> {
+        serde_json::to_vec(&self.body).map_err(AuthServerError::serde)
+    }
+
+    /// Attach gas sponsorship info to the request context
+    pub fn set_sponsorship_info(&mut self, info: Option<GasSponsorshipInfo>) {
+        self.sponsorship_info = info;
+    }
+}
+
+// --- Response Context --- //
+
+/// Context for an external match response
+#[derive(Debug, Clone)]
+pub struct ResponseContext<
+    Req: Serialize + for<'de> Deserialize<'de>,
+    Resp: Serialize + for<'de> Deserialize<'de>,
+> {
+    /// The path of the request
+    pub path: String,
+    /// The query string of the request
+    pub query_str: String,
+    /// Derived from the API key
+    pub user: String,
+    /// The version of the SDK used to make the request
+    pub sdk_version: String,
+    /// The headers of the request
+    pub headers: HeaderMap,
+    /// A copy of the request
+    pub request: Req,
+    /// A copy of the raw response
+    pub status: StatusCode,
+    /// The deserialized response body
+    ///
+    /// May be `None` if the relayer returned a non-200 status code
+    pub response: Option<Resp>,
+    /// The gas sponsorship info for the request
+    pub sponsorship_info: Option<GasSponsorshipInfo>,
+    /// Unique ID for this request-response flow
+    pub request_id: Uuid,
+}
+
+impl<
+        Req: Serialize + for<'de> Deserialize<'de>,
+        Resp: Serialize + for<'de> Deserialize<'de> + Clone,
+    > ResponseContext<Req, Resp>
+{
+    /// Create a response context from a response and request context
+    pub fn from_response(
+        status: StatusCode,
+        body: Option<Resp>,
+        request: RequestContext<Req>,
+    ) -> Result<ResponseContext<Req, Resp>, AuthServerError> {
+        Ok(ResponseContext {
+            path: request.path,
+            query_str: request.query_str,
+            user: request.user,
+            sdk_version: request.sdk_version,
+            headers: request.headers,
+            request: request.body,
+            status,
+            response: body,
+            sponsorship_info: request.sponsorship_info,
+            request_id: request.request_id,
+        })
+    }
+
+    /// Whether the relayer returned a 200 status code
+    pub fn is_success(&self) -> bool {
+        self.status == StatusCode::OK
+    }
+
+    /// Get the status code of the response
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// Get a reference to the user description
+    pub fn user(&self) -> String {
+        self.user.to_string()
+    }
+
+    /// Get a reference to the request
+    pub fn request(&self) -> &Req {
+        &self.request
+    }
+
+    /// Get a reference to the response body unwrapping its optional
+    ///
+    /// Panics if the response body is `None`
+    pub fn response(&self) -> Resp {
+        self.response.as_ref().unwrap().clone()
+    }
+
+    /// Get a reference to the gas sponsorship info
+    pub fn sponsorship_info(&self) -> Option<GasSponsorshipInfo> {
+        self.sponsorship_info.clone()
+    }
+}
+
+// ---------------------------
+// | Request Context Helpers |
+// ---------------------------
+
+impl Server {
+    /// Build request context for an external match related request, before the
+    /// request is proxied to the relayer
+    pub async fn preprocess_request<Req>(
+        &self,
+        path: warp::path::FullPath,
+        headers: warp::hyper::HeaderMap,
+        body: Bytes,
+        query_str: String,
+    ) -> Result<RequestContext<Req>, ApiError>
+    where
+        Req: Serialize + for<'de> Deserialize<'de>,
+    {
+        // Authorize the request
+        let path = path.as_str().to_string();
+        let key_desc = self.authorize_request(&path, &query_str, &headers, &body).await?;
+        let sdk_version = get_sdk_version(&headers);
+
+        // Deserialize the request body, then build the context
+        let body: Req = serde_json::from_slice(&body).map_err(AuthServerError::serde)?;
+        Ok(RequestContext {
+            path,
+            query_str,
+            sdk_version,
+            headers,
+            user: key_desc,
+            body,
+            sponsorship_info: None,
+            request_id: Uuid::new_v4(),
+        })
+    }
+
+    /// Forward a request context to the relayer's admin API, returning the
+    /// associated response context
+    ///
+    /// Returns the raw response from the relayer as well as the response
+    /// context generated from the relayer's response
+    pub async fn forward_request<Req, Resp>(
+        &self,
+        ctx: RequestContext<Req>,
+    ) -> Result<(Response<Bytes>, ResponseContext<Req, Resp>), AuthServerError>
+    where
+        Req: Serialize + for<'de> Deserialize<'de>,
+        Resp: Serialize + for<'de> Deserialize<'de> + Clone,
+    {
+        let body_bytes = ctx.body_bytes()?;
+        let resp = self
+            .send_admin_request(Method::POST, &ctx.path, ctx.headers.clone(), body_bytes.into())
+            .await?;
+
+        // Handle the status codes
+        let status = resp.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(ctx.user(), ctx.path());
+        } else if status != StatusCode::OK {
+            log_unsuccessful_relayer_request(&resp, &ctx.user(), &ctx.path(), &ctx.headers);
+        }
+
+        // Deserialize the response body
+        let response = if status == StatusCode::OK {
+            let body = serde_json::from_slice(resp.body()).map_err(AuthServerError::serde)?;
+            Some(body)
+        } else {
+            None
+        };
+
+        let ctx = ResponseContext::from_response(status, response, ctx)?;
+        Ok((resp, ctx))
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/external_match/quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/quote.rs
@@ -1,0 +1,80 @@
+//! Quote endpoint handler
+
+use bytes::Bytes;
+use http::{Method, StatusCode};
+use tracing::{error, instrument, warn};
+use warp::{reject::Rejection, reply::Reply};
+
+use crate::{
+    error::AuthServerError,
+    http_utils::overwrite_response_body,
+    server::{api_handlers::log_unsuccessful_relayer_request, Server},
+    telemetry::helpers::record_relayer_request_500,
+};
+
+impl Server {
+    /// Handle an external quote request
+    #[instrument(skip(self, path, headers, body))]
+    pub async fn handle_quote_request(
+        &self,
+        path: warp::path::FullPath,
+        headers: warp::hyper::HeaderMap,
+        body: Bytes,
+        query_str: String,
+    ) -> Result<impl Reply, Rejection> {
+        // Authorize the request
+        let path_str = path.as_str();
+        let key_desc = self.authorize_request(path_str, &query_str, &headers, &body).await?;
+        self.check_quote_rate_limit(key_desc.clone()).await?;
+
+        // If necessary, ensure that the exact output amount requested in the order is
+        // respected by any gas sponsorship applied to the relayer's quote
+        let (external_quote_req, gas_sponsorship_info) = self
+            .maybe_apply_gas_sponsorship_to_quote_request(key_desc.clone(), &body, &query_str)
+            .await?;
+
+        // Send the request to the relayer
+        let req_body = serde_json::to_vec(&external_quote_req).map_err(AuthServerError::serde)?;
+        let mut resp = self
+            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
+            .await?;
+
+        let status = resp.status();
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            record_relayer_request_500(key_desc.clone(), path_str.to_string());
+        }
+        if status == StatusCode::NO_CONTENT {
+            self.handle_no_quote_found(&key_desc, &external_quote_req);
+        }
+        if status != StatusCode::OK {
+            log_unsuccessful_relayer_request(&resp, &key_desc, path_str, &req_body, &headers);
+            return Ok(resp);
+        }
+
+        let sponsored_quote_response =
+            self.maybe_apply_gas_sponsorship_to_quote_response(resp.body(), gas_sponsorship_info)?;
+        overwrite_response_body(&mut resp, sponsored_quote_response.clone())?;
+
+        let server_clone = self.clone();
+        tokio::spawn(async move {
+            // Cache the gas sponsorship info for the quote in Redis if it exists
+            if let Err(e) =
+                server_clone.cache_quote_gas_sponsorship_info(&sponsored_quote_response).await
+            {
+                error!("Error caching quote gas sponsorship info: {e}");
+            }
+
+            // Log the quote response & emit metrics
+            if let Err(e) = server_clone.handle_quote_response(
+                key_desc,
+                &external_quote_req,
+                &headers,
+                &sponsored_quote_response,
+            ) {
+                warn!("Error handling quote: {e}");
+            }
+        });
+
+        Ok(resp)
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/external_match/quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/quote.rs
@@ -1,16 +1,67 @@
 //! Quote endpoint handler
 
+use auth_server_api::{GasSponsorshipInfo, SponsoredQuoteResponse};
 use bytes::Bytes;
-use http::{Method, StatusCode};
-use tracing::{error, instrument, warn};
+use http::{Response, StatusCode};
+use renegade_api::http::external_match::{ExternalQuoteRequest, ExternalQuoteResponse};
+use renegade_circuit_types::fixed_point::FixedPoint;
+use renegade_common::types::{token::Token, TimestampedPrice};
+use renegade_constants::EXTERNAL_MATCH_RELAYER_FEE;
+use renegade_util::hex::biguint_to_hex_addr;
+use tracing::{error, info, instrument, warn};
 use warp::{reject::Rejection, reply::Reply};
 
 use crate::{
     error::AuthServerError,
     http_utils::overwrite_response_body,
-    server::{api_handlers::log_unsuccessful_relayer_request, Server},
-    telemetry::helpers::record_relayer_request_500,
+    server::Server,
+    telemetry::{
+        helpers::{record_endpoint_metrics, record_fill_ratio, record_quote_not_found},
+        labels::{
+            BASE_ASSET_METRIC_TAG, EXTERNAL_MATCH_QUOTE_REQUEST_COUNT, KEY_DESCRIPTION_METRIC_TAG,
+            REQUEST_ID_METRIC_TAG, SDK_VERSION_METRIC_TAG,
+        },
+        QUOTE_FILL_RATIO_IGNORE_THRESHOLD,
+    },
 };
+
+use super::{RequestContext, ResponseContext};
+
+// -----------------
+// | Context Types |
+// -----------------
+
+/// The request context for a quote request
+type QuoteRequestCtx = RequestContext<ExternalQuoteRequest>;
+/// The response context for a quote request
+type QuoteResponseCtx = ResponseContext<ExternalQuoteRequest, ExternalQuoteResponse>;
+/// The response context for a sponsored quote response
+type SponsoredQuoteResponseCtx = ResponseContext<ExternalQuoteRequest, SponsoredQuoteResponse>;
+
+impl SponsoredQuoteResponseCtx {
+    /// Create a sponsored quote response context from a quote response context
+    pub fn from_quote_response_ctx(
+        sponsored_resp: SponsoredQuoteResponse,
+        ctx: QuoteResponseCtx,
+    ) -> Self {
+        Self {
+            path: ctx.path,
+            query_str: ctx.query_str,
+            user: ctx.user,
+            sdk_version: ctx.sdk_version,
+            headers: ctx.headers,
+            request: ctx.request,
+            status: ctx.status,
+            response: Some(sponsored_resp),
+            sponsorship_info: ctx.sponsorship_info,
+            request_id: ctx.request_id,
+        }
+    }
+}
+
+// --------------------
+// | Endpoint Handler |
+// --------------------
 
 impl Server {
     /// Handle an external quote request
@@ -22,59 +73,235 @@ impl Server {
         body: Bytes,
         query_str: String,
     ) -> Result<impl Reply, Rejection> {
-        // Authorize the request
-        let path_str = path.as_str();
-        let key_desc = self.authorize_request(path_str, &query_str, &headers, &body).await?;
-        self.check_quote_rate_limit(key_desc.clone()).await?;
+        // 1. Run the pre-request subroutines
+        let mut ctx = self.preprocess_request(path, headers, body, query_str).await?;
+        self.pre_request(&mut ctx).await?;
+
+        // 2. Proxy the request to the relayer
+        let (raw_resp, ctx) = self.forward_request(ctx).await?;
+
+        // 3. Run the post-request subroutines
+        let resp = self.post_request(raw_resp, ctx)?;
+        Ok(resp)
+    }
+
+    // -------------------------------
+    // | Request Pre/Post Processing |
+    // -------------------------------
+
+    /// Run endpoint handler subroutines before forwarding the request to the
+    /// relayer
+    async fn pre_request(&self, ctx: &mut QuoteRequestCtx) -> Result<(), AuthServerError> {
+        // Check the rate limit
+        self.check_quote_rate_limit(ctx.user()).await?;
 
         // If necessary, ensure that the exact output amount requested in the order is
         // respected by any gas sponsorship applied to the relayer's quote
-        let (external_quote_req, gas_sponsorship_info) = self
-            .maybe_apply_gas_sponsorship_to_quote_request(key_desc.clone(), &body, &query_str)
-            .await?;
+        let gas_sponsorship_info = self.sponsor_request(ctx).await?;
+        ctx.set_sponsorship_info(gas_sponsorship_info);
+        Ok(())
+    }
 
-        // Send the request to the relayer
-        let req_body = serde_json::to_vec(&external_quote_req).map_err(AuthServerError::serde)?;
-        let mut resp = self
-            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
-            .await?;
-
-        let status = resp.status();
-        if status == StatusCode::INTERNAL_SERVER_ERROR {
-            record_relayer_request_500(key_desc.clone(), path_str.to_string());
-        }
+    /// Run endpoint handler subroutines after receiving the relayer's
+    /// response
+    ///
+    /// Returns the auth server's response to the client
+    fn post_request(
+        &self,
+        mut resp: Response<Bytes>,
+        ctx: QuoteResponseCtx,
+    ) -> Result<impl Reply, AuthServerError> {
+        // If the relayer returns non-200, return the response directly
+        let status = ctx.status();
         if status == StatusCode::NO_CONTENT {
-            self.handle_no_quote_found(&key_desc, &external_quote_req);
+            self.record_no_quote_found(ctx.clone());
         }
-        if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(&resp, &key_desc, path_str, &req_body, &headers);
+        if !ctx.is_success() {
             return Ok(resp);
         }
 
-        let sponsored_quote_response =
-            self.maybe_apply_gas_sponsorship_to_quote_response(resp.body(), gas_sponsorship_info)?;
-        overwrite_response_body(&mut resp, sponsored_quote_response.clone())?;
+        // Otherwise, apply gas sponsorship and post-process the quote
+        let sponsored_resp = self.sponsor_response(&ctx)?;
+        overwrite_response_body(&mut resp, sponsored_resp.clone())?;
 
+        // Start a thread to record metrics and return
+        let ctx = SponsoredQuoteResponseCtx::from_quote_response_ctx(sponsored_resp, ctx);
+        self.record_metrics(ctx);
+        Ok(resp)
+    }
+
+    // -------------------
+    // | Gas Sponsorship |
+    // -------------------
+
+    /// Apply gas sponsorship to the given quote request, if eligible. This
+    /// ensures that any exact output amount requested in the order is
+    /// respected.
+    ///
+    /// Returns the gas sponsorship info for the request, if any.
+    async fn sponsor_request(
+        &self,
+        ctx: &mut QuoteRequestCtx,
+    ) -> Result<Option<GasSponsorshipInfo>, AuthServerError> {
+        // Apply gas sponsorship to the order
+        let ctx_clone = ctx.clone();
+        let req = ctx.body_mut();
+        let gas_sponsorship_info =
+            self.maybe_sponsor_order(&mut req.external_order, &ctx_clone).await?;
+
+        Ok(gas_sponsorship_info)
+    }
+
+    /// Apply gas sponsorship to the given external quote response, returning
+    /// the resulting `SponsoredQuoteResponse`
+    fn sponsor_response(
+        &self,
+        ctx: &QuoteResponseCtx,
+    ) -> Result<SponsoredQuoteResponse, AuthServerError> {
+        let resp = ctx.response();
+        if ctx.sponsorship_info().is_none() {
+            return Ok(SponsoredQuoteResponse {
+                signed_quote: resp.signed_quote,
+                gas_sponsorship_info: None,
+            });
+        }
+
+        let sponsorship_info = ctx.sponsorship_info().unwrap();
+        self.construct_sponsored_quote_response(resp, sponsorship_info)
+    }
+
+    // -----------
+    // | Metrics |
+    // -----------
+
+    /// Run the post-processing metrics subroutines for the quote endpoint
+    fn record_metrics(&self, ctx: SponsoredQuoteResponseCtx) {
         let server_clone = self.clone();
         tokio::spawn(async move {
             // Cache the gas sponsorship info for the quote in Redis if it exists
-            if let Err(e) =
-                server_clone.cache_quote_gas_sponsorship_info(&sponsored_quote_response).await
-            {
+            let resp = ctx.response();
+            if let Err(e) = server_clone.cache_quote_gas_sponsorship_info(&resp).await {
                 error!("Error caching quote gas sponsorship info: {e}");
             }
 
             // Log the quote response & emit metrics
-            if let Err(e) = server_clone.handle_quote_response(
-                key_desc,
-                &external_quote_req,
-                &headers,
-                &sponsored_quote_response,
-            ) {
-                warn!("Error handling quote: {e}");
+            if let Err(e) = server_clone.record_metrics_helper(&ctx) {
+                warn!("Error handling quote metrics: {e}");
             }
         });
-
-        Ok(resp)
     }
+
+    /// Handle a quote response
+    fn record_metrics_helper(
+        &self,
+        ctx: &SponsoredQuoteResponseCtx,
+    ) -> Result<(), AuthServerError> {
+        log_quote(ctx)?;
+        if !self.should_sample_metrics() {
+            return Ok(());
+        }
+
+        // Get the decimal-corrected price
+        let req = ctx.request();
+        let resp = ctx.response();
+        let ts_price: TimestampedPrice = resp.signed_quote.quote.price.clone().into();
+        let price = ts_price.as_fixed_point();
+        let relayer_fee = FixedPoint::from_f64_round_down(EXTERNAL_MATCH_RELAYER_FEE);
+
+        // Calculate requested and matched quote amounts
+        let requested_quote_amount = req.external_order.get_quote_amount(price, relayer_fee);
+        let matched_quote_amount = resp.signed_quote.quote.match_result.quote_amount;
+
+        // Record fill ratio metric
+        let labels = vec![
+            (KEY_DESCRIPTION_METRIC_TAG.to_string(), ctx.user()),
+            (REQUEST_ID_METRIC_TAG.to_string(), ctx.request_id.to_string()),
+            (SDK_VERSION_METRIC_TAG.to_string(), ctx.sdk_version.clone()),
+        ];
+        record_fill_ratio(requested_quote_amount, matched_quote_amount, &labels)?;
+
+        // Record endpoint metrics
+        let base_token = Token::from_addr_biguint(&req.external_order.base_mint);
+        record_endpoint_metrics(&base_token.addr, EXTERNAL_MATCH_QUOTE_REQUEST_COUNT, &labels);
+
+        Ok(())
+    }
+
+    /// Handle a no quote found response
+    fn record_no_quote_found(&self, ctx: QuoteResponseCtx) {
+        let self_clone = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = self_clone.record_no_quote_found_helper(&ctx).await {
+                error!("Error recording no quote found metrics: {e}");
+            }
+        });
+    }
+
+    /// A helper for recording metrics when a quote is not found
+    async fn record_no_quote_found_helper(
+        &self,
+        ctx: &QuoteResponseCtx,
+    ) -> Result<(), AuthServerError> {
+        let req = ctx.request();
+        let order = &req.external_order;
+        let base_mint = biguint_to_hex_addr(&order.base_mint);
+        record_quote_not_found(ctx.user(), &base_mint);
+
+        // Record a zero fill ratio
+        let price_f64 = self.price_reporter_client.get_price(&base_mint, self.chain).await.unwrap();
+        let price = FixedPoint::from_f64_round_down(price_f64);
+        let relayer_fee = FixedPoint::zero();
+        let quote_amt = order.get_quote_amount(price, relayer_fee);
+
+        // We ignore excessively large quotes for telemetry, as they're likely spam
+        if quote_amt >= QUOTE_FILL_RATIO_IGNORE_THRESHOLD {
+            return Ok(());
+        }
+
+        // Record fill ratio metrics
+        let labels = vec![
+            (REQUEST_ID_METRIC_TAG.to_string(), ctx.request_id.to_string()),
+            (KEY_DESCRIPTION_METRIC_TAG.to_string(), ctx.user()),
+            (BASE_ASSET_METRIC_TAG.to_string(), base_mint),
+        ];
+        record_fill_ratio(quote_amt, 0 /* matched_quote_amount */, &labels)
+            .expect("Failed to record fill ratio");
+
+        Ok(())
+    }
+}
+
+// -------------------
+// | Logging helpers |
+// -------------------
+
+/// Log a quote
+fn log_quote(ctx: &SponsoredQuoteResponseCtx) -> Result<(), AuthServerError> {
+    let SponsoredQuoteResponse { signed_quote, gas_sponsorship_info } = ctx.response();
+    let sdk_version = &ctx.sdk_version;
+    let key_desc = &ctx.user();
+    let match_result = signed_quote.match_result();
+    let is_buy = match_result.direction;
+    let recv = signed_quote.receive_amount();
+    let send = signed_quote.send_amount();
+    let is_sponsored = gas_sponsorship_info.is_some();
+    let (refund_amount, refund_native_eth) = gas_sponsorship_info
+        .as_ref()
+        .map(|s| (s.gas_sponsorship_info.refund_amount, s.gas_sponsorship_info.refund_native_eth))
+        .unwrap_or((0, false));
+
+    info!(
+            is_sponsored = is_sponsored,
+            key_description = key_desc,
+            sdk_version = sdk_version,
+            "Sending quote(is_buy: {is_buy}, receive: {} ({}), send: {} ({}), refund_amount: {} (refund_native_eth: {})) to client",
+            recv.amount,
+            recv.mint,
+            send.amount,
+            send.mint,
+            refund_amount,
+            refund_native_eth
+        );
+
+    Ok(())
 }

--- a/auth/auth-server/src/server/api_handlers/order_book.rs
+++ b/auth/auth-server/src/server/api_handlers/order_book.rs
@@ -31,7 +31,7 @@ impl Server {
             record_relayer_request_500(key_desc.clone(), path_str.to_string());
         }
         if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(&resp, &key_desc, path_str, &[], &headers);
+            log_unsuccessful_relayer_request(&resp, &key_desc, path_str, &headers);
             return Ok(resp);
         }
         Ok(resp)

--- a/auth/auth-server/src/server/rate_limiter/gas_sponsorship_rate_limiter.rs
+++ b/auth/auth-server/src/server/rate_limiter/gas_sponsorship_rate_limiter.rs
@@ -58,9 +58,9 @@ impl GasSponsorshipRateLimiter {
     }
 
     /// Check if the given user's bucket has a non-zero remaining value.
-    pub async fn has_remaining_value(&self, user_id: String) -> bool {
+    pub async fn has_remaining_value(&self, user_id: &str) -> bool {
         let mut map = self.buckets.lock().await;
-        let entry = map.entry(user_id).or_insert_with(|| self.new_bucket());
+        let entry = map.entry(user_id.to_string()).or_insert_with(|| self.new_bucket());
         entry.has_remaining_value()
     }
 


### PR DESCRIPTION
### Purpose
This PR makes the following changes to the endpoint handlers in the external match flow:
- Moves each handler to its own file for clarity
- Defines a `RequestContext` and `ResponseContext` type that will be used for pre and post-processing of the request.
- Uses this type throughout the quote endpoint's post-processing metrics.

### Todo
- Use this request context type for other external match endpoints