### PR TITLE
funds-manager-server: hot-wallets: Top up quoter wallet gas before swap

### DIFF
--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -213,7 +213,7 @@ impl ChainConfig {
         };
         let darkpool_client =
             MuxDarkpoolClient::new(chain, conf).map_err(FundsManagerError::custom)?;
-        let chain_id = darkpool_client.chain_id().await.map_err(FundsManagerError::arbitrum)?;
+        let chain_id = darkpool_client.chain_id().await.map_err(FundsManagerError::on_chain)?;
 
         // Build a custody client
         let gas_sponsor_address =

--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -202,13 +202,13 @@ impl CustodyClient {
         let latest_block = client
             .get_block(BlockId::latest())
             .await
-            .map_err(FundsManagerError::arbitrum)?
-            .ok_or(FundsManagerError::arbitrum("No latest block found".to_string()))?;
+            .map_err(FundsManagerError::on_chain)?
+            .ok_or(FundsManagerError::on_chain("No latest block found".to_string()))?;
 
         let latest_basefee = latest_block
             .header
             .base_fee_per_gas
-            .ok_or(FundsManagerError::arbitrum("No basefee found".to_string()))?
+            .ok_or(FundsManagerError::on_chain("No basefee found".to_string()))?
             as u128;
 
         let tx = TransactionRequest::default()
@@ -217,10 +217,8 @@ impl CustodyClient {
             .with_value(amount_units)
             .with_gas_price(latest_basefee * 2);
 
-        let pending_tx = client.send_transaction(tx).await.map_err(FundsManagerError::arbitrum)?;
-
-        let receipt = pending_tx.get_receipt().await.map_err(FundsManagerError::arbitrum)?;
-
+        let pending_tx = client.send_transaction(tx).await.map_err(FundsManagerError::on_chain)?;
+        let receipt = pending_tx.get_receipt().await.map_err(FundsManagerError::on_chain)?;
         Ok(receipt)
     }
 }

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -153,7 +153,7 @@ impl CustodyClient {
 
         let token = IERC20::new(token_address, self.arbitrum_provider.clone());
         let balance =
-            token.balanceOf(wallet_address).call().await.map_err(FundsManagerError::arbitrum)?;
+            token.balanceOf(wallet_address).call().await.map_err(FundsManagerError::on_chain)?;
 
         u256_try_into_u128(balance).map_err(FundsManagerError::parse)
     }

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -21,6 +21,11 @@ use crate::{
     helpers::{create_secrets_manager_entry_with_description, get_secret, IERC20},
 };
 
+/// The desired gas balance on the quoter hot wallet
+///
+/// Set to roughly $100 worth of ETH at the time of writing
+const DEFAULT_QUOTER_GAS_TOP_UP_AMOUNT: f64 = 0.04; // ETH
+
 impl CustodyClient {
     // ------------
     // | Handlers |
@@ -122,6 +127,8 @@ impl CustodyClient {
     // | Helpers |
     // -----------
 
+    // --- Hot Wallet Metadata --- //
+
     /// The secret name for a hot wallet
     pub(crate) fn hot_wallet_secret_name(address: &str) -> String {
         format!("hot-wallet-{address}")
@@ -156,5 +163,13 @@ impl CustodyClient {
             token.balanceOf(wallet_address).call().await.map_err(FundsManagerError::on_chain)?;
 
         u256_try_into_u128(balance).map_err(FundsManagerError::parse)
+    }
+
+    // --- Quoter Helpers --- //
+
+    /// Top up the gas (ether) balance on the quoter hot wallet
+    pub(crate) async fn top_up_quoter_hot_wallet_gas(&self) -> Result<(), FundsManagerError> {
+        let hot_wallet = self.get_quoter_hot_wallet().await?;
+        self.top_up_gas(&hot_wallet.address, DEFAULT_QUOTER_GAS_TOP_UP_AMOUNT).await
     }
 }

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -264,7 +264,7 @@ impl CustodyClient {
             .map_err(FundsManagerError::fireblocks)
     }
 
-    // --- Arbitrum JSON RPC --- //
+    // --- JSON RPC --- //
 
     /// Get an instance of a signer with the http provider attached
     fn get_signing_provider(&self, wallet: PrivateKeySigner) -> DynProvider {

--- a/funds-manager/funds-manager-server/src/error.rs
+++ b/funds-manager/funds-manager-server/src/error.rs
@@ -11,7 +11,7 @@ use fireblocks_sdk::{apis::Error as FireblocksApiError, FireblocksError};
 #[derive(Debug, Clone)]
 pub enum FundsManagerError {
     /// An error with the arbitrum client
-    Arbitrum(String),
+    OnChain(String),
     /// An error with a database query
     Db(String),
     /// An error with Fireblocks operations
@@ -37,8 +37,8 @@ pub enum FundsManagerError {
 #[allow(clippy::needless_pass_by_value)]
 impl FundsManagerError {
     /// Create an arbitrum error
-    pub fn arbitrum<T: ToString>(msg: T) -> FundsManagerError {
-        FundsManagerError::Arbitrum(msg.to_string())
+    pub fn on_chain<T: ToString>(msg: T) -> FundsManagerError {
+        FundsManagerError::OnChain(msg.to_string())
     }
 
     /// Create a database error
@@ -90,7 +90,7 @@ impl FundsManagerError {
 impl Display for FundsManagerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FundsManagerError::Arbitrum(e) => write!(f, "Arbitrum error: {}", e),
+            FundsManagerError::OnChain(e) => write!(f, "On-chain error: {}", e),
             FundsManagerError::Db(e) => write!(f, "Database error: {}", e),
             FundsManagerError::Http(e) => write!(f, "HTTP error: {}", e),
             FundsManagerError::Parse(e) => write!(f, "Parse error: {}", e),

--- a/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
+++ b/funds-manager/funds-manager-server/src/fee_indexer/redeem_fees.rs
@@ -172,7 +172,7 @@ impl Indexer {
             .darkpool_client
             .check_nullifier_used(nullifier)
             .await
-            .map_err(err_str!(FundsManagerError::Arbitrum))?
+            .map_err(err_str!(FundsManagerError::on_chain))?
         {
             warn!("nullifier not seen on-chain after redemption, tx: {tx_hash}");
             return Ok(());

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -217,7 +217,7 @@ impl MetricsRecorder {
         let events = filter
             .query()
             .await
-            .map_err(|_| FundsManagerError::arbitrum("failed to create transfer stream"))?;
+            .map_err(|_| FundsManagerError::on_chain("failed to create transfer stream"))?;
 
         // Find the transfer event that matches our transaction hash
         let transfer_event = events


### PR DESCRIPTION
### Purpose
This PR makes a quality of life improvement to top-up quoter hot wallet gas (ether) balances before swapping. This is done within a top-up tolerance, set to the default gas wallet top up tolerance of 10%.

I generalized the helpers for gas wallet top ups to allow for this flow.

### Testing
- [ ] Testing in testnet