### PR TITLE
funds-manager: server: add get-vault-balances endpoint

### DIFF
--- a/deploy/deploy-config.toml
+++ b/deploy/deploy-config.toml
@@ -42,3 +42,25 @@ cargo_features = "base"
 [services.base-mainnet-auth-server.deploy]
 environment = "base-mainnet"
 resource = "auth-server"
+
+#####################
+### Funds Manager ###
+#####################
+
+[services.testnet-funds-manager]
+[services.testnet-funds-manager.build]
+dockerfile = "funds-manager/Dockerfile"
+ecr_repo = "funds-manager-testnet"
+
+[services.testnet-funds-manager.deploy]
+environment = "testnet"
+resource = "funds-manager"
+
+[services.mainnet-funds-manager]
+[services.mainnet-funds-manager.build]
+dockerfile = "funds-manager/Dockerfile"
+ecr_repo = "funds-manager-mainnet"
+
+[services.mainnet-funds-manager.deploy]
+environment = "mainnet"
+resource = "funds-manager"

--- a/funds-manager/funds-manager-api/src/types/mod.rs
+++ b/funds-manager/funds-manager-api/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod fees;
 pub mod gas;
 pub mod hot_wallets;
 pub mod quoters;
+pub mod vaults;
 pub mod venue;
 
 /// The ping route

--- a/funds-manager/funds-manager-api/src/types/vaults.rs
+++ b/funds-manager/funds-manager-api/src/types/vaults.rs
@@ -1,0 +1,30 @@
+//! API types for vault management
+
+use serde::{Deserialize, Serialize};
+
+use super::hot_wallets::TokenBalance;
+
+// --------------
+// | Api Routes |
+// --------------
+
+/// The route to get the balances of a vault
+pub const GET_VAULT_BALANCES_ROUTE: &str = "get-vault-balances";
+
+// -------------
+// | Api Types |
+// -------------
+
+/// The request to get the balances of a vault
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetVaultBalancesRequest {
+    /// The name of the vault
+    pub vault: String,
+}
+
+/// The response containing the balances of a vault
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VaultBalancesResponse {
+    /// The balances of the vault
+    pub balances: Vec<TokenBalance>,
+}

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -5,6 +5,7 @@ pub mod gas_wallets;
 mod hot_wallets;
 mod queries;
 pub mod rpc_shim;
+pub mod vaults;
 pub mod withdraw;
 
 use alloy::{
@@ -21,10 +22,9 @@ use aws_config::SdkConfig as AwsConfig;
 use fireblocks_sdk::{
     apis::{
         blockchains_assets_beta_api::{ListAssetsParams, ListBlockchainsParams},
-        vaults_api::GetPagedVaultAccountsParams,
         Api,
     },
-    models::{TransactionResponse, VaultAccount},
+    models::TransactionResponse,
     Client as FireblocksSdk, ClientBuilder as FireblocksClientBuilder,
 };
 use renegade_common::types::chain::Chain;
@@ -40,9 +40,28 @@ use crate::{
 };
 use crate::{error::FundsManagerError, helpers::titlecase};
 
+// -------------
+// | Constants |
+// -------------
+
+/// The Fireblocks asset ID for ETH on Arbitrum One
+const ARB_ONE_ETH_ASSET_ID: &str = "ETH-AETH";
+/// The Fireblocks asset ID for ETH on Arbitrum Sepolia
+const ARB_SEPOLIA_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
+/// The Fireblocks asset ID for ETH on Base mainnet
+const BASE_MAINNET_ETH_ASSET_ID: &str = "BASECHAIN_ETH";
+/// The Fireblocks asset ID for ETH on Base Sepolia
+const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
+
+/// The error message emitted when an unsupported chain is configured.
+const ERR_UNSUPPORTED_CHAIN: &str = "Unsupported chain";
 /// The error message for when the Arbitrum blockchain is not found
 /// in the Fireblocks `/blockchains` endpoint response
 const ERR_ARB_CHAIN_NOT_FOUND: &str = "Arbitrum blockchain not found";
+
+// ---------
+// | Types |
+// ---------
 
 /// The source of a deposit
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -191,6 +210,18 @@ impl CustodyClient {
         Ok(None)
     }
 
+    /// Get the Fireblocks asset ID for the native asset (ETH) of the configured
+    /// chain.
+    pub(crate) fn get_native_eth_asset_id(&self) -> Result<String, FundsManagerError> {
+        match self.chain {
+            Chain::ArbitrumOne => Ok(ARB_ONE_ETH_ASSET_ID.to_string()),
+            Chain::ArbitrumSepolia => Ok(ARB_SEPOLIA_ETH_ASSET_ID.to_string()),
+            Chain::BaseMainnet => Ok(BASE_MAINNET_ETH_ASSET_ID.to_string()),
+            Chain::BaseSepolia => Ok(BASE_SEPOLIA_ETH_ASSET_ID.to_string()),
+            _ => Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
+        }
+    }
+
     /// Get the Fireblocks blockchain ID for the current chain
     async fn get_current_blockchain_id(&self) -> Result<String, FundsManagerError> {
         let list_blockchains_params = ListBlockchainsParams::builder()
@@ -212,28 +243,6 @@ impl CustodyClient {
             .find(|b| b.onchain.chain_id == Some(self.chain_id.to_string()))
             .map(|b| b.id)
             .ok_or(FundsManagerError::fireblocks(ERR_ARB_CHAIN_NOT_FOUND))
-    }
-
-    /// Get the vault account for a given asset and source
-    pub(crate) async fn get_vault_account(
-        &self,
-        name: &str,
-    ) -> Result<Option<VaultAccount>, FundsManagerError> {
-        let params = GetPagedVaultAccountsParams::builder()
-            .name_prefix(name.to_string())
-            .limit(100.0)
-            .build();
-
-        let vaults_resp =
-            self.fireblocks_client.sdk.vaults_api().get_paged_vault_accounts(params).await?;
-
-        for vault in vaults_resp.accounts.into_iter() {
-            if vault.name == name {
-                return Ok(Some(vault));
-            }
-        }
-
-        Ok(None)
     }
 
     /// Poll a fireblocks transaction for completion

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -52,6 +52,9 @@ const ARB_SEPOLIA_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
 const BASE_MAINNET_ETH_ASSET_ID: &str = "BASECHAIN_ETH";
 /// The Fireblocks asset ID for ETH on Base Sepolia
 const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
+/// The number of confirmations Fireblocks requires to consider a contract call
+/// final
+const FB_CONTRACT_CONFIRMATIONS: u64 = 3;
 
 /// The error message emitted when an unsupported chain is configured.
 const ERR_UNSUPPORTED_CHAIN: &str = "Unsupported chain";
@@ -347,9 +350,11 @@ impl CustodyClient {
         // Transfer the tokens
         let to_address = Address::from_str(to_address).map_err(FundsManagerError::parse)?;
         let tx = token.transfer(to_address, amount);
-        let pending_tx = tx.send().await.map_err(|e| {
+        let mut pending_tx = tx.send().await.map_err(|e| {
             FundsManagerError::arbitrum(format!("Failed to send transaction: {}", e))
         })?;
+
+        pending_tx.set_required_confirmations(FB_CONTRACT_CONFIRMATIONS);
 
         pending_tx.get_receipt().await.map_err(FundsManagerError::arbitrum)
     }

--- a/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/rpc_shim.rs
@@ -12,7 +12,6 @@ use fireblocks_sdk::{
         TransactionRequest, TransactionStatus, UnsignedMessage,
     },
 };
-use renegade_common::types::chain::Chain;
 use serde_json::Value;
 use tracing::error;
 
@@ -40,14 +39,6 @@ const ETH_ACCOUNTS_METHOD: &str = "eth_accounts";
 /// The method name for the `eth_signTypedData_v4` JSON-RPC method.
 const ETH_SIGN_TYPED_DATA_V4_METHOD: &str = "eth_signTypedData_v4";
 
-/// The Fireblocks asset ID for ETH on Arbitrum One
-const ARB_ONE_ETH_ASSET_ID: &str = "ETH-AETH";
-/// The Fireblocks asset ID for ETH on Arbitrum Sepolia
-const ARB_SEPOLIA_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
-/// The Fireblocks asset ID for ETH on Base mainnet
-const BASE_MAINNET_ETH_ASSET_ID: &str = "BASECHAIN_ETH";
-/// The Fireblocks asset ID for ETH on Base Sepolia
-const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
 /// The name of the Fireblocks vault custodying the Hyperliquid keypair
 const HYPERLIQUID_VAULT_NAME: &str = "Hyperliquid";
 /// The EIP-712 domain name for Hyperliquid L1 actions
@@ -61,8 +52,6 @@ const HYPERLIQUID_EXCHANGE_CHAIN_ID: U256 = U256([1337, 0, 0, 0]);
 
 /// The error message emitted when an unsupported RPC method is requested.
 const ERR_UNSUPPORTED_METHOD: &str = "Unsupported RPC method";
-/// The error message emitted when an unsupported chain is configured.
-const ERR_UNSUPPORTED_CHAIN: &str = "Unsupported chain";
 /// The error message emitted when the Hyperliquid vault is not found.
 const ERR_HYPERLIQUID_VAULT_NOT_FOUND: &str = "Hyperliquid vault not found";
 /// The error message emitted when no addresses are found for the Hyperliquid
@@ -240,18 +229,6 @@ impl CustodyClient {
         }
 
         Ok(())
-    }
-
-    /// Get the Fireblocks asset ID for the native asset (ETH) of the configured
-    /// chain.
-    fn get_native_eth_asset_id(&self) -> Result<String, FundsManagerError> {
-        match self.chain {
-            Chain::ArbitrumOne => Ok(ARB_ONE_ETH_ASSET_ID.to_string()),
-            Chain::ArbitrumSepolia => Ok(ARB_SEPOLIA_ETH_ASSET_ID.to_string()),
-            Chain::BaseMainnet => Ok(BASE_MAINNET_ETH_ASSET_ID.to_string()),
-            Chain::BaseSepolia => Ok(BASE_SEPOLIA_ETH_ASSET_ID.to_string()),
-            _ => Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
-        }
     }
 
     /// Get the Fireblocks vault ID for the Hyperliquid vault.

--- a/funds-manager/funds-manager-server/src/custody_client/vaults.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/vaults.rs
@@ -1,0 +1,95 @@
+//! Handlers for managing Fireblocks vaults
+
+use fireblocks_sdk::{
+    apis::{
+        blockchains_assets_beta_api::GetAssetByIdParams, vaults_api::GetPagedVaultAccountsParams,
+        Api,
+    },
+    models::{VaultAccount, VaultAsset},
+};
+use funds_manager_api::hot_wallets::TokenBalance;
+use futures::future::try_join_all;
+
+use crate::error::FundsManagerError;
+
+use super::CustodyClient;
+
+impl CustodyClient {
+    /// Get the vault account for a given asset and source
+    pub(crate) async fn get_vault_account(
+        &self,
+        name: &str,
+    ) -> Result<Option<VaultAccount>, FundsManagerError> {
+        let params = GetPagedVaultAccountsParams::builder()
+            .name_prefix(name.to_string())
+            .limit(100.0)
+            .build();
+
+        let vaults_resp =
+            self.fireblocks_client.sdk.vaults_api().get_paged_vault_accounts(params).await?;
+
+        for vault in vaults_resp.accounts.into_iter() {
+            if vault.name == name {
+                return Ok(Some(vault));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Get the non-zero token balances of a vault
+    pub(crate) async fn get_vault_token_balances(
+        &self,
+        vault_name: &str,
+    ) -> Result<Vec<TokenBalance>, FundsManagerError> {
+        let vault = self
+            .get_vault_account(vault_name)
+            .await?
+            .ok_or(FundsManagerError::fireblocks(format!("vault {vault_name} not found")))?;
+
+        let futures =
+            vault.assets.into_iter().map(|asset| self.try_get_token_balance_for_asset(asset));
+
+        let balances = try_join_all(futures).await?;
+
+        Ok(balances.into_iter().flatten().collect())
+    }
+
+    /// Try to construct a `TokenBalance` for a given asset.
+    ///
+    /// If the asset does not have an address (e.g. a native asset), this will
+    /// return `None`.
+    async fn try_get_token_balance_for_asset(
+        &self,
+        asset: VaultAsset,
+    ) -> Result<Option<TokenBalance>, FundsManagerError> {
+        let total_f64: f64 = asset.total.parse().map_err(FundsManagerError::parse)?;
+        if total_f64 == 0.0 {
+            return Ok(None);
+        }
+
+        let params = GetAssetByIdParams::builder().id(asset.id.clone()).build();
+        let asset_resp = self
+            .fireblocks_client
+            .sdk
+            .apis()
+            .blockchains_assets_beta_api()
+            .get_asset_by_id(params)
+            .await?;
+
+        let asset_onchain_data = asset_resp.onchain.ok_or(FundsManagerError::fireblocks(
+            format!("asset {} has no onchain data", &asset.id),
+        ))?;
+
+        // Skip if the asset has no address, e.g. if it's a native asset
+        if asset_onchain_data.address.is_none() {
+            return Ok(None);
+        }
+        let mint = asset_onchain_data.address.unwrap();
+
+        let amount_f64 = total_f64 * 10_f64.powf(asset_onchain_data.decimals as f64);
+        let amount: u128 = amount_f64.floor() as u128;
+
+        Ok(Some(TokenBalance { mint, amount }))
+    }
+}

--- a/funds-manager/funds-manager-server/src/error.rs
+++ b/funds-manager/funds-manager-server/src/error.rs
@@ -28,6 +28,8 @@ pub enum FundsManagerError {
     JsonRpc(String),
     /// An error with the price reporter
     PriceReporter(PriceReporterClientError),
+    /// An error converting between types
+    Conversion(String),
     /// A miscellaneous error
     Custom(String),
 }
@@ -74,6 +76,11 @@ impl FundsManagerError {
         FundsManagerError::JsonRpc(msg.to_string())
     }
 
+    /// Create a conversion error
+    pub fn conversion<T: ToString>(msg: T) -> FundsManagerError {
+        FundsManagerError::Conversion(msg.to_string())
+    }
+
     /// Create a custom error
     pub fn custom<T: ToString>(msg: T) -> FundsManagerError {
         FundsManagerError::Custom(msg.to_string())
@@ -93,6 +100,7 @@ impl Display for FundsManagerError {
             FundsManagerError::Custom(e) => write!(f, "Uncategorized error: {}", e),
             FundsManagerError::Fireblocks(e) => write!(f, "Fireblocks error: {}", e),
             FundsManagerError::PriceReporter(e) => write!(f, "Price reporter error: {}", e),
+            FundsManagerError::Conversion(e) => write!(f, "Conversion error: {}", e),
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -13,6 +13,7 @@ use alloy::{
 use aws_config::SdkConfig;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::client::Client as SecretsManagerClient;
+use bigdecimal::{BigDecimal, FromPrimitive, RoundingMode, ToPrimitive};
 use renegade_common::types::chain::Chain;
 use renegade_util::err_str;
 
@@ -182,4 +183,17 @@ pub fn titlecase(s: &str) -> String {
         .map(|w| w.chars().next().unwrap().to_uppercase().to_string() + &w[1..])
         .collect::<Vec<String>>()
         .join(" ")
+}
+
+/// Round an f64 value up to the given number of decimal places
+pub fn round_up(value: f64, decimals: i64) -> Result<f64, FundsManagerError> {
+    let value_bigdecimal = BigDecimal::from_f64(value).ok_or(FundsManagerError::conversion(
+        format!("Failed to convert {value} to a bigdecimal"),
+    ))?;
+
+    let rounded_value_bigdecimal = value_bigdecimal.with_scale_round(decimals, RoundingMode::Up);
+
+    rounded_value_bigdecimal.to_f64().ok_or(FundsManagerError::conversion(format!(
+        "Failed to convert {rounded_value_bigdecimal} to a f64"
+    )))
 }


### PR DESCRIPTION
This PR adds a `/custody/get-vault-balances` endpoint to the funds manager. This will be used to account for vault holdings in our NAV metrics.

### Testing
- [x] Ran a local funds manager & fetched Arbitrum Sepolia quoter vault balances