### PR TITLE
auth-server: telemetry: Enable OTLP and open span for each request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot 0.12.4",
  "pin-project",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -512,7 +512,7 @@ dependencies = [
  "async-stream",
  "futures",
  "pin-project",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "tokio",
@@ -797,7 +797,7 @@ checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ecs"
-version = "1.82.0"
+version = "1.82.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a1be085951ab54770aea857fe54e5182588b6534e0430ad515ad9b54871ec"
+checksum = "4abc7f510ba82af370e0b5c1ea1b6a65fe9d598fa620f2885a93ab4e57840ac7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -2528,9 +2528,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
@@ -2924,7 +2924,7 @@ dependencies = [
  "compliance-api",
  "diesel",
  "http-body-util",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde",
  "serde_json",
  "tokio",
@@ -3118,9 +3118,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc-fast"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add8d3a4c789d77eeb0f0e3c1035f73610d017f9047e87db94f89c02a56d8fef"
+checksum = "68fcb2be5386ffb77e30bf10820934cb89a628bcb976e7cc632dcd88c059ebea"
 dependencies = [
  "cc",
  "crc",
@@ -4393,7 +4393,7 @@ dependencies = [
  "http 1.3.1",
  "jsonwebtoken 9.3.1",
  "rand 0.8.5",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "reqwest-middleware",
  "reqwest-retry",
  "reqwest-tracing",
@@ -8044,9 +8044,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.18"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff6b0dbbe4d5a37318f433d4fc82babd21631f194d370409ceb2e40b2f0b5"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8095,7 +8095,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -8114,7 +8114,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "reqwest-middleware",
  "retry-policies",
  "thiserror 1.0.69",
@@ -8134,7 +8134,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http 1.3.1",
  "matchit 0.8.6",
- "reqwest 0.12.18",
+ "reqwest 0.12.19",
  "reqwest-middleware",
  "tracing",
 ]
@@ -10008,9 +10008,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",

--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -57,4 +57,5 @@ RUN apt-get update && \
 # Copy the binary from the build stage
 COPY --from=builder /build/target/release/auth-server /bin/auth-server
 
+ENV RUST_LOG="info,warp::filters::trace=warn"
 ENTRYPOINT ["/bin/auth-server"]

--- a/auth/auth-server/src/telemetry/mod.rs
+++ b/auth/auth-server/src/telemetry/mod.rs
@@ -18,18 +18,20 @@ pub mod sources;
 pub const QUOTE_FILL_RATIO_IGNORE_THRESHOLD: u128 = 100_000 * 10u128.pow(6u32); // $100,000 of USDC
 /// The prefix for metrics
 const METRICS_PREFIX: &str = "auth-server";
+/// The default OTLP collector endpoint
+const DEFAULT_OTLP_COLLECTOR_ENDPOINT: &str = "http://localhost:4317";
 
 /// Configure telemetry from the command line arguments
 pub(crate) fn configure_telemtry_from_args(args: &Cli) -> Result<(), AuthServerError> {
     let metrics_config =
         MetricsConfig { metrics_prefix: METRICS_PREFIX.to_string(), ..Default::default() };
     configure_telemetry_with_metrics_config(
-        args.datadog_enabled, // datadog_enabled
-        false,                // otlp_enabled
-        args.metrics_enabled, // metrics_enabled
-        "".to_string(),       // collector_endpoint
-        &args.statsd_host,    // statsd_host
-        args.statsd_port,     // statsd_port
+        args.datadog_enabled,                        // datadog_enabled
+        args.otlp_enabled,                           // otlp_enabled
+        args.metrics_enabled,                        // metrics_enabled
+        DEFAULT_OTLP_COLLECTOR_ENDPOINT.to_string(), // collector_endpoint
+        &args.statsd_host,                           // statsd_host
+        args.statsd_port,                            // statsd_port
         Some(metrics_config),
     )
     .map_err(AuthServerError::setup)


### PR DESCRIPTION
### Purpose
This PR enables OTLP in the auth server telemetry setup and opens a span for each request.

We don't use the built in warp tracing to open the span as this attaches spammy logs which we don't want in our output. Rather, we add a rust log configuration to ignore spammy `INFO` logs from `warp::trace` and instead open the span via a custom filter.

### Todo
- Enable OTLP via env var in terraform
- Add more granular spans to the request handler traces

### Testing
- [x] Tested in testnet