### PR TITLE
renegade-solver: Move from separate repo

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -17,7 +17,8 @@ jobs:
           "funds-manager-api",
           "funds-manager",
           "price-reporter",
-          "price-reporter-client"
+          "price-reporter-client",
+          "renegade-solver",
         ]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
           "funds-manager-api",
           "funds-manager",
           "price-reporter",
-          "price-reporter-client"
+          "price-reporter-client",
+          "renegade-solver",
         ]
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ target/
 .vscode/
 /.gitattributes
 
-.env*
+**/*.env*
 **/*.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7997,6 +7997,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "renegade-solver"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "reqwest 0.12.19",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "util",
+ "warp",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "compliance/compliance-server",
     "compliance/compliance-api",
     "deploy",
+    "renegade-solver",
     "dealer/renegade-dealer",
     "dealer/renegade-dealer-api",
     "funds-manager/funds-manager-api",
@@ -35,7 +36,9 @@ renegade-constants = { package = "constants", git = "https://github.com/renegade
 renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = ["metered-channels"] }
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", features = [
+    "metered-channels",
+] }
 renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git" }
 renegade-solidity-abi = { package = "abi", git = "https://github.com/renegade-fi/renegade-solidity-contracts" }

--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "renegade-solver"
+version = "0.1.0"
+edition = "2021"
+authors = ["Renegade Team <hello@renegade.fi>"]
+description = "An orderflow auction solver which routes through the Renegade darkpool"
+license = "MIT"
+repository = "https://github.com/renegade-fi/renegade-solver"
+homepage = "https://renegade.fi"
+readme = "README.md"
+keywords = ["solver", "renegade", "protocol", "intents", "darkpool"]
+
+[dependencies]
+# === Server === #
+clap = { version = "4.0", features = ["derive", "env"] }
+reqwest = "0.12"
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+warp = "0.3"
+
+# === Renegade Dependencies === #
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade", features = [
+    "telemetry",
+] }
+
+# === Misc Dependencies === #
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+url = "2.5.0"

--- a/renegade-solver/README.md
+++ b/renegade-solver/README.md
@@ -1,0 +1,2 @@
+# renegade-solver
+An orderflow auction solver which routes through the Renegade darkpool

--- a/renegade-solver/src/cli.rs
+++ b/renegade-solver/src/cli.rs
@@ -1,0 +1,60 @@
+//! The CLI for the renegade solver
+
+use clap::Parser;
+use renegade_util::telemetry::{configure_telemetry_with_metrics_config, metrics::MetricsConfig};
+
+/// The default metrics prefix
+const DEFAULT_METRICS_PREFIX: &str = "renegade-solver";
+/// The default OTLP collector endpoint
+const DEFAULT_OTLP_COLLECTOR_ENDPOINT: &str = "http://localhost:4317";
+/// The default statsd host
+const DEFAULT_STATSD_HOST: &str = "127.0.0.1";
+/// The default statsd port
+const DEFAULT_STATSD_PORT: u16 = 8125;
+
+/// Renegade solver server
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    // --- Application Config --- //
+    /// The URL of the UniswapX API
+    #[arg(long, env = "UNISWAPX_URL")]
+    pub uniswapx_url: String,
+
+    // --- Server --- //
+    /// Port to run the server on
+    #[arg(short, long, default_value_t = 3000)]
+    pub port: u16,
+
+    // --- Telemetry --- //
+    /// Whether or not to enable Datadog-formatted logs
+    #[arg(long, env = "ENABLE_DATADOG")]
+    pub datadog_enabled: bool,
+    /// Whether or not to enable OTLP tracing
+    #[arg(long, env = "ENABLE_OTLP")]
+    pub otlp_enabled: bool,
+    /// Whether or not to enable metrics collection
+    #[arg(long, env = "ENABLE_METRICS")]
+    pub metrics_enabled: bool,
+}
+
+impl Cli {
+    /// Configure telemetry from the CLI
+    pub fn configure_telemetry(&self) {
+        let metrics_config = MetricsConfig {
+            metrics_prefix: DEFAULT_METRICS_PREFIX.to_string(),
+            ..Default::default()
+        };
+
+        configure_telemetry_with_metrics_config(
+            self.datadog_enabled,
+            self.otlp_enabled,
+            self.metrics_enabled,
+            DEFAULT_OTLP_COLLECTOR_ENDPOINT.to_string(),
+            DEFAULT_STATSD_HOST,
+            DEFAULT_STATSD_PORT,
+            Some(metrics_config),
+        )
+        .expect("Failed to configure telemetry");
+    }
+}

--- a/renegade-solver/src/error.rs
+++ b/renegade-solver/src/error.rs
@@ -1,0 +1,52 @@
+//! Error types for the solver
+
+use serde_json::json;
+use thiserror::Error;
+use warp::{
+    http::StatusCode,
+    reject::Reject,
+    reply::{Json, WithStatus},
+    Rejection,
+};
+
+/// Type alias for Results using SolverError
+pub type SolverResult<T> = Result<T, SolverError>;
+
+/// The generic solver error
+#[derive(Error, Debug)]
+pub enum SolverError {
+    /// HTTP error occurred
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    /// JSON serialization/deserialization error
+    #[error("JSON error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl Reject for SolverError {}
+
+// ------------------
+// | Error Handling |
+// ------------------
+
+/// Handle rejections and convert SolverError to JSON responses
+pub async fn handle_rejection(err: Rejection) -> Result<WithStatus<Json>, Rejection> {
+    if let Some(solver_error) = err.find::<SolverError>() {
+        let (status_code, message) = match solver_error {
+            SolverError::Http(_) | SolverError::Serialization(_) => {
+                let msg = format!("Internal server error: {solver_error}");
+                (StatusCode::INTERNAL_SERVER_ERROR, msg)
+            },
+        };
+
+        Ok(json_error(&message, status_code))
+    } else {
+        Err(err)
+    }
+}
+
+/// Return a json error from a string message
+fn json_error(msg: &str, code: StatusCode) -> WithStatus<Json> {
+    let json = json!({ "error": msg });
+    warp::reply::with_status(warp::reply::json(&json), code)
+}

--- a/renegade-solver/src/main.rs
+++ b/renegade-solver/src/main.rs
@@ -1,0 +1,65 @@
+//! Entrypoint for the renegade solver
+
+#![deny(missing_docs)]
+#![deny(clippy::missing_docs_in_private_items)]
+#![deny(clippy::needless_pass_by_value)]
+#![deny(clippy::needless_pass_by_ref_mut)]
+#![deny(unsafe_code)]
+
+use std::net::SocketAddr;
+
+use clap::Parser;
+use serde_json::json;
+use tracing::{info, info_span};
+use warp::Filter;
+
+use crate::{cli::Cli, error::handle_rejection, uniswapx::UniswapXSolver};
+
+mod cli;
+mod error;
+mod uniswapx;
+
+/// Main entrypoint for the renegade solver server
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    cli.configure_telemetry();
+
+    // Create the UniswapX solver and begin its polling loop
+    let uniswapx = UniswapXSolver::new(cli.uniswapx_url);
+    uniswapx.spawn_polling_loop();
+
+    // Create the endpoints
+    info!("Starting renegade solver server on port {}", cli.port);
+    let ping = ping_handler();
+
+    // Add request tracing
+    let routes = ping.with(with_tracing()).recover(handle_rejection);
+    let listen_addr: SocketAddr = ([0, 0, 0, 0], cli.port).into();
+    warp::serve(routes).run(listen_addr).await;
+}
+
+/// Creates the ping endpoint handler
+fn ping_handler() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path("ping").and(warp::get()).map(|| warp::reply::json(&json!({ "message": "PONG" })))
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Custom tracing filter that creates spans for requests at info level
+/// with the renegade_solver::request target to work with our RUST_LOG
+/// configuration
+fn with_tracing() -> warp::trace::Trace<impl Fn(warp::trace::Info) -> tracing::Span + Clone> {
+    warp::trace(|info| {
+        let span = info_span!(
+            target: "renegade_solver::request",
+            "handle_request",
+            method = %info.method(),
+            path = %info.path(),
+        );
+
+        span
+    })
+}

--- a/renegade-solver/src/uniswapx/api_types.rs
+++ b/renegade-solver/src/uniswapx/api_types.rs
@@ -1,0 +1,148 @@
+//! API types for the UniswapX API
+//!
+//! These types are based on the UniswapX API OpenAPI specification
+//! [here](https://github.com/Uniswap/uniswapx-service/blob/main/swagger.json)
+
+use serde::{Deserialize, Serialize};
+
+/// The response from the orders endpoint
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetOrdersResponse {
+    /// List of orders
+    pub orders: Vec<OrderEntity>,
+    /// Cursor for pagination (optional)
+    pub cursor: Option<String>,
+}
+
+/// A UniswapX order entity
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderEntity {
+    /// The order type
+    #[serde(rename = "type")]
+    pub order_type: OrderType,
+    /// Current status of the order
+    pub order_status: OrderStatus,
+    /// The order signature
+    pub signature: String,
+    /// The encoded order data
+    pub encoded_order: String,
+    /// The chain ID where the order exists
+    pub chain_id: u64,
+    /// The nonce
+    pub nonce: String,
+    /// The unique hash of the order
+    pub order_hash: String,
+    /// The swapper address (who created the order)
+    pub swapper: String,
+    /// Block when auction starts
+    pub auction_start_block: u64,
+    /// Baseline priority fee in wei
+    pub baseline_priority_fee_wei: String,
+    /// Input token information
+    pub input: OrderInput,
+    /// Output token information (array)
+    pub outputs: Vec<OrderOutput>,
+    /// Cosigner data
+    pub cosigner_data: CosignerData,
+    /// Cosignature
+    pub cosignature: String,
+    /// Optional quote ID
+    pub quote_id: Option<String>,
+    /// Timestamp when the order was created
+    pub created_at: u64,
+    /// Routing information
+    pub route: Route,
+}
+
+/// Order input information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderInput {
+    /// Token contract address
+    pub token: String,
+    /// Token amount
+    pub amount: String,
+    /// MPS per priority fee wei
+    pub mps_per_priority_fee_wei: String,
+}
+
+/// Order output information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderOutput {
+    /// Token contract address
+    pub token: String,
+    /// Token amount
+    pub amount: String,
+    /// MPS per priority fee wei
+    pub mps_per_priority_fee_wei: String,
+    /// Recipient address
+    pub recipient: String,
+}
+
+/// Cosigner data
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosignerData {
+    /// Auction target block
+    pub auction_target_block: u64,
+}
+
+/// Route information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Route {
+    /// Gas use estimate
+    pub gas_use_estimate: String,
+    /// Gas use estimate quote
+    pub gas_use_estimate_quote: String,
+    /// Gas price in wei
+    pub gas_price_wei: String,
+    /// Quote amount
+    pub quote: String,
+    /// Gas adjusted quote
+    pub quote_gas_adjusted: String,
+    /// Method parameters
+    pub method_parameters: MethodParameters,
+}
+
+/// Method parameters for routing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MethodParameters {
+    /// Calldata for the transaction
+    pub calldata: String,
+    /// Value to send with transaction
+    pub value: String,
+    /// Target address
+    pub to: String,
+}
+
+/// Order type enumeration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum OrderType {
+    /// Dutch auction order
+    Dutch,
+    /// Priority order
+    Priority,
+}
+
+/// Order status enumeration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderStatus {
+    /// Order is open and can be filled
+    Open,
+    /// Order has expired
+    Expired,
+    /// Order has encountered an error
+    Error,
+    /// Order has been cancelled
+    Cancelled,
+    /// Order has been filled
+    Filled,
+    /// Order has insufficient funds
+    #[serde(rename = "insufficient-funds")]
+    InsufficientFunds,
+}

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -1,0 +1,127 @@
+//! UniswapX API client and handlers
+
+use std::time::Duration;
+
+use reqwest::Client as ReqwestClient;
+use tracing::{error, info};
+use url::form_urlencoded;
+
+use crate::{error::SolverResult, uniswapx::api_types::OrderEntity};
+
+mod api_types;
+use api_types::GetOrdersResponse;
+
+/// The interval at which to poll for new orders
+const POLLING_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The order status parameter
+const ORDER_STATUS_PARAM: &str = "orderStatus";
+/// The chain ID parameter
+const CHAIN_ID_PARAM: &str = "chainId";
+/// The order type parameter
+const ORDER_TYPE_PARAM: &str = "orderType";
+
+/// Query parameter values
+/// The order status value
+const ORDER_STATUS_OPEN: &str = "open";
+/// The chain ID for base
+const CHAIN_ID_BASE: &str = "8453";
+/// The order type for priority orders
+const ORDER_TYPE_PRIORITY: &str = "Priority";
+
+/// The UniswapX API client
+#[derive(Clone)]
+pub struct UniswapXSolver {
+    /// The base URL for the UniswapX API
+    base_url: String,
+    /// The API client
+    client: ReqwestClient,
+}
+
+impl UniswapXSolver {
+    /// Create a new UniswapX solver
+    pub fn new(base_url: String) -> Self {
+        Self { base_url, client: ReqwestClient::new() }
+    }
+
+    /// Spawn a polling loop for the UniswapX API
+    pub fn spawn_polling_loop(&self) {
+        let self_clone = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = self_clone.polling_loop().await {
+                error!("Polling loop error: {e}");
+                error!("Critical error in polling loop, shutting down process");
+                std::process::exit(1);
+            }
+        });
+    }
+
+    /// The inner polling loop
+    async fn polling_loop(&self) -> SolverResult<()> {
+        loop {
+            tokio::time::sleep(POLLING_INTERVAL).await;
+            if let Err(e) = self.poll_orders().await {
+                error!("Error polling for orders: {e}");
+                continue;
+            }
+        }
+    }
+
+    /// Poll the UniswapX API for new orders
+    async fn poll_orders(&self) -> SolverResult<()> {
+        // For now, just print each order
+        let orders = self.fetch_open_orders().await?;
+        for order in &orders {
+            let input = &order.input;
+            let first_output = &order.outputs[0];
+            info!(
+                "Found order for {} {} -> {} {}",
+                input.amount, input.token, first_output.amount, first_output.token
+            );
+        }
+
+        // TODO: Process each order
+        Ok(())
+    }
+
+    /// Fetch open orders from the UniswapX API
+    async fn fetch_open_orders(&self) -> SolverResult<Vec<OrderEntity>> {
+        let url = self.build_request_url();
+        let response = self.client.get(&url).send().await?;
+
+        // Check if the response is successful
+        if !response.status().is_success() {
+            let status = response.status();
+            let error_text = response.text().await.unwrap_or_default();
+            error!("API request failed with status: {status}: {error_text}");
+            return Ok(vec![]);
+        }
+
+        // Deserialize the JSON response
+        let response_text = response.text().await?;
+        let orders_response: GetOrdersResponse = serde_json::from_str(&response_text)?;
+        Ok(orders_response.orders)
+    }
+
+    /// Build the request URL for the UniswapX API
+    ///
+    /// See docs [here](https://docs.uniswap.org/contracts/uniswapx/guides/priority/priorityorderreactor#retrieving-and-executing-signed-orders)
+    fn build_request_url(&self) -> String {
+        let query_params = Self::get_default_query_params();
+        let mut query_string = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in query_params {
+            query_string.append_pair(key, value);
+        }
+        let query = query_string.finish();
+        format!("{}/orders?{}", self.base_url, query)
+    }
+
+    /// Get the default query parameters for fetching orders
+    fn get_default_query_params() -> Vec<(&'static str, &'static str)> {
+        vec![
+            (ORDER_STATUS_PARAM, ORDER_STATUS_OPEN),
+            (CHAIN_ID_PARAM, CHAIN_ID_BASE),
+            (ORDER_TYPE_PARAM, ORDER_TYPE_PRIORITY),
+        ]
+    }
+}


### PR DESCRIPTION
### Purpose
This PR moves the renegade solver into the relayer extensions monorepo.

### Testing
- [x] Ran the solver locally