### PR TITLE
funds-manager: api, server: add swap-immediate route

### DIFF
--- a/funds-manager/Dockerfile
+++ b/funds-manager/Dockerfile
@@ -57,4 +57,3 @@ COPY --from=builder /build/target/release/funds-manager /bin/funds-manager
 # Set log filtering
 ENV RUST_LOG="funds_manager=info,fireblocks_sdk=off,warp=warn"
 ENTRYPOINT ["/bin/funds-manager"]
-CMD ["--datadog-logging"]

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -33,6 +33,9 @@ pub const GET_EXECUTION_QUOTE_ROUTE: &str = "get-execution-quote";
 pub const EXECUTE_SWAP_ROUTE: &str = "execute-swap";
 /// The route to withdraw USDC to Hyperliquid from the quoter hot wallet
 pub const WITHDRAW_TO_HYPERLIQUID_ROUTE: &str = "withdraw-to-hyperliquid";
+/// The route to swap immediately on the quoter hot wallet,
+/// fetching a quote and executing it without first returning it to the client
+pub const SWAP_IMMEDIATE_ROUTE: &str = "swap-immediate";
 
 // -------------
 // | Api Types |
@@ -255,6 +258,15 @@ pub struct ExecuteSwapRequest {
 /// The response body for executing a swap on the execution venue
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExecuteSwapResponse {
+    /// The tx hash of the swap
+    pub tx_hash: String,
+}
+
+/// The response body for executing an immediate swap
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SwapImmediateResponse {
+    /// The quote that was executed
+    pub quote: ExecutionQuote,
     /// The tx hash of the swap
     pub tx_hash: String,
 }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -17,7 +17,8 @@ use funds_manager_api::hot_wallets::{
 };
 use funds_manager_api::quoters::{
     AugmentedExecutionQuote, DepositAddressResponse, ExecuteSwapRequest, ExecuteSwapResponse,
-    GetExecutionQuoteResponse, WithdrawFundsRequest, WithdrawToHyperliquidRequest,
+    GetExecutionQuoteResponse, SwapImmediateResponse, WithdrawFundsRequest,
+    WithdrawToHyperliquidRequest,
 };
 use funds_manager_api::vaults::{GetVaultBalancesRequest, VaultBalancesResponse};
 use itertools::Itertools;
@@ -26,7 +27,7 @@ use renegade_common::types::token::default_chain;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{instrument, warn};
 use warp::reply::Json;
 
 // --- Constants --- //
@@ -181,6 +182,7 @@ pub(crate) async fn get_deposit_address_handler(
 }
 
 /// Handler for getting an execution quote
+#[instrument(skip_all)]
 pub(crate) async fn get_execution_quote_handler(
     chain: Chain,
     _body: Bytes, // no body
@@ -204,6 +206,7 @@ pub(crate) async fn get_execution_quote_handler(
 }
 
 /// Handler for executing a swap
+#[instrument(skip_all)]
 pub(crate) async fn execute_swap_handler(
     chain: Chain,
     req: ExecuteSwapRequest,
@@ -240,6 +243,39 @@ pub(crate) async fn execute_swap_handler(
     });
 
     let resp = ExecuteSwapResponse { tx_hash: format!("{:#x}", tx_hash) };
+    Ok(warp::reply::json(&resp))
+}
+
+/// Handler for executing an immediate swap
+#[instrument(skip_all)]
+pub(crate) async fn swap_immediate_handler(
+    chain: Chain,
+    query_params: HashMap<String, String>,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let execution_client = server.get_execution_client(&chain)?;
+    let custody_client = server.get_custody_client(&chain)?;
+    let metrics_recorder = server.get_metrics_recorder(&chain)?;
+
+    // Fetch a quote using the provided query parameters
+    let quote = execution_client.get_quote(query_params).await?;
+    let augmented_quote = AugmentedExecutionQuote::new(quote.clone(), chain);
+
+    // Top up the quoter hot wallet gas before swapping
+    custody_client.top_up_quoter_hot_wallet_gas().await?;
+
+    // Execute the swap
+    let hot_wallet = custody_client.get_quoter_hot_wallet().await?;
+    let wallet = custody_client.get_hot_wallet_private_key(&hot_wallet.address).await?;
+    let receipt = execution_client.execute_swap(quote.clone(), &wallet).await?;
+    let tx_hash = receipt.transaction_hash;
+
+    // Record swap cost metrics
+    tokio::spawn(async move {
+        metrics_recorder.record_swap_cost(&receipt, &augmented_quote).await;
+    });
+
+    let resp = SwapImmediateResponse { quote, tx_hash: format!("{:#x}", tx_hash) };
     Ok(warp::reply::json(&resp))
 }
 

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use alloy::{
     providers::{
         fillers::{BlobGasFiller, ChainIdFiller, GasFiller},
-        DynProvider, ProviderBuilder,
+        DynProvider, Provider, ProviderBuilder,
     },
     sol,
 };
@@ -17,7 +17,10 @@ use bigdecimal::{BigDecimal, FromPrimitive, RoundingMode, ToPrimitive};
 use renegade_common::types::chain::Chain;
 use renegade_util::err_str;
 
-use crate::{cli::Environment, error::FundsManagerError};
+use crate::{
+    cli::{Environment, BLOCK_POLLING_INTERVAL},
+    error::FundsManagerError,
+};
 
 // ---------
 // | ERC20 |
@@ -52,6 +55,8 @@ pub fn build_provider(url: &str) -> Result<DynProvider, FundsManagerError> {
         .filler(GasFiller)
         .filler(BlobGasFiller)
         .connect_http(url);
+
+    provider.client().set_poll_interval(BLOCK_POLLING_INTERVAL);
 
     Ok(DynProvider::new(provider))
 }


### PR DESCRIPTION
This PR adds a `/swap-immediate` route, which fetches & executes a quote without first returning the quote to the client. The client can set desired slippage etc. parameters via the query string.

This PR also configures the funds manager to export OTLP traces and instruments the `get-execution-quote`, `execute-swap`, and `swap-immediate` routes so that we can measure the overal latency improvements due to using the new endpoint.

### Testing
- [ ] Test against local funds manager w/ updated TS SDK