### PR TITLE
price-reporter: add token pair resolution

### DIFF
--- a/price-reporter/src/utils/mod.rs
+++ b/price-reporter/src/utils/mod.rs
@@ -333,7 +333,6 @@ pub fn setup_all_token_remaps(
         },
         // Otherwise, fetch remap from default location
         None => chains.iter().try_for_each(|chain| {
-            tracing::info!("Setting up token remaps for chain: {}", chain);
             set_canonical_exchange_map(None /* remap file */, *chain)?;
             setup_token_remaps(None, *chain).map_err(err_str!(ServerError::TokenRemap))
         }),


### PR DESCRIPTION
### Purpose
This PR adds a helper to find a token pair that exists on the same chain. This ensures PairInfo can be parsed from incoming price topics in a multi-chain price reporter where neither base nor quote token are guaranteed to be unique to a chain.

### Testing
- [x] Tested locally that partial/fully qualified renegade topics always return price, non-unique base/quote mints always return price
- [x] Test in testnet