### PR TITLE
funds-manager: execution-client: Use LiFi API key

### DIFF
--- a/funds-manager/Dockerfile
+++ b/funds-manager/Dockerfile
@@ -54,5 +54,7 @@ RUN apt-get update && \
 # Copy the binary from the build stage
 COPY --from=builder /build/target/release/funds-manager /bin/funds-manager
 
+# Set log filtering
+ENV RUST_LOG="funds_manager=info,fireblocks_sdk=off,warp=warn"
 ENTRYPOINT ["/bin/funds-manager"]
 CMD ["--datadog-logging"]

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -41,7 +41,9 @@ ethers = "2"
 
 # === Renegade Dependencies === #
 price-reporter-client = { path = "../../price-reporter-client" }
-renegade-darkpool-client = { package = "darkpool-client", workspace = true, features = [ "all-chains" ] }
+renegade-darkpool-client = { package = "darkpool-client", workspace = true, features = [
+    "all-chains",
+] }
 renegade-api = { package = "external-api", workspace = true }
 renegade-common = { package = "common", workspace = true }
 renegade-config = { package = "config", workspace = true }

--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -183,7 +183,7 @@ pub struct ChainConfig {
 
     // --- Execution Venue Params --- //
     /// The execution venue api key
-    pub execution_venue_api_key: String,
+    pub execution_venue_api_key: Option<String>,
     /// The execution venue base url
     pub execution_venue_base_url: String,
 }


### PR DESCRIPTION
### Purpose
This PR adds the LiFi API key to all execution requests when configured. The requests are valid without an API key, but [rate limits]() are 120x higher with a key configured. 

This is done to prevent the rate limiting issues we ran into when going x-chain.

### Testing
- [ ] Test in mainnet