### PR TITLE
funds-manager: metrics: use correct buy mint when searching for transfer logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,6 +4547,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serde_qs",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -8854,6 +8855,22 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb0b9062a400c31442e67d1f2b1e7746bebd691110ebee1b7d0c7293b04fab1"
+dependencies = [
+ "futures",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "serde",
+ "thiserror 2.0.12",
+ "tracing",
+ "warp",
 ]
 
 [[package]]

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -224,14 +224,14 @@ impl AugmentedExecutionQuote {
     }
 
     /// Returns the notional volume in USDC, taking into account the actual
-    /// transfer amount for sell orders
-    pub fn notional_volume_usdc(&self, transfer_amount: U256) -> Result<f64, String> {
+    /// buy amount for sell orders
+    pub fn notional_volume_usdc(&self, buy_amount_actual: U256) -> Result<f64, String> {
         if self.is_buy() {
             self.get_decimal_corrected_sell_amount()
         } else {
-            let transfer_amount = u256_try_into_u128(transfer_amount)?;
+            let buy_amount = u256_try_into_u128(buy_amount_actual)?;
 
-            Ok(self.get_buy_token().convert_to_decimal(transfer_amount))
+            Ok(self.get_buy_token().convert_to_decimal(buy_amount))
         }
     }
 }

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -80,7 +80,7 @@ pub struct ExecutionQuote {
     pub buy_amount_min: U256,
     /// The submitting address
     pub from: Address,
-    /// The 0x swap contract address
+    /// The swap contract address
     pub to: Address,
     /// The calldata for the swap
     pub data: Bytes,
@@ -260,6 +260,68 @@ pub struct ExecuteSwapRequest {
 pub struct ExecuteSwapResponse {
     /// The tx hash of the swap
     pub tx_hash: String,
+}
+
+/// The subset of LiFi quote request query parameters that we support
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiFiQuoteParams {
+    /// The token that should be transferred. Can be the address or the symbol
+    pub from_token: String,
+    /// The token that should be transferred to. Can be the address or the
+    /// symbol
+    pub to_token: String,
+    /// The amount that should be sent including all decimals (e.g. 1000000 for
+    /// 1 USDC (6 decimals))
+    #[serde(with = "u256_string_serialization")]
+    pub from_amount: U256,
+    /// The sending wallet address
+    pub from_address: String,
+    /// The receiving wallet address. If none is provided, the fromAddress will
+    /// be used
+    #[serde(default)]
+    pub to_address: Option<String>,
+    /// The ID of the sending chain
+    pub from_chain: usize,
+    /// The ID of the receiving chain
+    pub to_chain: usize,
+    /// The maximum allowed slippage for the transaction as a decimal value.
+    /// 0.005 represents 0.5%.
+    #[serde(default = "default_slippage")]
+    pub slippage: Option<f64>,
+    /// Timing setting to wait for a certain amount of swap rates. In the format
+    /// minWaitTime-${minWaitTimeMs}-${startingExpectedResults}-${reduceEveryMs}.
+    /// Please check docs.li.fi for more details.
+    #[serde(default)]
+    pub swap_step_timing_strategies: Option<Vec<String>>,
+    /// Which kind of route should be preferred
+    #[serde(default)]
+    pub order: Option<String>,
+    /// Parameter to skip transaction simulation. The quote will be returned
+    /// faster but the transaction gas limit won't be accurate.
+    #[serde(default)]
+    pub skip_simulation: Option<bool>,
+    /// List of exchanges that are allowed for this transaction
+    #[serde(default = "default_allow_exchanges")]
+    pub allow_exchanges: Option<Vec<String>>,
+    /// List of exchanges that are not allowed for this transaction
+    #[serde(default = "default_deny_exchanges")]
+    pub deny_exchanges: Option<Vec<String>>,
+}
+
+/// The default value for the slippage parameter
+fn default_slippage() -> Option<f64> {
+    Some(0.005)
+}
+
+/// The default value for the allow_exchanges parameter
+fn default_allow_exchanges() -> Option<Vec<String>> {
+    Some(vec!["all".to_string()])
+}
+
+/// The default value for the deny_exchanges parameter
+fn default_deny_exchanges() -> Option<Vec<String>> {
+    Some(vec!["none".to_string()])
 }
 
 /// The response body for executing an immediate swap

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -68,3 +68,4 @@ serde = "1.0"
 serde_json = "1.0"
 tracing = "0.1"
 uuid = "1.16"
+serde_qs = { version = "1.0.0-rc.3", features = ["warp"] }

--- a/funds-manager/funds-manager-server/src/execution_client/error.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/error.rs
@@ -13,6 +13,8 @@ pub enum ExecutionClientError {
     Http(String),
     /// An error parsing a value
     Parse(String),
+    /// A custom error
+    Custom(String),
 }
 
 impl ExecutionClientError {
@@ -33,6 +35,12 @@ impl ExecutionClientError {
     pub fn parse<T: ToString>(e: T) -> Self {
         ExecutionClientError::Parse(e.to_string())
     }
+
+    /// Create a new custom error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom<T: ToString>(e: T) -> Self {
+        ExecutionClientError::Custom(e.to_string())
+    }
 }
 
 impl Display for ExecutionClientError {
@@ -41,6 +49,7 @@ impl Display for ExecutionClientError {
             ExecutionClientError::Arbitrum(e) => format!("Arbitrum error: {e}"),
             ExecutionClientError::Http(e) => format!("HTTP error: {e}"),
             ExecutionClientError::Parse(e) => format!("Parse error: {e}"),
+            ExecutionClientError::Custom(e) => format!("Custom error: {e}"),
         };
 
         write!(f, "{}", msg)

--- a/funds-manager/funds-manager-server/src/execution_client/quotes.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/quotes.rs
@@ -1,8 +1,6 @@
 //! Client methods for fetching quotes and prices from the execution venue
 
-use std::collections::HashMap;
-
-use funds_manager_api::quoters::ExecutionQuote;
+use funds_manager_api::quoters::{ExecutionQuote, LiFiQuoteParams};
 use funds_manager_api::venue::LiFiQuote;
 
 use super::{error::ExecutionClientError, ExecutionClient};
@@ -14,12 +12,13 @@ impl ExecutionClient {
     /// Fetch a quote by forwarding raw query parameters
     pub async fn get_quote(
         &self,
-        query_params: HashMap<String, String>,
+        params: LiFiQuoteParams,
     ) -> Result<ExecutionQuote, ExecutionClientError> {
-        let params: Vec<(&str, &str)> =
-            query_params.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let qs_config = serde_qs::Config::new().array_format(serde_qs::ArrayFormat::Unindexed);
+        let query_string = qs_config.serialize_string(&params).unwrap();
+        let url = format!("{}?{}", QUOTE_ENDPOINT, query_string);
 
-        let resp: LiFiQuote = self.send_get_request(QUOTE_ENDPOINT, &params).await?;
+        let resp: LiFiQuote = self.send_get_request(&url).await?;
         Ok(resp.into())
     }
 }

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -102,10 +102,12 @@ impl MetricsRecorder {
         receipt: &TransactionReceipt,
         quote: &AugmentedExecutionQuote,
     ) -> Result<SwapExecutionData, FundsManagerError> {
-        let mint = quote.get_base_token().get_alloy_address();
+        let base_mint = quote.get_base_token().get_alloy_address();
+        let binance_price = self.get_price(&base_mint, quote.chain).await?;
 
-        let binance_price = self.get_price(&mint, quote.chain).await?;
-        let buy_amount_actual = self.get_buy_amount_actual(receipt, mint, quote.quote.from).await?;
+        let buy_mint = quote.get_buy_token().get_alloy_address();
+        let buy_amount_actual =
+            self.get_buy_amount_actual(receipt, buy_mint, quote.quote.from).await?;
 
         let execution_price =
             quote.get_price(Some(buy_amount_actual)).map_err(FundsManagerError::parse)?;


### PR DESCRIPTION
This PR ensures that we search for transfers of the _buy_ mint, rather than the _base_ mint, when finding the actual buy amount in a swap. This was preciously preventing us from recording swap costs on sells.

### TODO
- Test against mainnet