### PR TITLE
auth-server: gas-estimation: Add base gas estimation

### DIFF
--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -148,7 +148,7 @@ impl OnChainEventListenerExecutor {
             (refund_asset_ticker, refund_amount_whole)
         };
 
-        let (_, l2_base_fee, l1_cost_per_byte) = self
+        let estimate = self
             .gas_cost_sampler
             .sample_gas_prices()
             .await
@@ -162,8 +162,8 @@ impl OnChainEventListenerExecutor {
             (REMAINING_TIME_TAG.to_string(), remaining_time.as_secs().to_string()),
             (REFUND_ASSET_TAG.to_string(), refund_asset_ticker),
             (REFUND_AMOUNT_TAG.to_string(), refund_amount_whole.to_string()),
-            (L2_BASE_FEE_TAG.to_string(), l2_base_fee.to_string()),
-            (L1_COST_PER_BYTE_TAG.to_string(), l1_cost_per_byte.to_string()),
+            (L2_BASE_FEE_TAG.to_string(), estimate.l2_base_fee.to_string()),
+            (L1_COST_PER_BYTE_TAG.to_string(), estimate.l1_data_fee.to_string()),
         ];
 
         metrics::gauge!(GAS_SPONSORSHIP_VALUE, &labels).set(gas_sponsorship_value);

--- a/auth/auth-server/src/server/gas_estimation/constants.rs
+++ b/auth/auth-server/src/server/gas_estimation/constants.rs
@@ -2,15 +2,20 @@
 
 use std::time::Duration;
 
-use alloy::primitives::Address;
-use alloy_primitives::{hex, FixedBytes};
+use alloy_primitives::U256;
+
+use crate::server::helpers::u64_to_u256;
 
 /// A pessimistic overestimate of the gas cost of L2 execution for an external
 /// match, rounded up to the nearest 100k.
 
-// In the future, we can consider sampling execution gas costs from a recent
-// external match
-pub const ESTIMATED_L2_GAS: u64 = 3_600_000; // 3.6m
+/// The estimated L2 gas cost of submitting an external match settlement
+pub const ESTIMATED_L2_GAS_U64: u64 = 3_600_000; // 3.6m
+
+/// The estimated L2 gas cost as a U256
+/// In the future, we can consider sampling execution gas costs from a recent
+/// external match
+pub const ESTIMATED_L2_GAS: U256 = u64_to_u256(ESTIMATED_L2_GAS_U64);
 
 /// The approximate size in bytes of the calldata for an external match,
 /// accounting for an expected compression ratio.
@@ -19,10 +24,6 @@ pub const ESTIMATED_L2_GAS: u64 = 3_600_000; // 3.6m
 
 // In the future, we can consider sampling calldata from a recent external match
 pub const ESTIMATED_COMPRESSED_CALLDATA_SIZE_BYTES: usize = 6_000;
-
-/// The address of the `NodeInterface` precompile
-pub const NODE_INTERFACE_ADDRESS: Address =
-    Address(FixedBytes(hex!("00000000000000000000000000000000000000c8")));
 
 /// The interval at which to sample the gas cost of an external match
 pub const GAS_COST_SAMPLING_INTERVAL: Duration = Duration::from_secs(10);

--- a/auth/auth-server/src/server/gas_estimation/gas_oracles/arbitrum.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_oracles/arbitrum.rs
@@ -1,0 +1,62 @@
+//! Arbitrum specific gas oracle contract methods
+
+use alloy::primitives::{Address, U256};
+use alloy::sol;
+use alloy_primitives::{hex, FixedBytes};
+use renegade_darkpool_client::client::RenegadeProvider;
+
+use crate::server::helpers::u64_to_u256;
+
+use super::GasPriceEstimation;
+
+/// The address of the NodeInterface precompile
+pub const NODE_INTERFACE_ADDRESS: Address =
+    Address(FixedBytes(hex!("00000000000000000000000000000000000000c8")));
+
+// The ABI for the `NodeInterface` precompile:
+// https://docs.arbitrum.io/build-decentralized-apps/nodeinterface/overview
+sol! {
+    #[sol(rpc)]
+    contract NodeInterface {
+        function gasEstimateL1Component(address to, bool contractCreation, bytes calldata data) external payable returns (uint64 gasEstimateForL1, uint256 baseFee, uint256 l1BaseFeeEstimate);
+    }
+}
+
+/// Estimate the L1 gas component for a transaction with the given calldata
+///
+/// Returns a tuple containing:
+/// - `gas_estimate_for_l1`: the cost in units of L2 gas for including all of
+///   the provided calldata. Effectively equal to `compressed_calldata_size *
+///   l1_base_fee_estimate*16 / l2_base_fee`.
+/// - `l2_base_fee`: the cost in wei of a single unit of L2 gas.
+/// - `l1_data_fee`: the cost in wei (on the L2) of including a single byte of
+///   calldata (l1_base_fee_estimate*16).
+pub async fn estimate_l1_gas_component(
+    provider: RenegadeProvider,
+    to: Address,
+    data: Vec<u8>,
+) -> Result<GasPriceEstimation, String> {
+    let node_interface = NodeInterface::new(NODE_INTERFACE_ADDRESS, provider);
+
+    // As per https://github.com/OffchainLabs/nitro-contracts/blob/main/src/node-interface/NodeInterface.sol#L102-L103,
+    // this doesn't actually simulate the transaction, just estimates L1 portion of
+    // gas costs from the calldata size.
+    let res = node_interface
+        .gasEstimateL1Component(
+            to,
+            false, // contract_creation
+            data.into(),
+        )
+        .call()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let (gas_estimate_for_l1, l2_base_fee, l1_base_fee_estimate) =
+        (res.gasEstimateForL1, res.baseFee, res.l1BaseFeeEstimate);
+
+    Ok(GasPriceEstimation {
+        gas_estimate_for_l1: u64_to_u256(gas_estimate_for_l1),
+        l2_base_fee,
+        l1_data_fee: l1_base_fee_estimate * U256::from(16),
+    })
+}

--- a/auth/auth-server/src/server/gas_estimation/gas_oracles/base.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_oracles/base.rs
@@ -1,0 +1,44 @@
+//! Base specific gas oracle contract methods
+
+use alloy::primitives::{Address, U256};
+use alloy::{hex, sol};
+use alloy_primitives::FixedBytes;
+use renegade_darkpool_client::client::RenegadeProvider;
+use GasOracle::GasOracleInstance;
+
+use super::GasPriceEstimation;
+
+/// The address of the gas oracle contract on Base
+pub const GAS_ORACLE_ADDRESS: Address =
+    Address(FixedBytes(hex!("0x420000000000000000000000000000000000000F")));
+
+sol! {
+    #[sol(rpc)]
+    contract GasOracle {
+        function l1BaseFee() external view returns (uint256);
+        function gasPrice() external view returns (uint256);
+        function getL1GasUsed(bytes data) external view returns (uint256);
+    }
+}
+
+/// Estimate the L1 gas component for a transaction on Base
+pub async fn estimate_l1_gas_component(
+    provider: RenegadeProvider,
+    _to: Address,
+    data: Vec<u8>,
+) -> Result<GasPriceEstimation, String> {
+    let gas_oracle = GasOracleInstance::new(GAS_ORACLE_ADDRESS, provider);
+
+    // Sample values from the gas oracle contract
+    let l1_base_fee = gas_oracle.l1BaseFee().call().await.map_err(|e| e.to_string())?;
+    let gas_price = gas_oracle.gasPrice().call().await.map_err(|e| e.to_string())?;
+    let l1_gas_used =
+        gas_oracle.getL1GasUsed(data.into()).call().await.map_err(|e| e.to_string())?;
+
+    Ok(GasPriceEstimation {
+        gas_estimate_for_l1: l1_gas_used,
+        l2_base_fee: gas_price,
+        // Ethereum L1 charges 16 gas per non-zero byte of calldata
+        l1_data_fee: l1_base_fee * U256::from(16),
+    })
+}

--- a/auth/auth-server/src/server/gas_estimation/gas_oracles/mod.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_oracles/mod.rs
@@ -1,0 +1,22 @@
+//! Chain specific gas oracle contract methods
+use alloy_primitives::U256;
+
+#[cfg(feature = "arbitrum")]
+mod arbitrum;
+#[cfg(feature = "base")]
+mod base;
+
+#[cfg(feature = "arbitrum")]
+pub use arbitrum::estimate_l1_gas_component;
+#[cfg(feature = "base")]
+pub use base::estimate_l1_gas_component;
+
+/// Result of the gas price estimation
+pub struct GasPriceEstimation {
+    /// The L1 gas estimate in L2 gas units
+    pub gas_estimate_for_l1: U256,
+    /// The L2 base fee in wei
+    pub l2_base_fee: U256,
+    /// The L1 base fee estimate (per byte) in wei
+    pub l1_data_fee: U256,
+}

--- a/auth/auth-server/src/server/gas_estimation/mod.rs
+++ b/auth/auth-server/src/server/gas_estimation/mod.rs
@@ -6,6 +6,7 @@ use crate::server::Server;
 
 pub mod constants;
 pub mod gas_cost_sampler;
+pub mod gas_oracles;
 
 // ---------------
 // | Server Impl |

--- a/auth/auth-server/src/server/helpers.rs
+++ b/auth/auth-server/src/server/helpers.rs
@@ -81,6 +81,15 @@ pub fn sign_message(
     Ok(sig_bytes)
 }
 
+// ----------------------
+// | Conversion Helpers |
+// ----------------------
+
+/// Convert a u64 to a U256
+pub const fn u64_to_u256(value: u64) -> U256 {
+    U256::from_limbs([value, 0, 0, 0])
+}
+
 // ----------------
 // | Misc Helpers |
 // ----------------

--- a/auth/auth-server/src/telemetry/sources/mod.rs
+++ b/auth/auth-server/src/telemetry/sources/mod.rs
@@ -6,7 +6,7 @@ use renegade_api::http::external_match::AtomicMatchApiBundle;
 use renegade_circuit_types::{order::OrderSide, Amount};
 use renegade_common::types::token::Token;
 
-use crate::{error::AuthServerError, server::gas_estimation::constants::ESTIMATED_L2_GAS};
+use crate::{error::AuthServerError, server::gas_estimation::constants::ESTIMATED_L2_GAS_U64};
 
 /// The name of our quote source
 const RENEGADE_SOURCE_NAME: &str = "renegade";
@@ -98,7 +98,7 @@ impl QuoteResponse {
 /// Converts the `AtomicMatchApiBundle` into a `QuoteResponse`.
 impl From<&AtomicMatchApiBundle> for QuoteResponse {
     fn from(bundle: &AtomicMatchApiBundle) -> Self {
-        let gas = bundle.settlement_tx.gas.unwrap_or(ESTIMATED_L2_GAS);
+        let gas = bundle.settlement_tx.gas.unwrap_or(ESTIMATED_L2_GAS_U64);
         let fee_take = bundle.fees.total();
         Self {
             quote_mint: bundle.match_result.quote_mint.clone(),


### PR DESCRIPTION
### Purpose
This PR sets up gas estimation for Base. I generalized the existing Arbitrum implementation into a `gas_oracles` module which is feature flagged.

### Testing
- [x] Ran locally, was able to fetch an assembled bundle on Base Sepolia.
- [ ] Will test in testnet