### PR TITLE
auth-server: gas-sponsorship: Add Base gas sponsorship implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#6775ee37c8350483f2048b7d54024d14830c85b5"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#f586c24f0042e410448dd8f46c18cacdfffba45e"
 dependencies = [
  "alloy",
 ]
@@ -395,6 +395,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
+ "getrandom 0.3.3",
  "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "itoa",
@@ -893,12 +894,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -1368,6 +1369,7 @@ checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
 name = "auth-server"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "aes-gcm",
  "alloy",
  "alloy-primitives 1.1.2",
@@ -1537,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.87.0"
+version = "1.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ebea705311db979d0ce141cbebf1426e2ce7f5c5d6b248baaf6d6e511b976"
+checksum = "5ffc2a1c6dfd4585ad423350c04da3c8be831c9f418e58e8c837656054ec45f8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1571,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.73.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a09113113f5b457128e7157f2fa2e1969cca2f94e46684d65b86e141fad9e1e"
+checksum = "ca681408228085cf3936cd78405996b1295e006221b7f7bf78735f5c70a78fa1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2597,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2608,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2639,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2827,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2890,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2963,7 +2965,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3268,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "abi",
  "alloy",
@@ -4194,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4705,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5523,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -6450,6 +6452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7151,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7792,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7842,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -8156,9 +8164,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -8220,6 +8228,9 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+dependencies = [
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -8386,9 +8397,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -9325,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "bus",
  "common",
@@ -9337,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10253,7 +10264,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#fec29f1c97263c5a85b2e587661aaaf660929a95"
+source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
 renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = ["metered-channels"] }
 renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git" }
+renegade-solidity-abi = { package = "abi", git = "https://github.com/renegade-fi/renegade-solidity-contracts" }
+
 
 # === Blockchain Dependencies === #
 alloy-sol-types = "1.0.1"

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 arbitrum = ["renegade-darkpool-client/arbitrum"]
-base = ["renegade-darkpool-client/base"]
+base = ["renegade-darkpool-client/base", "dep:renegade-solidity-abi"]
 
 [dependencies]
 # === HTTP Server === #
@@ -38,7 +38,7 @@ rand = "0.8.5"
 
 # === Ethereum Libraries === #
 alloy = { workspace = true, features = ["provider-ws"] }
-alloy-primitives = { workspace = true, features = ["serde", "k256"] }
+alloy-primitives = { workspace = true, features = ["serde", "k256", "rand"] }
 alloy-sol-types = { workspace = true }
 
 # === Renegade Dependencies === #
@@ -53,6 +53,7 @@ renegade-config = { workspace = true }
 renegade-crypto = { workspace = true }
 renegade-util = { workspace = true }
 renegade-api = { workspace = true }
+renegade-solidity-abi = { workspace = true, optional = true }
 renegade-system-clock = { workspace = true }
 
 # === Misc Dependencies === #

--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -3,6 +3,10 @@ name = "auth-server"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+arbitrum = ["renegade-darkpool-client/arbitrum"]
+base = ["renegade-darkpool-client/base"]
+
 [dependencies]
 # === HTTP Server === #
 clap = { version = "4.0", features = ["derive", "env"] }
@@ -41,7 +45,7 @@ alloy-sol-types = { workspace = true }
 auth-server-api = { path = "../auth-server-api" }
 price-reporter-client = { path = "../../price-reporter-client" }
 contracts-common = { workspace = true }
-renegade-darkpool-client = { workspace = true, features = ["arbitrum"] }
+renegade-darkpool-client = { workspace = true }
 renegade-circuit-types = { workspace = true }
 renegade-common = { workspace = true }
 renegade-constants = { workspace = true }

--- a/auth/auth-server/src/server/gas_sponsorship/contract_interaction/base.rs
+++ b/auth/auth-server/src/server/gas_sponsorship/contract_interaction/base.rs
@@ -1,0 +1,194 @@
+//! Contract interaction helpers for Base
+//! Logic for interacting with the gas sponsor contract
+
+use alloy::signers::k256::ecdsa::SigningKey;
+use alloy_primitives::{Address, Bytes, U256};
+use alloy_sol_types::{SolCall, SolValue};
+use renegade_api::http::external_match::{ExternalMatchResponse, MalleableExternalMatchResponse};
+use renegade_solidity_abi::IDarkpool::{
+    processAtomicMatchSettleCall, processMalleableAtomicMatchSettleCall,
+    sponsorAtomicMatchSettleCall, sponsorMalleableAtomicMatchSettleCall,
+};
+
+use crate::{
+    error::AuthServerError,
+    server::{
+        helpers::{get_selector, sign_message},
+        Server,
+    },
+};
+
+// ---------------
+// | ABI Helpers |
+// ---------------
+
+/// Convert a `processAtomicMatchSettle` calldata into a
+/// `sponsorAtomicMatchSettleWithRefundOptions` call
+fn sponsored_atomic_match_calldata(
+    calldata: &[u8],
+    refund_address: Address,
+    nonce: U256,
+    refund_native_eth: bool,
+    refund_amount: U256,
+    signature: Bytes,
+) -> Result<sponsorAtomicMatchSettleCall, AuthServerError> {
+    let processAtomicMatchSettleCall {
+        receiver,
+        internalPartyPayload,
+        matchSettleStatement,
+        proofs,
+        linkingProofs,
+    } = processAtomicMatchSettleCall::abi_decode(calldata)
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+    Ok(sponsorAtomicMatchSettleCall {
+        receiver,
+        internalPartyMatchPayload: internalPartyPayload,
+        validMatchSettleAtomicStatement: matchSettleStatement,
+        matchProofs: proofs,
+        matchLinkingProofs: linkingProofs,
+        refundAddress: refund_address,
+        nonce,
+        refundNativeEth: refund_native_eth,
+        refundAmount: refund_amount,
+        signature,
+    })
+}
+
+/// Convert a `processMalleableAtomicMatchSettle` calldata into a
+/// `sponsorMalleableAtomicMatchSettleWithRefundOptions` call
+fn sponsored_malleable_atomic_match_calldata(
+    calldata: &[u8],
+    refund_address: Address,
+    nonce: U256,
+    refund_native_eth: bool,
+    refund_amount: U256,
+    signature: Bytes,
+) -> Result<sponsorMalleableAtomicMatchSettleCall, AuthServerError> {
+    let processMalleableAtomicMatchSettleCall {
+        quoteAmount,
+        baseAmount,
+        receiver,
+        internalPartyPayload,
+        matchSettleStatement,
+        proofs,
+        linkingProofs,
+    } = processMalleableAtomicMatchSettleCall::abi_decode(calldata)
+        .map_err(AuthServerError::gas_sponsorship)?;
+
+    Ok(sponsorMalleableAtomicMatchSettleCall {
+        quoteAmount,
+        baseAmount,
+        receiver,
+        internalPartyMatchPayload: internalPartyPayload,
+        malleableMatchSettleStatement: matchSettleStatement,
+        matchProofs: proofs,
+        matchLinkingProofs: linkingProofs,
+        refundAddress: refund_address,
+        nonce,
+        refundNativeEth: refund_native_eth,
+        refundAmount: refund_amount,
+        signature,
+    })
+}
+
+// ---------------
+// | Server Impl |
+// ---------------
+
+impl Server {
+    /// Generate the calldata for sponsoring the given match via the gas sponsor
+    pub(crate) fn generate_gas_sponsor_calldata(
+        &self,
+        external_match_resp: &ExternalMatchResponse,
+        refund_address: Address,
+        refund_native_eth: bool,
+        refund_amount: U256,
+    ) -> Result<Bytes, AuthServerError> {
+        let (nonce, signature) = gen_signed_sponsorship_nonce(
+            refund_address,
+            refund_amount,
+            &self.gas_sponsor_auth_key,
+        )?;
+
+        let tx = &external_match_resp.match_bundle.settlement_tx;
+        let calldata = tx.input.input().unwrap_or_default();
+        let selector = get_selector(calldata)?;
+
+        let gas_sponsor_call = match selector {
+            processAtomicMatchSettleCall::SELECTOR => sponsored_atomic_match_calldata(
+                calldata,
+                refund_address,
+                nonce,
+                refund_native_eth,
+                refund_amount,
+                signature,
+            ),
+            _ => {
+                return Err(AuthServerError::gas_sponsorship("invalid selector"));
+            },
+        }?;
+
+        let calldata = gas_sponsor_call.abi_encode().into();
+        Ok(calldata)
+    }
+
+    /// Generate the calldata for sponsoring the given malleable match bundle
+    pub(crate) fn generate_gas_sponsor_malleable_calldata(
+        &self,
+        external_match_resp: &MalleableExternalMatchResponse,
+        refund_address: Address,
+        refund_native_eth: bool,
+        refund_amount: U256,
+    ) -> Result<Bytes, AuthServerError> {
+        // Sign a sponsorship permit
+        let (nonce, signature) = gen_signed_sponsorship_nonce(
+            refund_address,
+            refund_amount,
+            &self.gas_sponsor_auth_key,
+        )?;
+
+        // Parse the calldata and translate it into a gas sponsorship call
+        let tx = &external_match_resp.match_bundle.settlement_tx;
+        let calldata = tx.input.input().unwrap_or_default();
+        let selector = get_selector(calldata)?;
+
+        let gas_sponsor_call = match selector {
+            processMalleableAtomicMatchSettleCall::SELECTOR => {
+                sponsored_malleable_atomic_match_calldata(
+                    calldata,
+                    refund_address,
+                    nonce,
+                    refund_native_eth,
+                    refund_amount,
+                    signature,
+                )
+            },
+            _ => {
+                return Err(AuthServerError::gas_sponsorship("invalid selector"));
+            },
+        }?;
+
+        let calldata = gas_sponsor_call.abi_encode().into();
+        Ok(calldata)
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Generate a random nonce for gas sponsorship, signing it along with
+/// the provided refund address and the refund amount
+fn gen_signed_sponsorship_nonce(
+    refund_address: Address,
+    refund_amount: U256,
+    gas_sponsor_auth_key: &SigningKey,
+) -> Result<(U256, Bytes), AuthServerError> {
+    // Generate a random sponsorship nonce then sign the message
+    let nonce = U256::random();
+    let message = (nonce, refund_address, refund_amount).abi_encode();
+    let signature = sign_message(&message, gas_sponsor_auth_key)?.into();
+
+    Ok((nonce, signature))
+}

--- a/auth/auth-server/src/server/gas_sponsorship/contract_interaction/mod.rs
+++ b/auth/auth-server/src/server/gas_sponsorship/contract_interaction/mod.rs
@@ -1,0 +1,9 @@
+//! Contract interaction helpers
+
+#[cfg(feature = "arbitrum")]
+mod arbitrum;
+#[cfg(feature = "arbitrum")]
+pub use arbitrum::*;
+
+#[cfg(feature = "base")]
+mod base;

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -2,10 +2,10 @@
 
 use aes_gcm::{aead::Aead, AeadCore, Aes128Gcm};
 use alloy::signers::k256::ecdsa::SigningKey;
-use alloy_primitives::{keccak256, Address, Bytes as AlloyBytes, Signature, U256};
+use alloy_primitives::{keccak256, Signature, U256};
 use base64::{engine::general_purpose, Engine as _};
 use contracts_common::constants::NUM_BYTES_SIGNATURE;
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 use renegade_api::http::external_match::SignedExternalQuote;
 use uuid::Uuid;
 
@@ -57,29 +57,6 @@ pub fn aes_decrypt(value: &str, key: &Aes128Gcm) -> Result<String, AuthServerErr
 // ---------------------------
 // | Gas Sponsorship Helpers |
 // ---------------------------
-
-/// Generate a random nonce for gas sponsorship, signing it along with
-/// the provided refund address and the refund amount
-pub fn gen_signed_sponsorship_nonce(
-    refund_address: Address,
-    refund_amount: U256,
-    gas_sponsor_auth_key: &SigningKey,
-) -> Result<(U256, AlloyBytes), AuthServerError> {
-    // Generate a random sponsorship nonce
-    let mut nonce_bytes = [0u8; U256::BYTES];
-    thread_rng().fill(&mut nonce_bytes);
-
-    // Construct & sign the message
-    let mut message = Vec::new();
-    message.extend_from_slice(&nonce_bytes);
-    message.extend_from_slice(refund_address.as_ref());
-    message.extend_from_slice(&refund_amount.to_be_bytes::<{ U256::BYTES }>());
-
-    let signature = sign_message(&message, gas_sponsor_auth_key)?.into();
-    let nonce = U256::from_be_bytes(nonce_bytes);
-
-    Ok((nonce, signature))
-}
 
 /// Sign a message using a secp256k1 key, serializing the signature to bytes
 pub fn sign_message(


### PR DESCRIPTION
### Purpose
This PR adds a `base` submodule to the gas sponsorships module with the correct base gas sponsorship implementation. The differences between the base implementation and the arbitrum implementation are:
- The base gas sponsor authority (auth server), signs the abi encoded tuple `(nonce, refundAddress, refundAmount)`, whereas the arbitrum implementation manually serializes these values.
- The base gas sponsor ABI has slightly different function names.
- The base darkpool contract does not have separate methods for an external match and an external match with receiver specified. Instead it uses `address(0)` to encode `msg.sender` as the match recipient.

### Testing
- Deferred until the auth server builds for base