### PR TITLE
renegade-solver: uniswapx: Handle USDC and native ETH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8035,6 +8035,7 @@ name = "renegade-solver"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "bimap",
  "clap",
  "lru 0.12.5",
  "renegade-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,7 +2644,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2655,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2937,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -3023,7 +3023,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 [[package]]
 name = "constants"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "abi",
  "alloy",
@@ -4291,7 +4291,7 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "alloy",
  "base64 0.22.1",
@@ -4811,7 +4811,7 @@ dependencies = [
 [[package]]
 name = "gossip-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "bincode",
  "circuit-types",
@@ -5644,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "job-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "ark-mpc",
  "circuit-types",
@@ -7278,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "price-reporter"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "async-trait",
  "atomic_float 0.1.0",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "renegade-metrics"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "atomic_float 1.1.0",
  "circuit-types",
@@ -8034,6 +8034,7 @@ dependencies = [
 name = "renegade-solver"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "clap",
  "lru 0.12.5",
  "renegade-sdk",
@@ -9492,7 +9493,7 @@ dependencies = [
 [[package]]
 name = "system-bus"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "bus",
  "common",
@@ -9504,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -10444,7 +10445,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git#a745f3cc29892a1894a1d387ff977593541edf35"
+source = "git+https://github.com/renegade-fi/renegade#a745f3cc29892a1894a1d387ff977593541edf35"
 dependencies = [
  "alloy",
  "ark-ec",

--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -18,6 +18,9 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 warp = "0.3"
 
+# === Ethereum Dependencies === #
+alloy = { version = "1.0", features = ["essentials"] }
+
 # === Renegade Dependencies === #
 renegade-sdk = "0.1.15"
 renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade", features = [

--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -28,6 +28,7 @@ renegade-util = { package = "util", git = "https://github.com/renegade-fi/renega
 ] }
 
 # === Misc Dependencies === #
+bimap = "0.6"
 lru = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -1,16 +1,19 @@
 //! Code for solving order routes
 
+use std::str::FromStr;
+
+use alloy::primitives::Address;
 use tracing::info;
 
 use crate::{
     error::SolverResult,
-    uniswapx::{api_types::OrderEntity, UniswapXSolver},
+    uniswapx::{api_types::OrderEntity, UniswapXSolver, USDC_SYMBOL},
 };
 
 impl UniswapXSolver {
     /// Solve a set of orders and submit solutions to the reactor
     pub(crate) async fn solve_order(&self, order: OrderEntity) -> SolverResult<()> {
-        // If the order is not serviceable, print it and return
+        // Check if the order is serviceable
         if !self.is_order_serviceable(&order).await {
             return Ok(());
         }
@@ -28,6 +31,18 @@ impl UniswapXSolver {
     }
 
     /// Decide whether an order is serviceable by the solver
+    async fn is_order_serviceable(&self, order: &OrderEntity) -> bool {
+        let input_token = &order.input.token;
+        for output in order.outputs.iter() {
+            if self.is_pair_serviceable(input_token, &output.token).await {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Returns whether a pair is serviceable
     ///
     /// An order is serviceable if one of the input or output tokens are
     /// supported by the Renegade API.
@@ -35,17 +50,30 @@ impl UniswapXSolver {
     /// If both tokens are supported, we can route the entire trade through the
     /// darkpool. Otherwise, we can build a two-legged trade brokered
     /// through USDC
-    pub(crate) async fn is_order_serviceable(&self, order: &OrderEntity) -> bool {
-        // TODO: Generalize across all output tokens
-        let input_token = &order.input.token;
-        let first_output_token = &order.outputs[0].token;
+    ///
+    /// Note that if the only known token is USDC, the pair is not serviceable.
+    async fn is_pair_serviceable(&self, input_token: &str, output_token: &str) -> bool {
+        // Parse the tokens, return false if they are not valid addresses
+        let input_token = match Address::from_str(input_token) {
+            Ok(addr) => addr,
+            Err(_) => return false,
+        };
+        let output_token = match Address::from_str(output_token) {
+            Ok(addr) => addr,
+            Err(_) => return false,
+        };
 
-        let input_known = self.is_token_supported(input_token).await;
-        let output_known = self.is_token_supported(first_output_token).await;
+        // At least one of the input or output token must be supported and not USDC
+        let input_usdc = self.is_usdc(input_token);
+        let output_usdc = self.is_usdc(output_token);
+        let input_known_not_usdc = self.is_token_supported(input_token) && !input_usdc;
+        let output_known_not_usdc = self.is_token_supported(output_token) && !output_usdc;
+        input_known_not_usdc || output_known_not_usdc
+    }
 
-        // If either token is known, the order is serviceable
-        // TODO: Exclude USDC orders paired with unsupported tokens
-        // TODO: Include native ETH orders
-        input_known || output_known
+    /// Returns whether the given token is USDC
+    fn is_usdc(&self, token: Address) -> bool {
+        let usdc_addr = self.get_token_address(USDC_SYMBOL).expect("No USDC address");
+        token == usdc_addr
     }
 }


### PR DESCRIPTION
### Purpose
This PR makes two changes:
- Adds `Address::ZERO` as a stand-in for native ETH swaps to the supported tokens map
- Requires that if one token is USDC in a pair, the other token must be explicitly supported for the pair to be supported. E.g. We cannot fill `TOKENABC -> USDC` if `TOKENABC` is not supported by Renegade.

### Testing
- [x] Tested locally, verified that orders were properly filtered