### PR TITLE
funds-manager: custody_client: poll ext tx indexing in fb

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -217,11 +217,11 @@ impl CustodyClient {
 
         // Transfer the USDC to the address used by the Hyperliquid account.
         let tx = self.erc20_transfer(usdc_mint, hyperliquid_addr, amount, hot_wallet).await?;
+        let tx_hash = tx.transaction_hash;
 
-        info!(
-            "Withdrew {amount} USDC from hot wallet to {hyperliquid_addr}. Tx: {:#x}",
-            tx.transaction_hash
-        );
+        self.poll_fireblocks_external_transaction(tx_hash).await?;
+
+        info!("Withdrew {amount} USDC from hot wallet to {hyperliquid_addr}. Tx: {:#x}", tx_hash);
 
         Ok(())
     }


### PR DESCRIPTION
This PR tweaks the manner in which we await the completion of the first leg of a Hyperliquid deposit, the transfer from the quoter hot wallet to the Hyperliquid vault deposit address. Since this is an externally-initiated transaction, we have to wait for Fireblocks to index it. 

This includes not only waiting for the same number of confirmations as Fireblocks does (3), but also waiting for the transaction to be processed on their end and for vault balances to updated, before the second leg can be invoked.

To this end, we add a new method, `poll_fireblocks_external_transaction`, which polls the Fireblocks API until it has indexed a given transaction hash into account history.

### Testing
- [x] Tested by running a local funds manager and triggering a HL deposit via the admin panel. Asserted that the two-leg deposit succeeded without issue