### PR TITLE
auth-server: api-handlers: external-match: Modularize remaining external match handlers

### DIFF
--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -1,17 +1,64 @@
 //! Assemble quote endpoint handler
 
+use auth_server_api::{GasSponsorshipInfo, SponsoredMatchResponse};
 use bytes::Bytes;
-use http::{Method, StatusCode};
-use renegade_api::http::external_match::AssembleExternalMatchRequest;
-use tracing::{instrument, warn};
+use http::Response;
+use renegade_api::http::external_match::{AssembleExternalMatchRequest, ExternalMatchResponse};
+use tracing::{error, info, instrument, warn};
 use warp::{reject::Rejection, reply::Reply};
 
 use crate::{
     error::AuthServerError,
     http_utils::overwrite_response_body,
-    server::{api_handlers::log_unsuccessful_relayer_request, Server},
-    telemetry::helpers::record_relayer_request_500,
+    server::{
+        gas_sponsorship::refund_calculation::{
+            apply_gas_sponsorship_to_exact_output_amount, remove_gas_sponsorship_from_quote,
+            requires_exact_output_amount_update,
+        },
+        helpers::generate_quote_uuid,
+        Server,
+    },
 };
+
+use super::{RequestContext, ResponseContext};
+
+// -----------------
+// | Context Types |
+// -----------------
+
+/// The request context for an assemble quote request
+type AssembleQuoteRequestCtx = RequestContext<AssembleExternalMatchRequest>;
+/// The response context for an assemble quote request
+type AssembleQuoteResponseCtx =
+    ResponseContext<AssembleExternalMatchRequest, ExternalMatchResponse>;
+/// The response context for a sponsored assemble quote response
+type SponsoredAssembleQuoteResponseCtx =
+    ResponseContext<AssembleExternalMatchRequest, SponsoredMatchResponse>;
+
+impl SponsoredAssembleQuoteResponseCtx {
+    /// Create a new sponsored assemble quote response context
+    pub fn from_assemble_quote_response_ctx(
+        sponsored_resp: SponsoredMatchResponse,
+        ctx: AssembleQuoteResponseCtx,
+    ) -> Self {
+        Self {
+            path: ctx.path,
+            query_str: ctx.query_str,
+            user: ctx.user,
+            sdk_version: ctx.sdk_version,
+            headers: ctx.headers,
+            request: ctx.request,
+            status: ctx.status,
+            response: Some(sponsored_resp),
+            sponsorship_info: ctx.sponsorship_info,
+            request_id: ctx.request_id,
+        }
+    }
+}
+
+// --------------------
+// | Endpoint Handler |
+// --------------------
 
 impl Server {
     /// Handle an external quote-assembly request
@@ -23,65 +70,185 @@ impl Server {
         body: Bytes,
         query_str: String,
     ) -> Result<impl Reply, Rejection> {
-        // Authorize the request
-        let path_str = path.as_str();
-        let key_desc = self.authorize_request(path_str, &query_str, &headers, &body).await?;
+        // 1. Run the pre-request subroutines
+        let mut ctx = self.preprocess_request(path, headers, body, query_str).await?;
+        self.assembly_pre_request(&mut ctx).await?;
 
-        // Check the bundle rate limit
-        let mut req: AssembleExternalMatchRequest =
-            serde_json::from_slice(&body).map_err(AuthServerError::serde)?;
-        self.check_bundle_rate_limit(key_desc.clone(), req.allow_shared).await?;
+        // 2. Proxy the request to the relayer
+        let (raw_resp, ctx) = self.forward_request(ctx).await?;
 
-        // Update the request to remove the effects of gas sponsorship, if
-        // necessary
-        let gas_sponsorship_info =
-            self.maybe_update_assembly_request_with_gas_sponsorship(&mut req).await?;
+        // 3. Run the post-request subroutines
+        let res = self.assembly_post_request(raw_resp, ctx)?;
+        Ok(res)
+    }
 
-        // Serialize the potentially updated request body
-        let req_body = serde_json::to_vec(&req).map_err(AuthServerError::serde)?;
+    // -------------------------------
+    // | Request Pre/Post Processing |
+    // -------------------------------
 
-        // Send the request to the relayer
-        let mut res = self
-            .send_admin_request(Method::POST, path_str, headers.clone(), req_body.clone().into())
-            .await?;
+    /// Run the pre-request subroutines for the assembly quote endpoint
+    async fn assembly_pre_request(
+        &self,
+        ctx: &mut AssembleQuoteRequestCtx,
+    ) -> Result<(), AuthServerError> {
+        let allow_shared = ctx.body.allow_shared;
+        let key_desc = ctx.user();
+        self.check_bundle_rate_limit(key_desc, allow_shared).await?;
 
-        let status = res.status();
-        if status == StatusCode::INTERNAL_SERVER_ERROR {
-            record_relayer_request_500(key_desc.clone(), path_str.to_string());
-        }
-        if status != StatusCode::OK {
-            log_unsuccessful_relayer_request(&res, &key_desc, path_str, &headers);
-            return Ok(res);
+        // Apply gas sponsorship to the assembly request
+        let gas_sponsorship_info = self.sponsor_assembly_request(ctx).await?;
+        ctx.set_sponsorship_info(gas_sponsorship_info);
+        Ok(())
+    }
+
+    /// Run the post-request subroutines for the assembly quote endpoint
+    fn assembly_post_request(
+        &self,
+        mut resp: Response<Bytes>,
+        ctx: AssembleQuoteResponseCtx,
+    ) -> Result<impl Reply, AuthServerError> {
+        // If the relayer returns non-200, return the response directly
+        if !ctx.is_success() {
+            return Ok(resp);
         }
 
         // Apply gas sponsorship to the resulting bundle, if necessary
+        let sponsored_resp = self.sponsor_match_response(&ctx)?;
+        overwrite_response_body(&mut resp, sponsored_resp.clone())?;
+
+        // Record metrics
+        let ctx = SponsoredAssembleQuoteResponseCtx::from_assemble_quote_response_ctx(
+            sponsored_resp,
+            ctx,
+        );
+        self.record_assemble_metrics(ctx);
+        Ok(resp)
+    }
+
+    // -------------------
+    // | Gas Sponsorship |
+    // -------------------
+
+    /// Check if the given assembly request pertains to a sponsored quote,
+    /// and if so, remove the effects of gas sponsorship from the signed quote,
+    /// and ensure sponsorship is correctly applied to the updated order, if
+    /// present.
+    ///
+    /// Returns the assembly request, and the gas sponsorship info, if any.
+    async fn sponsor_assembly_request(
+        &self,
+        ctx: &mut AssembleQuoteRequestCtx,
+    ) -> Result<Option<GasSponsorshipInfo>, AuthServerError> {
+        let req = ctx.body_mut();
+        let redis_key = generate_quote_uuid(&req.signed_quote);
+        let gas_sponsorship_info = match self.read_gas_sponsorship_info_from_redis(redis_key).await
+        {
+            Err(e) => {
+                error!("Error reading gas sponsorship info from Redis: {e}");
+                None
+            },
+            Ok(gas_sponsorship_info) => gas_sponsorship_info,
+        };
+
+        if let Some(ref gas_sponsorship_info) = gas_sponsorship_info {
+            // Reconstruct original signed quote
+            if gas_sponsorship_info.requires_match_result_update() {
+                let quote = &mut req.signed_quote.quote;
+                remove_gas_sponsorship_from_quote(quote, gas_sponsorship_info);
+            }
+
+            // Ensure that the exact output amount is respected on the updated order
+            if let Some(ref mut updated_order) = req.updated_order
+                && requires_exact_output_amount_update(updated_order, gas_sponsorship_info)
+            {
+                apply_gas_sponsorship_to_exact_output_amount(updated_order, gas_sponsorship_info);
+            }
+        }
+
+        Ok(gas_sponsorship_info)
+    }
+
+    /// Potentially apply gas sponsorship to the given
+    /// external match response, returning the resulting
+    /// `SponsoredMatchResponse`
+    fn sponsor_match_response(
+        &self,
+        ctx: &AssembleQuoteResponseCtx,
+    ) -> Result<SponsoredMatchResponse, AuthServerError> {
+        let resp = ctx.response();
+        let gas_sponsorship_info = ctx.sponsorship_info();
+        if gas_sponsorship_info.is_none() {
+            return Ok(SponsoredMatchResponse {
+                match_bundle: resp.match_bundle,
+                is_sponsored: false,
+                gas_sponsorship_info: None,
+            });
+        }
+
+        info!("Sponsoring match bundle via gas sponsor");
+        let sponsorship_info = gas_sponsorship_info.unwrap();
         let sponsored_match_resp =
-            self.maybe_apply_gas_sponsorship_to_match_response(res.body(), gas_sponsorship_info)?;
-        overwrite_response_body(&mut res, sponsored_match_resp.clone())?;
+            self.construct_sponsored_match_response(resp, sponsorship_info)?;
 
-        // Record the bundle context in the store
-        let bundle_id = self
-            .write_bundle_context(
-                &sponsored_match_resp,
-                &headers,
-                key_desc.clone(),
-                req.allow_shared,
-            )
-            .await?;
+        Ok(sponsored_match_resp)
+    }
 
+    // -----------
+    // | Metrics |
+    // -----------
+
+    /// Record metrics for the assemble quote endpoint
+    fn record_assemble_metrics(&self, ctx: SponsoredAssembleQuoteResponseCtx) {
         let server_clone = self.clone();
         tokio::spawn(async move {
-            if let Err(e) = server_clone.handle_quote_assembly_bundle_response(
-                &key_desc,
-                &req,
-                &headers,
-                &sponsored_match_resp,
-                &bundle_id,
-            ) {
-                warn!("Error handling bundle: {e}");
-            };
+            if let Err(e) = server_clone.record_assemble_metrics_helper(&ctx).await {
+                warn!("Error handling assemble metrics: {e}");
+            }
         });
-
-        Ok(res)
     }
+
+    /// A helper function to record metrics for the assemble quote endpoint
+    async fn record_assemble_metrics_helper(
+        &self,
+        ctx: &SponsoredAssembleQuoteResponseCtx,
+    ) -> Result<(), AuthServerError> {
+        // Record the bundle context in the store
+        let shared = ctx.request().allow_shared;
+        self.write_bundle_context(shared, ctx).await?;
+
+        let req = ctx.request();
+        if req.updated_order.is_some() {
+            log_updated_order(ctx);
+        }
+
+        let order = &req.signed_quote.quote.order;
+        self.handle_bundle_response(order, ctx)
+    }
+}
+
+// -------------------
+// | Logging Helpers |
+// -------------------
+
+/// Log an updated order
+fn log_updated_order(ctx: &SponsoredAssembleQuoteResponseCtx) {
+    let req = ctx.request();
+    let original_order = &req.signed_quote.quote.order;
+    let updated_order = req.updated_order.as_ref().unwrap_or(original_order);
+
+    let key = ctx.user();
+    let request_id = ctx.request_id.to_string();
+    let sdk_version = &ctx.sdk_version;
+
+    let original_base_amount = original_order.base_amount;
+    let updated_base_amount = updated_order.base_amount;
+    let original_quote_amount = original_order.quote_amount;
+    let updated_quote_amount = updated_order.quote_amount;
+    info!(
+        key_description = key,
+        request_id = request_id,
+        sdk_version = sdk_version,
+        "Quote updated(original_base_amount: {}, updated_base_amount: {}, original_quote_amount: {}, updated_quote_amount: {})",
+        original_base_amount, updated_base_amount, original_quote_amount, updated_quote_amount
+    );
 }

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -135,7 +135,7 @@ impl Server {
     /// present.
     ///
     /// Returns the assembly request, and the gas sponsorship info, if any.
-    async fn sponsor_assembly_request(
+    pub(crate) async fn sponsor_assembly_request(
         &self,
         ctx: &mut AssembleQuoteRequestCtx,
     ) -> Result<Option<GasSponsorshipInfo>, AuthServerError> {

--- a/auth/auth-server/src/server/rate_limiter/mod.rs
+++ b/auth/auth-server/src/server/rate_limiter/mod.rs
@@ -26,7 +26,7 @@ use gas_sponsorship_rate_limiter::GasSponsorshipRateLimiter;
 use tracing::warn;
 use user_rate_limiter::ApiTokenRateLimiter;
 
-use crate::{error::AuthServerError, ApiError};
+use crate::error::AuthServerError;
 
 use super::Server;
 
@@ -55,10 +55,10 @@ impl Server {
         &self,
         key_description: String,
         shared: bool,
-    ) -> Result<(), ApiError> {
+    ) -> Result<(), AuthServerError> {
         if !self.rate_limiter.check_bundle_token(key_description.clone(), shared).await {
             warn!("Bundle rate limit exceeded for key: {key_description}");
-            return Err(ApiError::TooManyRequests);
+            return Err(AuthServerError::RateLimit);
         }
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR makes analogous changes to the remaining auth server endpoints (direct match, assemble match, assemble malleable match) as were made in #218. 

The malleable match metrics are left unimplemented still, and will be taken care of in a follow-up.
