### PR TITLE
funds-manager: custody_client: withdraw: round HL transfer amounts, wait 3 confs

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -52,6 +52,9 @@ const ARB_SEPOLIA_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
 const BASE_MAINNET_ETH_ASSET_ID: &str = "BASECHAIN_ETH";
 /// The Fireblocks asset ID for ETH on Base Sepolia
 const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
+/// The number of confirmations Fireblocks requires to consider a contract call
+/// final
+const FB_CONTRACT_CONFIRMATIONS: u64 = 3;
 
 /// The error message emitted when an unsupported chain is configured.
 const ERR_UNSUPPORTED_CHAIN: &str = "Unsupported chain";
@@ -347,9 +350,11 @@ impl CustodyClient {
         // Transfer the tokens
         let to_address = Address::from_str(to_address).map_err(FundsManagerError::parse)?;
         let tx = token.transfer(to_address, amount);
-        let pending_tx = tx.send().await.map_err(|e| {
+        let mut pending_tx = tx.send().await.map_err(|e| {
             FundsManagerError::arbitrum(format!("Failed to send transaction: {}", e))
         })?;
+
+        pending_tx.set_required_confirmations(FB_CONTRACT_CONFIRMATIONS);
 
         pending_tx.get_receipt().await.map_err(FundsManagerError::arbitrum)
     }

--- a/funds-manager/funds-manager-server/src/error.rs
+++ b/funds-manager/funds-manager-server/src/error.rs
@@ -28,6 +28,8 @@ pub enum FundsManagerError {
     JsonRpc(String),
     /// An error with the price reporter
     PriceReporter(PriceReporterClientError),
+    /// An error converting between types
+    Conversion(String),
     /// A miscellaneous error
     Custom(String),
 }
@@ -74,6 +76,11 @@ impl FundsManagerError {
         FundsManagerError::JsonRpc(msg.to_string())
     }
 
+    /// Create a conversion error
+    pub fn conversion<T: ToString>(msg: T) -> FundsManagerError {
+        FundsManagerError::Conversion(msg.to_string())
+    }
+
     /// Create a custom error
     pub fn custom<T: ToString>(msg: T) -> FundsManagerError {
         FundsManagerError::Custom(msg.to_string())
@@ -93,6 +100,7 @@ impl Display for FundsManagerError {
             FundsManagerError::Custom(e) => write!(f, "Uncategorized error: {}", e),
             FundsManagerError::Fireblocks(e) => write!(f, "Fireblocks error: {}", e),
             FundsManagerError::PriceReporter(e) => write!(f, "Price reporter error: {}", e),
+            FundsManagerError::Conversion(e) => write!(f, "Conversion error: {}", e),
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -13,6 +13,7 @@ use alloy::{
 use aws_config::SdkConfig;
 use aws_sdk_s3::Client as S3Client;
 use aws_sdk_secretsmanager::client::Client as SecretsManagerClient;
+use bigdecimal::{BigDecimal, FromPrimitive, RoundingMode, ToPrimitive};
 use renegade_common::types::chain::Chain;
 use renegade_util::err_str;
 
@@ -182,4 +183,17 @@ pub fn titlecase(s: &str) -> String {
         .map(|w| w.chars().next().unwrap().to_uppercase().to_string() + &w[1..])
         .collect::<Vec<String>>()
         .join(" ")
+}
+
+/// Round an f64 value up to the given number of decimal places
+pub fn round_up(value: f64, decimals: i64) -> Result<f64, FundsManagerError> {
+    let value_bigdecimal = BigDecimal::from_f64(value).ok_or(FundsManagerError::conversion(
+        format!("Failed to convert {value} to a bigdecimal"),
+    ))?;
+
+    let rounded_value_bigdecimal = value_bigdecimal.with_scale_round(decimals, RoundingMode::Up);
+
+    rounded_value_bigdecimal.to_f64().ok_or(FundsManagerError::conversion(format!(
+        "Failed to convert {rounded_value_bigdecimal} to a f64"
+    )))
 }


### PR DESCRIPTION
This PR makes a couple tweaks to the `/withdraw-to-hyperliquid` code paths in order to smooth out `Insufficient funds` errors we see in Fireblocks when trying to transfer from the HL vault to the bridge:
1. We round up the requested withdrawal amount (and the derived transfer amount from the quoter hot wallet, if necessary) to the nearest 6th decimal place (USDC decimals). This is to obviate any f64 precision issues due to requested withdrawal amount w/ higher precision than 6 decimal places.
2. For ERC20 transfers, we wait 3 confirmations - this is the [default # of confirmations](https://support.fireblocks.io/hc/en-us/articles/10883496786204-Default-Deposit-Control-and-Confirmation-Policy) used by Fireblocks for contract calls, and could explain why even after transferring from the hot wallet to the HL vault, we sometimes see `Insufficient funds` when attempting to transfer to the bridge.

### Testing
- [ ] Test in testnet by triggering hedge syncs