### PR TITLE
auth-server: telemetry: Fix metrics prefix for datadog

### DIFF
--- a/auth/auth-server/src/telemetry/mod.rs
+++ b/auth/auth-server/src/telemetry/mod.rs
@@ -1,6 +1,6 @@
 //! Defines helpers for recording metrics
 
-use renegade_util::telemetry::configure_telemetry;
+use renegade_util::telemetry::{configure_telemetry_with_metrics_config, metrics::MetricsConfig};
 
 use crate::{error::AuthServerError, Cli};
 pub mod helpers;
@@ -15,16 +15,21 @@ pub mod sources;
 ///
 /// Specified in USDC
 pub const QUOTE_FILL_RATIO_IGNORE_THRESHOLD: u128 = 100_000 * 10u128.pow(6u32); // $100,000 of USDC
+/// The prefix for metrics
+const METRICS_PREFIX: &str = "auth-server";
 
 /// Configure telemetry from the command line arguments
 pub(crate) fn configure_telemtry_from_args(args: &Cli) -> Result<(), AuthServerError> {
-    configure_telemetry(
+    let metrics_config =
+        MetricsConfig { metrics_prefix: METRICS_PREFIX.to_string(), ..Default::default() };
+    configure_telemetry_with_metrics_config(
         args.datadog_enabled, // datadog_enabled
         false,                // otlp_enabled
         args.metrics_enabled, // metrics_enabled
         "".to_string(),       // collector_endpoint
         &args.statsd_host,    // statsd_host
         args.statsd_port,     // statsd_port
+        Some(metrics_config),
     )
     .map_err(AuthServerError::setup)
 }


### PR DESCRIPTION
### Purpose
This PR fixes the metrics naming prefix for the auth server; `renegade_relayer` -> `auth-server`.