### PR TITLE
auth-server: telemetry: abi_helpers: Add chain-specific ABI helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2829,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2892,7 +2892,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2965,7 +2965,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "abi",
  "alloy",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4707,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7159,7 +7159,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7850,7 +7850,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -9336,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "bus",
  "common",
@@ -9348,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10264,7 +10264,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#5d368889b0aac8996090819d35930b4e58b022fa"
+source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -15,7 +15,7 @@ use renegade_api::http::external_match::ApiExternalMatchResult;
 use renegade_circuit_types::wallet::Nullifier;
 use renegade_common::types::chain::Chain;
 use renegade_darkpool_client::{
-    arbitrum::abi::Darkpool::NullifierSpent, conversion::u256_to_scalar, DarkpoolClient,
+    conversion::u256_to_scalar, traits::DarkpoolImpl, DarkpoolClient, DarkpoolImplementation,
 };
 use tracing::{error, info};
 
@@ -25,6 +25,9 @@ use crate::server::{
 };
 
 use super::error::OnChainEventListenerError;
+
+/// The nullifier spent event for the darkpool
+type NullifierSpent = <DarkpoolImplementation as DarkpoolImpl>::NullifierSpent;
 
 // ----------
 // | Worker |

--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -153,3 +153,9 @@ impl From<AuthServerError> for ApiError {
         }
     }
 }
+
+impl From<alloy_sol_types::Error> for AuthServerError {
+    fn from(err: alloy_sol_types::Error) -> Self {
+        Self::custom(err)
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/settlement.rs
+++ b/auth/auth-server/src/server/api_handlers/settlement.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::{MatchBundleResponseCtx, Server};
 use crate::bundle_store::{helpers::generate_bundle_id, BundleContext};
 use crate::error::AuthServerError;
-use crate::telemetry::helpers::extract_nullifier_from_match_bundle;
+use crate::telemetry::abi_helpers::extract_nullifier_from_match_bundle;
 
 impl Server {
     /// Write the bundle context to the store, handling gas sponsorship if

--- a/auth/auth-server/src/telemetry/abi_helpers/arbitrum.rs
+++ b/auth/auth-server/src/telemetry/abi_helpers/arbitrum.rs
@@ -1,0 +1,61 @@
+//! Telemetry helpers for Arbitrum specific ABI functionality
+
+use alloy_sol_types::SolCall;
+use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_circuit_types::wallet::Nullifier;
+use renegade_constants::Scalar;
+use renegade_darkpool_client::arbitrum::{
+    abi::Darkpool::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
+    contract_types::types::MatchPayload,
+    helpers::deserialize_calldata,
+};
+
+use crate::{
+    error::AuthServerError,
+    server::{
+        gas_sponsorship::contract_interaction::sponsorAtomicMatchSettleWithRefundOptionsCall,
+        helpers::get_selector,
+    },
+};
+
+/// Extracts the nullifier from a match bundle's settlement transaction
+///
+/// This function attempts to decode the settlement transaction data in two
+/// ways:
+/// 1. As a standard atomic match settle call
+/// 2. As a match settle with receiver call
+pub fn extract_nullifier_from_match_bundle(
+    match_bundle: &AtomicMatchApiBundle,
+) -> Result<Nullifier, AuthServerError> {
+    let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
+    let selector = get_selector(tx_data)?;
+
+    // Retrieve serialized match payload from the transaction data
+    let serialized_match_payload = match selector {
+        processAtomicMatchSettleCall::SELECTOR => {
+            processAtomicMatchSettleCall::abi_decode(tx_data)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        processAtomicMatchSettleWithReceiverCall::SELECTOR => {
+            processAtomicMatchSettleWithReceiverCall::abi_decode(tx_data)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        sponsorAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
+            sponsorAtomicMatchSettleWithRefundOptionsCall::abi_decode(tx_data)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        _ => {
+            return Err(AuthServerError::serde("Invalid selector for settlement tx"));
+        },
+    };
+
+    // Extract nullifier from the payload
+    let match_payload = deserialize_calldata::<MatchPayload>(&serialized_match_payload)
+        .map_err(AuthServerError::serde)?;
+    let nullifier = Scalar::new(match_payload.valid_reblind_statement.original_shares_nullifier);
+
+    Ok(nullifier)
+}

--- a/auth/auth-server/src/telemetry/abi_helpers/base.rs
+++ b/auth/auth-server/src/telemetry/abi_helpers/base.rs
@@ -1,0 +1,46 @@
+//! Telemetry helpers for Base specific ABI functionality
+
+use alloy_sol_types::SolCall;
+use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_circuit_types::wallet::Nullifier;
+use renegade_darkpool_client::conversion::u256_to_scalar;
+use renegade_solidity_abi::IDarkpool::{
+    processAtomicMatchSettleCall, processMalleableAtomicMatchSettleCall,
+    sponsorAtomicMatchSettleCall, sponsorMalleableAtomicMatchSettleCall,
+};
+
+use crate::{error::AuthServerError, server::helpers::get_selector};
+
+/// Extract the nullifier from a match bundle
+pub fn extract_nullifier_from_match_bundle(
+    match_bundle: &AtomicMatchApiBundle,
+) -> Result<Nullifier, AuthServerError> {
+    let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
+    let selector = get_selector(tx_data)?;
+
+    match selector {
+        processAtomicMatchSettleCall::SELECTOR => {
+            let call = processAtomicMatchSettleCall::abi_decode(tx_data)?;
+            let nullifier = call.internalPartyPayload.validReblindStatement.originalSharesNullifier;
+            Ok(u256_to_scalar(nullifier))
+        },
+        processMalleableAtomicMatchSettleCall::SELECTOR => {
+            let call = processMalleableAtomicMatchSettleCall::abi_decode(tx_data)?;
+            let nullifier = call.internalPartyPayload.validReblindStatement.originalSharesNullifier;
+            Ok(u256_to_scalar(nullifier))
+        },
+        sponsorAtomicMatchSettleCall::SELECTOR => {
+            let call = sponsorAtomicMatchSettleCall::abi_decode(tx_data)?;
+            let nullifier =
+                call.internalPartyMatchPayload.validReblindStatement.originalSharesNullifier;
+            Ok(u256_to_scalar(nullifier))
+        },
+        sponsorMalleableAtomicMatchSettleCall::SELECTOR => {
+            let call = sponsorMalleableAtomicMatchSettleCall::abi_decode(tx_data)?;
+            let nullifier =
+                call.internalPartyMatchPayload.validReblindStatement.originalSharesNullifier;
+            Ok(u256_to_scalar(nullifier))
+        },
+        _ => Err(AuthServerError::serde("Invalid selector for settlement tx")),
+    }
+}

--- a/auth/auth-server/src/telemetry/abi_helpers/mod.rs
+++ b/auth/auth-server/src/telemetry/abi_helpers/mod.rs
@@ -1,0 +1,11 @@
+//! Helpers for working with ABI definitions across chains
+
+#[cfg(feature = "arbitrum")]
+mod arbitrum;
+#[cfg(feature = "base")]
+mod base;
+
+#[cfg(feature = "arbitrum")]
+pub use arbitrum::*;
+#[cfg(feature = "base")]
+pub use base::*;

--- a/auth/auth-server/src/telemetry/mod.rs
+++ b/auth/auth-server/src/telemetry/mod.rs
@@ -3,6 +3,7 @@
 use renegade_util::telemetry::{configure_telemetry_with_metrics_config, metrics::MetricsConfig};
 
 use crate::{error::AuthServerError, Cli};
+pub mod abi_helpers;
 pub mod helpers;
 pub mod labels;
 pub mod quote_comparison;


### PR DESCRIPTION
### Purpose
This PR factors the chain-dependent functionality out of the telemetry module into a submodule `abi_helpers`. This is specifically the logic to parse nullifiers from chain-specific calldata.

### Todo
- Gas estimation module fails on base with the current implementation.

### Testing
- [x] Auth server builds and runs for both Base and Arbitrum