### PR TITLE
auth-server: api-helpers: settlement: Record malleable bundles in store

### DIFF
--- a/auth/auth-server/src/bundle_store/helpers.rs
+++ b/auth/auth-server/src/bundle_store/helpers.rs
@@ -1,6 +1,6 @@
 //! Helper methods for the bundle store
 use alloy_primitives::{hex, keccak256};
-use renegade_api::http::external_match::ApiExternalMatchResult;
+use renegade_api::http::external_match::{ApiBoundedMatchResult, ApiExternalMatchResult};
 use renegade_circuit_types::wallet::Nullifier;
 use renegade_constants::Scalar;
 
@@ -33,5 +33,17 @@ pub fn generate_bundle_id(
     let mut bytes = nullifier.to_bytes_be();
     bytes.extend(Scalar::from(quote_amt).to_bytes_be());
     bytes.extend(Scalar::from(base_amt).to_bytes_be());
+    Ok(hex::encode(keccak256::<&[u8]>(&bytes)))
+}
+
+/// Generates a deterministic bundle ID for a malleable match
+///
+/// See the disclaimers in `generate_bundle_id` for more details.
+pub fn generate_malleable_bundle_id(
+    match_result: &ApiBoundedMatchResult,
+    nullifier: &Nullifier,
+) -> Result<String, AuthServerError> {
+    let mut bytes = serde_json::to_vec(match_result).map_err(AuthServerError::serde)?;
+    bytes.extend(nullifier.to_bytes_be());
     Ok(hex::encode(keccak256::<&[u8]>(&bytes)))
 }

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -1,5 +1,10 @@
 //! Handlers for external match endpoints
 
+mod assemble_malleable_quote;
+mod assemble_quote;
+mod direct_match;
+mod quote;
+
 use auth_server_api::GasSponsorshipInfo;
 use bytes::Bytes;
 use http::{HeaderMap, Method, Response, StatusCode};
@@ -10,13 +15,9 @@ use crate::{
     error::AuthServerError, server::Server, telemetry::helpers::record_relayer_request_500,
     ApiError,
 };
+pub(crate) use assemble_malleable_quote::SponsoredAssembleMalleableQuoteResponseCtx;
 
 use super::{get_sdk_version, log_unsuccessful_relayer_request};
-
-mod assemble_malleable_quote;
-mod assemble_quote;
-mod direct_match;
-mod quote;
 
 // --------------------
 // | Request Contexts |

--- a/auth/auth-server/src/server/api_handlers/settlement.rs
+++ b/auth/auth-server/src/server/api_handlers/settlement.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 use super::{MatchBundleResponseCtx, Server};
 use crate::bundle_store::{helpers::generate_bundle_id, BundleContext};
 use crate::error::AuthServerError;
-use crate::telemetry::abi_helpers::extract_nullifier_from_match_bundle;
+use crate::server::api_handlers::external_match::SponsoredAssembleMalleableQuoteResponseCtx;
+use crate::telemetry::abi_helpers::{
+    extract_nullifier_from_malleable_match_bundle, extract_nullifier_from_match_bundle,
+};
 
 impl Server {
     /// Write the bundle context to the store, handling gas sponsorship if
@@ -50,6 +53,16 @@ impl Server {
         }
 
         Ok(bundle_id)
+    }
+
+    /// Write the bundle context for a malleable match to the store
+    pub async fn write_malleable_bundle_context(
+        &self,
+        ctx: &SponsoredAssembleMalleableQuoteResponseCtx,
+    ) -> Result<String, AuthServerError> {
+        let resp = ctx.response();
+        let nullifier = extract_nullifier_from_malleable_match_bundle(&resp.match_bundle)?;
+        todo!()
     }
 
     /// Determines the appropriate `ApiExternalMatchResult` to use for bundle ID

--- a/auth/auth-server/src/telemetry/abi_helpers/arbitrum.rs
+++ b/auth/auth-server/src/telemetry/abi_helpers/arbitrum.rs
@@ -1,7 +1,7 @@
 //! Telemetry helpers for Arbitrum specific ABI functionality
 
 use alloy_sol_types::SolCall;
-use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_api::http::external_match::{AtomicMatchApiBundle, MalleableAtomicMatchApiBundle};
 use renegade_circuit_types::wallet::Nullifier;
 use renegade_constants::Scalar;
 use renegade_darkpool_client::arbitrum::{
@@ -18,16 +18,26 @@ use crate::{
     },
 };
 
-/// Extracts the nullifier from a match bundle's settlement transaction
-///
-/// This function attempts to decode the settlement transaction data in two
-/// ways:
-/// 1. As a standard atomic match settle call
-/// 2. As a match settle with receiver call
+/// Extract the nullifier from a match bundle
 pub fn extract_nullifier_from_match_bundle(
     match_bundle: &AtomicMatchApiBundle,
 ) -> Result<Nullifier, AuthServerError> {
     let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
+    extract_nullifier_from_settlement_tx_calldata(tx_data)
+}
+
+/// Extract the nullifier from a malleable match bundle
+pub fn extract_nullifier_from_malleable_match_bundle(
+    match_bundle: &MalleableAtomicMatchApiBundle,
+) -> Result<Nullifier, AuthServerError> {
+    let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
+    extract_nullifier_from_settlement_tx_calldata(tx_data)
+}
+
+/// Extracts the nullifier from a match bundle's settlement transaction
+pub fn extract_nullifier_from_settlement_tx_calldata(
+    tx_data: &[u8],
+) -> Result<Nullifier, AuthServerError> {
     let selector = get_selector(tx_data)?;
 
     // Retrieve serialized match payload from the transaction data

--- a/auth/auth-server/src/telemetry/abi_helpers/base.rs
+++ b/auth/auth-server/src/telemetry/abi_helpers/base.rs
@@ -1,7 +1,7 @@
 //! Telemetry helpers for Base specific ABI functionality
 
 use alloy_sol_types::SolCall;
-use renegade_api::http::external_match::AtomicMatchApiBundle;
+use renegade_api::http::external_match::{AtomicMatchApiBundle, MalleableAtomicMatchApiBundle};
 use renegade_circuit_types::wallet::Nullifier;
 use renegade_darkpool_client::conversion::u256_to_scalar;
 use renegade_solidity_abi::IDarkpool::{
@@ -16,6 +16,21 @@ pub fn extract_nullifier_from_match_bundle(
     match_bundle: &AtomicMatchApiBundle,
 ) -> Result<Nullifier, AuthServerError> {
     let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
+    extract_nullifier_from_settlement_tx_calldata(tx_data)
+}
+
+/// Extract the nullifier from a malleable match bundle
+pub fn extract_nullifier_from_malleable_match_bundle(
+    match_bundle: &MalleableAtomicMatchApiBundle,
+) -> Result<Nullifier, AuthServerError> {
+    let tx_data = match_bundle.settlement_tx.input.input().unwrap_or_default();
+    extract_nullifier_from_settlement_tx_calldata(tx_data)
+}
+
+/// Extract a nullifier from settlement tx calldata
+fn extract_nullifier_from_settlement_tx_calldata(
+    tx_data: &[u8],
+) -> Result<Nullifier, AuthServerError> {
     let selector = get_selector(tx_data)?;
 
     match selector {


### PR DESCRIPTION
### Purpose
This PR records malleable match bundles in the bundle store. The bundle ID is generated from the malleable match rather than an external match -- which is not known until the tx is submitted.

### Todo
- Fetch malleable matches in the on-chain event listener to resolve these bundles.

### Testing
- [x] Existing auth server functionality works