### PR TITLE
auth-server: chain-events: abis: Parse external matches from calldata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abi"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#f586c24f0042e410448dd8f46c18cacdfffba45e"
+source = "git+https://github.com/renegade-fi/renegade-solidity-contracts#f7f29c3181919ad88da712f820f4d38fb7adfc94"
 dependencies = [
  "alloy",
 ]
@@ -110,9 +110,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd58a5dd60681ca6faffe2abf6507409e8f4f18e528c931930371e3a36df13a"
+checksum = "0093d23bf026b580c1f66ed3a053d8209c104a446c5264d3ad99587f6edef24e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5848366a4f08dca1caca0a6151294a4799fe2e59ba25df100491d92e0b921b1c"
+checksum = "517e5acbd38b6d4c59da380e8bbadc6d365bf001903ce46cf5521c53c647e07b"
 dependencies = [
  "alloy-primitives 1.1.2",
  "num_enum",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2123d190c823301be54e14a12ef10c00823d90047a140aa41650c26668d5b1"
+checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 1.1.2",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b71e608e06b3d55169595c8ff39bd2177389508b0e91da8400b48d88d3afd"
+checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "210f50a648d28ee4266ff42523186efab61dd54d2ab2f8853fe38ad45d254756"
+checksum = "ebf25443920ecb9728cb087fe4dc04a0b290bd6ac85638c58fe94aba70f1a44e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2126e39e1557f0e661e0a5a36748a0bf280490ca2c0a1d149a55d2c2c8675"
+checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -291,9 +291,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf47e07c0dbcb8f1fa2c903d9eb32b14fec3dc04e60e7fee29fc0d3799fba34"
+checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 1.1.2",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83498cbeb8353b78985ad6c127fc7376767c5d341e05e3f641076d61f3a78471"
+checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-sol-types 1.1.2",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c443287af072731c28fb6c09b62fb882257a4d20fc151bc110357a56fb19559"
+checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad99d5b76aed5ed7bd752a9ef5c5e4acf74e8956df80080a492dc83e96d7067e"
+checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39721fb4c0526ec2c98ad47f5010ea6930ba121e56f46a0ff2746ed761e92a40"
+checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -442,9 +442,9 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru 0.13.0",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -456,16 +456,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbeb2dd970e7d70d2d408bc6fba391ad66406d766312399a42d6f93a9586f818"
+checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.1.2",
  "alloy-transport",
  "bimap",
  "futures",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "serde",
  "serde_json",
  "tokio",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e59b7ec68078fcae32736052a5f56ffe1a01da267c10692757a9ae70698bb99"
+checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.1.2",
@@ -512,7 +512,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "tokio",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933d9ad7e50156f1cd5574227e6f15c6d237d50006b1754e3f3564d6e8293ed5"
+checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-rpc-types-eth",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7233023bbb100b0527e5eb7ad9fe87b74a1dfed75bb202302c318f1cc68094ab"
+checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e393e02f83d17384a7595d5288d1217cab0863ad5f10b0824325d814e7bf21c5"
+checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
 dependencies = [
  "alloy-primitives 1.1.2",
  "serde",
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c2b3bd2a36df4417a349a5405b5130af948a72bf2f305fc0084cac5fbe5cc1"
+checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4c2404b7ee0bd81900d63c61adef877992f430d7c932d4f3ce2a79e3f3f822"
+checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
 dependencies = [
  "alloy-primitives 1.1.2",
  "alloy-rpc-types-eth",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9f6973e552b33c9e0733165ef3f6cea3cc70617d5768260e98a29aab5e974e"
+checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
 dependencies = [
  "alloy-primitives 1.1.2",
  "serde",
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873c4e578c20af87b62b66d6f6c1cd81ab192f52515d4e63ddfecba1ac69216b"
+checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
 dependencies = [
  "alloy-primitives 1.1.2",
  "async-trait",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bbc5479f66f49f06c91b69c4ffd33b4df3b6f286c55c2dc94fb7ac8571053a"
+checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db88a480955a3a1a6dbcd51076b03f522c64fb4ecb74545c4d38b0ca58d9fbe6"
+checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.1.2",
@@ -778,7 +778,7 @@ dependencies = [
  "derive_more 2.0.1",
  "futures",
  "futures-utils-wasm",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -791,13 +791,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba0d8eace41128b4dbf87adff5d63347b8004977aa7f9c62b63308539dd2a29"
+checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -806,9 +806,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d39c87d5b9f3dd8e8efdc95bd3aaeef947e7938dbf45cffda9bd5689cd9517"
+checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1416,7 +1416,7 @@ dependencies = [
  "tokio-tungstenite 0.26.2",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid 1.17.0",
  "warp",
 ]
 
@@ -1427,7 +1427,7 @@ dependencies = [
  "alloy-primitives 1.1.2",
  "external-api",
  "serde",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -1534,14 +1534,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "tracing",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
 name = "aws-sdk-ecr"
-version = "1.77.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e64d42a9789960b5c6b94528098eabeb252becd1e109a8f6a96740dde8c5fab"
+checksum = "36a6c787ae5fa44bb47c3ae72c7bc740da29a1ea159a53005848905fdf4728a5"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecs"
-version = "1.81.0"
+version = "1.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ef717840a85a39b0a716fa9dffffdadef6c04dba48607eaa8fc0cce0a400e0"
+checksum = "d61a1be085951ab54770aea857fe54e5182588b6534e0430ad515ad9b54871ec"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1583,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.88.0"
+version = "1.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffc2a1c6dfd4585ad423350c04da3c8be831c9f418e58e8c837656054ec45f8"
+checksum = "5934beb9403c562bd129a1de1bd51ab67209c05ddf3a4a8c86714120181c860f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1617,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-secretsmanager"
-version = "1.74.0"
+version = "1.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca681408228085cf3936cd78405996b1295e006221b7f7bf78735f5c70a78fa1"
+checksum = "f9c0b663c9e8f67af8b264a94f81c0f7dfd1edad1484cdfca30944d1fb4429b6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1639,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.70.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83447efb7179d8e2ad2afb15ceb9c113debbc2ecdf109150e338e2e28b86190b"
+checksum = "95a4fd09d6e863655d99cd2260f271c6d1030dc6bfad68e19e126d2e4c8ceb18"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1661,9 +1661,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.71.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f9bfbbda5e2b9fe330de098f14558ee8b38346408efe9f2e9cee82dc1636a4"
+checksum = "3224ab02ebb3074467a33d57caf6fcb487ca36f3697fdd381b0428dc72380696"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.71.0"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17b984a66491ec08b4f4097af8911251db79296b3e4a763060b45805746264f"
+checksum = "f6933f189ed1255e78175fbd73fb200c0aae7240d220ed3346f567b0ddca3083"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1811,7 +1811,7 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.6.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
@@ -1988,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
 dependencies = [
  "fastrand",
 ]
@@ -2070,7 +2070,7 @@ checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
 dependencies = [
  "async-trait",
  "futures-util",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "tokio",
 ]
 
@@ -2370,7 +2370,7 @@ checksum = "4b7118d0221d84fada881b657c2ddb7cd55108db79c8764c9ee212c0c259b783"
 dependencies = [
  "crossbeam-channel",
  "num_cpus",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -2560,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2654,7 +2654,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2724,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2734,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2873,7 +2873,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2905,7 +2905,7 @@ dependencies = [
  "tokio",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -2924,7 +2924,7 @@ dependencies = [
  "compliance-api",
  "diesel",
  "http-body-util",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde",
  "serde_json",
  "tokio",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -3022,7 +3022,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3063,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "abi",
  "alloy",
@@ -3401,7 +3401,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -3573,7 +3573,7 @@ dependencies = [
  "num-traits",
  "pq-sys",
  "r2d2",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4289,7 +4289,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4306,7 +4306,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "util",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4393,7 +4393,7 @@ dependencies = [
  "http 1.3.1",
  "jsonwebtoken 9.3.1",
  "rand 0.8.5",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -4407,7 +4407,7 @@ dependencies = [
  "tokio-util 0.7.15",
  "tracing",
  "url",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4550,7 +4550,7 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid 1.17.0",
  "warp",
 ]
 
@@ -4567,7 +4567,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4800,7 +4800,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -4813,7 +4813,7 @@ dependencies = [
  "sha2 0.10.9",
  "tracing",
  "util",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4986,9 +4986,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -5117,7 +5117,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5162,11 +5162,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
@@ -5221,22 +5220,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.5.10",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -5499,6 +5504,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5618,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -5635,7 +5650,7 @@ dependencies = [
  "serde",
  "tokio",
  "util",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -5802,9 +5817,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -5878,7 +5893,7 @@ dependencies = [
  "multihash",
  "multistream-select",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project",
  "quick-protobuf",
  "rand 0.8.5",
@@ -5972,9 +5987,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -6182,13 +6197,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6487,9 +6502,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -6624,9 +6639,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -6656,9 +6671,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.108"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -6881,12 +6896,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.10",
+ "parking_lot_core 0.9.11",
 ]
 
 [[package]]
@@ -6905,9 +6920,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -7241,9 +7256,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -7252,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7567,7 +7582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
 dependencies = [
  "log",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "scheduled-thread-pool",
 ]
 
@@ -7722,7 +7737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ea961700fd7260e7fa3701c8287d901b2172c51f9c1421fa0f21d7f7e184b7"
 dependencies = [
  "clocksource",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "thiserror 1.0.69",
 ]
 
@@ -7794,12 +7809,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1_smol",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-native-tls",
  "tokio-util 0.7.15",
  "url",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -7893,7 +7908,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7923,7 +7938,7 @@ dependencies = [
  "renegade-dealer-api",
  "serde_json",
  "tokio",
- "uuid 1.16.0",
+ "uuid 1.17.0",
  "warp",
 ]
 
@@ -7937,13 +7952,13 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -8007,7 +8022,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8029,9 +8044,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8043,7 +8058,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -8055,21 +8070,20 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -8081,7 +8095,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -8100,7 +8114,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 1.0.69",
@@ -8120,7 +8134,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http 1.3.1",
  "matchit 0.8.6",
- "reqwest 0.12.15",
+ "reqwest 0.12.18",
  "reqwest-middleware",
  "tracing",
 ]
@@ -8208,7 +8222,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -8422,7 +8436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -8446,15 +8460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -8589,7 +8594,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
@@ -8729,7 +8734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -9152,9 +9157,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -9256,7 +9261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "phf_shared",
  "precomputed-hash",
 ]
@@ -9435,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "bus",
  "common",
@@ -9447,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9679,18 +9684,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -9707,7 +9712,7 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
- "uuid 1.16.0",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -9754,14 +9759,14 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "percent-encoding",
  "phf",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.1",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util 0.7.15",
  "whoami",
@@ -9997,6 +10002,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -10369,7 +10392,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a59104d8947fab19ee823ba62f7e1c19c0a87adf"
+source = "git+https://github.com/renegade-fi/renegade.git#8d45d01417f3f6388825e8772cfe048a886afc28"
 dependencies = [
  "alloy",
  "ark-ec",
@@ -10417,12 +10440,14 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10657,7 +10682,7 @@ checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-utils",
  "slab",
  "wasm-bindgen",
@@ -10713,7 +10738,7 @@ dependencies = [
  "jsonrpc-core",
  "log",
  "once_cell",
- "parking_lot 0.12.3",
+ "parking_lot 0.12.4",
  "pin-project",
  "reqwest 0.11.27",
  "rlp",

--- a/auth/auth-server/src/chain_events/abis/arbitrum.rs
+++ b/auth/auth-server/src/chain_events/abis/arbitrum.rs
@@ -1,0 +1,84 @@
+//! Arbitrum ABI helpers
+
+use alloy_primitives::U256;
+use alloy_sol_types::SolCall;
+use renegade_darkpool_client::{
+    arbitrum::{
+        abi::{
+            Darkpool::{
+                processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+                processMalleableAtomicMatchSettleCall,
+                processMalleableAtomicMatchSettleWithReceiverCall,
+            },
+            PROCESS_ATOMIC_MATCH_SETTLE_SELECTOR,
+            PROCESS_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR,
+            PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_SELECTOR,
+            PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR,
+        },
+        contract_types::{
+            conversion::{to_circuit_bounded_match_result, to_circuit_external_match_result},
+            types::{ValidMalleableMatchSettleAtomicStatement, ValidMatchSettleAtomicStatement},
+        },
+        helpers::deserialize_calldata,
+    },
+    conversion::u256_to_amount,
+};
+
+use crate::{
+    chain_events::{abis::ExternalMatch, error::OnChainEventListenerError},
+    server::helpers::get_selector,
+};
+
+/// Parse an external match from darkpool calldata
+pub(crate) fn parse_external_match(
+    calldata: &[u8],
+) -> Result<Option<ExternalMatch>, OnChainEventListenerError> {
+    let selector = get_selector(calldata)?;
+    // Parse the `VALID MATCH SETTLE ATOMIC` statement from the calldata
+    let match_res = match selector {
+        PROCESS_ATOMIC_MATCH_SETTLE_SELECTOR => {
+            let call = processAtomicMatchSettleCall::abi_decode(calldata)?;
+            parse_standard_match(&call.valid_match_settle_atomic_statement)
+        },
+        PROCESS_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR => {
+            let call = processAtomicMatchSettleWithReceiverCall::abi_decode(calldata)?;
+            parse_standard_match(&call.valid_match_settle_atomic_statement)
+        },
+        PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR => {
+            let call = processMalleableAtomicMatchSettleWithReceiverCall::abi_decode(calldata)?;
+            parse_malleable_match(call.base_amount, &call.valid_match_settle_statement)
+        },
+        PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_SELECTOR => {
+            let call = processMalleableAtomicMatchSettleCall::abi_decode(calldata)?;
+            parse_malleable_match(call.base_amount, &call.valid_match_settle_statement)
+        },
+        _ => return Ok(None),
+    }?;
+
+    Ok(Some(match_res))
+}
+
+/// Parse an external match from a regular atomic match settle call
+fn parse_standard_match(
+    statement_bytes: &[u8],
+) -> Result<ExternalMatch, OnChainEventListenerError> {
+    let statement: ValidMatchSettleAtomicStatement = deserialize_calldata(statement_bytes)?;
+    let match_res = to_circuit_external_match_result(&statement.match_result)
+        .map_err(OnChainEventListenerError::darkpool)?;
+
+    Ok(ExternalMatch::Standard(match_res))
+}
+
+/// Parse an external match from a malleable atomic match settle call
+fn parse_malleable_match(
+    base_amount: U256,
+    statement_bytes: &[u8],
+) -> Result<ExternalMatch, OnChainEventListenerError> {
+    let base_amt = u256_to_amount(base_amount).map_err(OnChainEventListenerError::darkpool)?;
+    let statement: ValidMalleableMatchSettleAtomicStatement =
+        deserialize_calldata(statement_bytes)?;
+    let match_res = to_circuit_bounded_match_result(&statement.match_result)
+        .map_err(OnChainEventListenerError::darkpool)?;
+
+    Ok(ExternalMatch::Malleable(match_res, base_amt))
+}

--- a/auth/auth-server/src/chain_events/abis/base.rs
+++ b/auth/auth-server/src/chain_events/abis/base.rs
@@ -1,0 +1,37 @@
+//! Base ABI helpers
+
+use alloy_sol_types::SolCall;
+use renegade_darkpool_client::{base::conversion::ToCircuitType, conversion::u256_to_amount};
+use renegade_solidity_abi::IDarkpool::{
+    processAtomicMatchSettleCall, processMalleableAtomicMatchSettleCall,
+};
+
+use crate::{
+    chain_events::{abis::ExternalMatch, error::OnChainEventListenerError},
+    server::helpers::get_selector,
+};
+
+/// Parse an external match from darkpool calldata
+pub(crate) fn parse_external_match(
+    calldata: &[u8],
+) -> Result<Option<ExternalMatch>, OnChainEventListenerError> {
+    let selector = get_selector(calldata)?;
+    let match_res = match selector {
+        processAtomicMatchSettleCall::SELECTOR => {
+            let call = processAtomicMatchSettleCall::abi_decode(calldata)?;
+            let match_res = call.matchSettleStatement.matchResult.to_circuit_type()?;
+            ExternalMatch::Standard(match_res)
+        },
+        processMalleableAtomicMatchSettleCall::SELECTOR => {
+            let call = processMalleableAtomicMatchSettleCall::abi_decode(calldata)?;
+            let match_res = call.matchSettleStatement.matchResult.to_circuit_type()?;
+            let base_amt =
+                u256_to_amount(call.baseAmount).map_err(OnChainEventListenerError::darkpool)?;
+
+            ExternalMatch::Malleable(match_res, base_amt)
+        },
+        _ => return Ok(None),
+    };
+
+    Ok(Some(match_res))
+}

--- a/auth/auth-server/src/chain_events/abis/mod.rs
+++ b/auth/auth-server/src/chain_events/abis/mod.rs
@@ -1,0 +1,56 @@
+//! ABI helpers for the chain events listener
+use renegade_api::http::external_match::{ApiBoundedMatchResult, ApiExternalMatchResult};
+use renegade_circuit_types::{
+    r#match::{BoundedMatchResult, ExternalMatchResult},
+    wallet::Nullifier,
+    Amount,
+};
+
+use crate::{
+    bundle_store::helpers::{generate_bundle_id, generate_malleable_bundle_id},
+    error::AuthServerError,
+};
+
+#[cfg(feature = "arbitrum")]
+mod arbitrum;
+#[cfg(feature = "base")]
+mod base;
+
+#[cfg(feature = "arbitrum")]
+pub(crate) use arbitrum::*;
+#[cfg(feature = "base")]
+pub(crate) use base::*;
+
+/// An external match in the darkpool
+pub enum ExternalMatch {
+    /// A normal external match
+    Standard(ExternalMatchResult),
+    /// A malleable external match with the actual amount swapped attached
+    Malleable(BoundedMatchResult, Amount),
+}
+
+impl ExternalMatch {
+    /// Get the bundle ID for an external match
+    pub fn bundle_id(&self, nullifier: &Nullifier) -> Result<String, AuthServerError> {
+        match self {
+            ExternalMatch::Standard(match_result) => {
+                let api_match: ApiExternalMatchResult = match_result.clone().into();
+                generate_bundle_id(&api_match, nullifier)
+            },
+            ExternalMatch::Malleable(match_result, _) => {
+                let api_match: ApiBoundedMatchResult = match_result.clone().into();
+                generate_malleable_bundle_id(&api_match, nullifier)
+            },
+        }
+    }
+
+    /// Get the external match result from the match bundle
+    pub fn match_result(&self) -> ExternalMatchResult {
+        match self {
+            ExternalMatch::Standard(match_result) => match_result.clone(),
+            ExternalMatch::Malleable(match_result, base_amt) => {
+                match_result.to_external_match_result(*base_amt)
+            },
+        }
+    }
+}

--- a/auth/auth-server/src/chain_events/mod.rs
+++ b/auth/auth-server/src/chain_events/mod.rs
@@ -3,6 +3,7 @@
 //! The event listener is responsible for:
 //! - Metrics: listening for nullifier spent events and recording metrics
 //!   related to settlement volume
+mod abis;
 mod error;
 pub mod listener;
 mod tasks;

--- a/auth/auth-server/src/telemetry/abi_helpers/arbitrum.rs
+++ b/auth/auth-server/src/telemetry/abi_helpers/arbitrum.rs
@@ -5,7 +5,10 @@ use renegade_api::http::external_match::{AtomicMatchApiBundle, MalleableAtomicMa
 use renegade_circuit_types::wallet::Nullifier;
 use renegade_constants::Scalar;
 use renegade_darkpool_client::arbitrum::{
-    abi::Darkpool::{processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall},
+    abi::Darkpool::{
+        processAtomicMatchSettleCall, processAtomicMatchSettleWithReceiverCall,
+        processMalleableAtomicMatchSettleCall, processMalleableAtomicMatchSettleWithReceiverCall,
+    },
     contract_types::types::MatchPayload,
     helpers::deserialize_calldata,
 };
@@ -13,7 +16,10 @@ use renegade_darkpool_client::arbitrum::{
 use crate::{
     error::AuthServerError,
     server::{
-        gas_sponsorship::contract_interaction::sponsorAtomicMatchSettleWithRefundOptionsCall,
+        gas_sponsorship::contract_interaction::{
+            sponsorAtomicMatchSettleWithRefundOptionsCall,
+            sponsorMalleableAtomicMatchSettleWithRefundOptionsCall,
+        },
         helpers::get_selector,
     },
 };
@@ -52,10 +58,25 @@ pub fn extract_nullifier_from_settlement_tx_calldata(
                 .map_err(AuthServerError::serde)?
                 .internal_party_match_payload
         },
+        processMalleableAtomicMatchSettleCall::SELECTOR => {
+            processMalleableAtomicMatchSettleCall::abi_decode(tx_data)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
+        processMalleableAtomicMatchSettleWithReceiverCall::SELECTOR => {
+            processMalleableAtomicMatchSettleWithReceiverCall::abi_decode(tx_data)
+                .map_err(AuthServerError::serde)?
+                .internal_party_match_payload
+        },
         sponsorAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
             sponsorAtomicMatchSettleWithRefundOptionsCall::abi_decode(tx_data)
                 .map_err(AuthServerError::serde)?
                 .internal_party_match_payload
+        },
+        sponsorMalleableAtomicMatchSettleWithRefundOptionsCall::SELECTOR => {
+            sponsorMalleableAtomicMatchSettleWithRefundOptionsCall::abi_decode(tx_data)
+                .map_err(AuthServerError::serde)?
+                .internal_party_payload
         },
         _ => {
             return Err(AuthServerError::serde("Invalid selector for settlement tx"));


### PR DESCRIPTION
### Purpose
This PR adds helpers for parsing external matches (malleable or standard) from darkpool calldata. This allows the chain events listener to record settlement metrics for malleable match bundles.

### Testing
- [x] Test in testnet