### PR TITLE
funds-manager: Add warp tracing to requests

### DIFF
--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -348,6 +348,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(create_hot_wallet)
         .or(rpc)
         .or(backwards_compatibility_routes)
+        .boxed()
+        .with(warp::trace::request())
         .recover(handle_rejection);
 
     warp::serve(routes).run(([0, 0, 0, 0], port)).await;


### PR DESCRIPTION
### Purpose
This PR adds the warp tracing filter to all requests in the funds manager. This will allow us to track down request info for erroring requests easier.

I'll use this to debug some funds manager issues fetching vaults.

### Testing
- [ ] Testing in testnet