### PR TITLE
renegade-solver: uniswapx: Cache serviced orders to deduplicate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8035,6 +8035,7 @@ name = "renegade-solver"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "lru 0.12.5",
  "renegade-sdk",
  "reqwest 0.12.19",
  "serde",

--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -25,6 +25,7 @@ renegade-util = { package = "util", git = "https://github.com/renegade-fi/renega
 ] }
 
 # === Misc Dependencies === #
+lru = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/renegade-solver/src/uniswapx/api_interaction.rs
+++ b/renegade-solver/src/uniswapx/api_interaction.rs
@@ -43,7 +43,15 @@ impl UniswapXSolver {
         // Deserialize the JSON response
         let response_text = response.text().await?;
         let orders_response: GetOrdersResponse = serde_json::from_str(&response_text)?;
-        Ok(orders_response.orders)
+
+        let mut orders = Vec::new();
+        for order in orders_response.orders {
+            if !self.is_order_processed(&order).await {
+                orders.push(order);
+            }
+        }
+
+        Ok(orders)
     }
 
     /// Build the request URL for the UniswapX API

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -2,11 +2,13 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use lru::LruCache;
 use renegade_sdk::ExternalMatchClient;
 use reqwest::Client as ReqwestClient;
+use tokio::sync::RwLock;
 use tracing::error;
 
-use crate::{cli::Cli, error::SolverResult};
+use crate::{cli::Cli, error::SolverResult, uniswapx::api_types::OrderEntity};
 
 mod api_interaction;
 mod api_types;
@@ -15,10 +17,24 @@ mod solve;
 /// The interval at which to poll for new orders
 const POLLING_INTERVAL: Duration = Duration::from_secs(1);
 
+/// The maximum number of orders to cache
+///
+/// Orders are typically only duplicated for a short window while the auction
+/// commences, so a small cache is sufficient.
+const ORDER_CACHE_SIZE: usize = 100;
+
 /// A shared read-only hashmap of supported tokens
 ///
 /// Maps from address to symbol
 type SupportedTokens = Arc<HashMap<String, String>>;
+/// A shared read-only LRU cache of order hashes we've already tried to handle
+type OrderCache = Arc<RwLock<LruCache<String, ()>>>;
+
+/// Create a new order cache
+fn new_order_cache() -> OrderCache {
+    let cache_size = std::num::NonZeroUsize::new(ORDER_CACHE_SIZE).unwrap();
+    Arc::new(RwLock::new(LruCache::new(cache_size)))
+}
 
 /// The UniswapX API client
 #[derive(Clone)]
@@ -33,6 +49,11 @@ pub struct UniswapXSolver {
     http_client: ReqwestClient,
     /// The Renegade client
     renegade_client: ExternalMatchClient,
+    /// LRU cache of order hashes we've already tried to handle
+    ///
+    /// An order is placed in the cache even if processing the order fails, this
+    /// cache is for deduplicating requests rather than tracking order status.
+    order_cache: OrderCache,
 }
 
 impl UniswapXSolver {
@@ -49,7 +70,13 @@ impl UniswapXSolver {
             ExternalMatchClient::new_base_mainnet_client(&renegade_api_key, &renegade_api_secret)?;
         let supported_tokens = Self::load_supported_tokens(&renegade_client).await?;
 
-        Ok(Self { base_url, http_client: ReqwestClient::new(), renegade_client, supported_tokens })
+        Ok(Self {
+            base_url,
+            http_client: ReqwestClient::new(),
+            renegade_client,
+            supported_tokens,
+            order_cache: new_order_cache(),
+        })
     }
 
     /// Load the known tokens from the database
@@ -71,6 +98,20 @@ impl UniswapXSolver {
     async fn is_token_supported(&self, token: &str) -> bool {
         let token = token.to_lowercase();
         self.supported_tokens.contains_key(&token)
+    }
+
+    /// Check if an order has already been processed
+    async fn is_order_processed(&self, order: &OrderEntity) -> bool {
+        let hash = order.order_hash.clone();
+        let cache = self.order_cache.read().await;
+        cache.contains(&hash)
+    }
+
+    /// Mark an order as being processed
+    async fn mark_order_processed(&self, order: &OrderEntity) {
+        let hash = order.order_hash.clone();
+        let mut cache = self.order_cache.write().await;
+        cache.put(hash, ());
     }
 
     // ----------------
@@ -105,9 +146,10 @@ impl UniswapXSolver {
         // Fetch open orders from the API
         let orders = self.fetch_open_orders().await?;
 
-        // Spawn a task to solve each order
+        // Spawn a task to solve each new order
         for order in orders {
             let self_clone = self.clone();
+            self.mark_order_processed(&order).await;
             tokio::spawn(async move {
                 if let Err(e) = self_clone.solve_order(order).await {
                     error!("Error solving order: {e}");


### PR DESCRIPTION
### Purpose
This PR adds a simple LRU cache to deduplicate orders polled from the UniswapX API. We cache the order on its `orderHash` field provided by the API.

### Testing
- [x] Tested locally, verified that we no longer processed duplicate requests