### PR TITLE
auth-server: api-handlers: Add tracing for auth server endpoints

### DIFF
--- a/auth/auth-server/src/server/api_auth.rs
+++ b/auth/auth-server/src/server/api_auth.rs
@@ -4,7 +4,7 @@ use auth_server_api::RENEGADE_API_KEY_HEADER;
 use http::HeaderMap;
 use renegade_api::auth::validate_expiring_auth;
 use renegade_common::types::hmac::HmacKey;
-use tracing::info;
+use tracing::{info, instrument};
 use uuid::Uuid;
 use warp::filters::path::FullPath;
 
@@ -28,6 +28,7 @@ impl Server {
     ///
     /// Returns the description for the API key, i.e. a human readable name for
     /// the entity that is making the request
+    #[instrument(skip_all)]
     pub(crate) async fn authorize_request(
         &self,
         path: &str,

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
@@ -81,6 +81,7 @@ impl Server {
 
     /// Run the pre-request subroutines for the assemble malleable quote
     /// endpoint
+    #[instrument(skip_all)]
     async fn assemble_malleable_quote_pre_request(
         &self,
         ctx: &mut AssembleMalleableQuoteRequestCtx,
@@ -99,6 +100,7 @@ impl Server {
 
     /// Run the post-request subroutines for the assemble malleable quote
     /// endpoint
+    #[instrument(skip_all, fields(success = ctx.is_success(), status = ctx.status().as_u16()))]
     fn assemble_malleable_quote_post_request(
         &self,
         mut resp: Response<Bytes>,

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -87,6 +87,7 @@ impl Server {
     // -------------------------------
 
     /// Run the pre-request subroutines for the assembly quote endpoint
+    #[instrument(skip_all)]
     async fn assembly_pre_request(
         &self,
         ctx: &mut AssembleQuoteRequestCtx,
@@ -102,6 +103,7 @@ impl Server {
     }
 
     /// Run the post-request subroutines for the assembly quote endpoint
+    #[instrument(skip_all, fields(success = ctx.is_success(), status = ctx.status().as_u16()))]
     fn assembly_post_request(
         &self,
         mut resp: Response<Bytes>,
@@ -135,6 +137,7 @@ impl Server {
     /// present.
     ///
     /// Returns the assembly request, and the gas sponsorship info, if any.
+    #[instrument(skip_all)]
     pub(crate) async fn sponsor_assembly_request(
         &self,
         ctx: &mut AssembleQuoteRequestCtx,

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -76,6 +76,7 @@ impl Server {
     // -------------------------------
 
     /// Run the pre-request subroutines for the direct match endpoint
+    #[instrument(skip_all)]
     async fn direct_match_pre_request(
         &self,
         ctx: &mut DirectMatchRequestCtx,
@@ -91,6 +92,7 @@ impl Server {
     }
 
     /// Run the post-request subroutines for the direct match endpoint
+    #[instrument(skip_all, fields(success = ctx.is_success(), status = ctx.status().as_u16()))]
     fn direct_match_post_request(
         &self,
         mut resp: Response<Bytes>,
@@ -119,6 +121,7 @@ impl Server {
     /// Apply gas sponsorship to the given match request, returning the
     /// resulting `ExternalMatchRequest` and the generated gas sponsorship
     /// info, if any
+    #[instrument(skip_all)]
     async fn sponsor_direct_match_request(
         &self,
         ctx: &mut DirectMatchRequestCtx,

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -9,6 +9,7 @@ use auth_server_api::GasSponsorshipInfo;
 use bytes::Bytes;
 use http::{HeaderMap, Method, Response, StatusCode};
 use serde::{Deserialize, Serialize};
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -179,6 +180,7 @@ impl<
 impl Server {
     /// Build request context for an external match related request, before the
     /// request is proxied to the relayer
+    #[instrument(skip_all)]
     pub async fn preprocess_request<Req>(
         &self,
         path: warp::path::FullPath,
@@ -213,6 +215,7 @@ impl Server {
     ///
     /// Returns the raw response from the relayer as well as the response
     /// context generated from the relayer's response
+    #[instrument(skip_all)]
     pub async fn forward_request<Req, Resp>(
         &self,
         ctx: RequestContext<Req>,

--- a/auth/auth-server/src/server/api_handlers/external_match/quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/quote.rs
@@ -91,6 +91,7 @@ impl Server {
 
     /// Run endpoint handler subroutines before forwarding the request to the
     /// relayer
+    #[instrument(skip_all)]
     async fn quote_pre_request(&self, ctx: &mut QuoteRequestCtx) -> Result<(), AuthServerError> {
         // Check the rate limit
         self.check_quote_rate_limit(ctx.user()).await?;
@@ -105,6 +106,7 @@ impl Server {
     /// response
     ///
     /// Returns the auth server's response to the client
+    #[instrument(skip_all, fields(success = ctx.is_success(), status = ctx.status().as_u16()))]
     fn quote_post_request(
         &self,
         mut resp: Response<Bytes>,
@@ -138,6 +140,7 @@ impl Server {
     /// respected.
     ///
     /// Returns the gas sponsorship info for the request, if any.
+    #[instrument(skip_all)]
     async fn sponsor_quote_request(
         &self,
         ctx: &mut QuoteRequestCtx,
@@ -153,6 +156,7 @@ impl Server {
 
     /// Apply gas sponsorship to the given external quote response, returning
     /// the resulting `SponsoredQuoteResponse`
+    #[instrument(skip_all)]
     fn sponsor_response(
         &self,
         ctx: &QuoteResponseCtx,

--- a/auth/auth-server/src/server/api_handlers/key_management.rs
+++ b/auth/auth-server/src/server/api_handlers/key_management.rs
@@ -7,6 +7,7 @@ use crate::{
 use auth_server_api::CreateApiKeyRequest;
 use bytes::Bytes;
 use http::HeaderMap;
+use tracing::instrument;
 use uuid::Uuid;
 use warp::{filters::path::FullPath, reject::Rejection, reply::Reply};
 
@@ -16,6 +17,7 @@ use super::Server;
 
 impl Server {
     /// Add a new API key to the database
+    #[instrument(skip_all)]
     pub async fn add_key(
         &self,
         path: FullPath,
@@ -38,6 +40,7 @@ impl Server {
     }
 
     /// Expire an existing API key
+    #[instrument(skip_all)]
     pub async fn expire_key(
         &self,
         key_id: Uuid,

--- a/auth/auth-server/src/server/rate_limiter/mod.rs
+++ b/auth/auth-server/src/server/rate_limiter/mod.rs
@@ -23,7 +23,7 @@
 use std::time::Duration;
 
 use gas_sponsorship_rate_limiter::GasSponsorshipRateLimiter;
-use tracing::warn;
+use tracing::{instrument, warn};
 use user_rate_limiter::ApiTokenRateLimiter;
 
 use crate::error::AuthServerError;
@@ -39,6 +39,7 @@ mod user_rate_limiter;
 
 impl Server {
     /// Check the quote rate limiter
+    #[instrument(skip(self))]
     pub async fn check_quote_rate_limit(
         &self,
         key_description: String,
@@ -51,6 +52,7 @@ impl Server {
     }
 
     /// Check the bundle rate limiter
+    #[instrument(skip(self))]
     pub async fn check_bundle_rate_limit(
         &self,
         key_description: String,
@@ -67,6 +69,7 @@ impl Server {
     ///
     /// Returns a boolean indicating whether or not the gas sponsorship rate
     /// limit has been exceeded.
+    #[instrument(skip(self))]
     pub async fn check_gas_sponsorship_rate_limit(&self, key_description: &str) -> bool {
         if !self.rate_limiter.check_gas_sponsorship(key_description).await {
             warn!(


### PR DESCRIPTION
### Purpose
This PR follows up on #240 to add more in-depth tracing for auth server requests. This will, at a high level, allow us to determine where the bottlenecks are in serving a bundle request. 

I will add more trace spans and fields as need comes.

### Testing
- [ ] Deploy to testnet