### PR TITLE
funds-manager: execution_client: recursively invoke half-sized swaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4547,6 +4547,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serde_qs",
  "tokio",
  "tokio-postgres",
  "tracing",
@@ -8854,6 +8855,22 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb0b9062a400c31442e67d1f2b1e7746bebd691110ebee1b7d0c7293b04fab1"
+dependencies = [
+ "futures",
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "serde",
+ "thiserror 2.0.12",
+ "tracing",
+ "warp",
 ]
 
 [[package]]

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -262,13 +262,74 @@ pub struct ExecuteSwapResponse {
     pub tx_hash: String,
 }
 
-/// The response body for executing an immediate swap
+/// Which kind of LiFi route should be preferred when fetching a quote
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum LiFiRouteOrder {
+    /// This sorting criterion prioritizes routes with the shortest estimated
+    /// execution time
+    #[serde(rename = "FASTEST")]
+    Fastest,
+    /// This criterion focuses on minimizing the cost of the transaction,
+    /// whether in token amount or USD amount (USD amount minus gas cost)
+    #[serde(rename = "CHEAPEST")]
+    Cheapest,
+}
+
+/// The subset of LiFi quote request query parameters that we support
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LiFiQuoteParams {
+    /// The token that should be transferred. Can be the address or the symbol
+    pub from_token: String,
+    /// The token that should be transferred to. Can be the address or the
+    /// symbol
+    pub to_token: String,
+    /// The amount that should be sent including all decimals (e.g. 1000000 for
+    /// 1 USDC (6 decimals))
+    pub from_amount: U256,
+    /// The sending wallet address
+    pub from_address: String,
+    /// The receiving wallet address. If none is provided, the fromAddress will
+    /// be used
+    pub to_address: Option<String>,
+    /// The ID of the sending chain
+    pub from_chain: usize,
+    /// The ID of the receiving chain
+    pub to_chain: usize,
+    /// The maximum allowed slippage for the transaction as a decimal value.
+    /// 0.005 represents 0.5%.
+    pub slippage: Option<f64>,
+    /// Timing setting to wait for a certain amount of swap rates. In the format
+    /// minWaitTime-${minWaitTimeMs}-${startingExpectedResults}-${reduceEveryMs}.
+    /// Please check docs.li.fi for more details.
+    pub swap_step_timing_strategies: Option<Vec<String>>,
+    /// Which kind of route should be preferred
+    pub order: Option<LiFiRouteOrder>,
+    /// Parameter to skip transaction simulation. The quote will be returned
+    /// faster but the transaction gas limit won't be accurate.
+    pub skip_simulation: Option<bool>,
+    /// List of exchanges that are allowed for this transaction
+    pub allow_exchanges: Option<Vec<String>>,
+    /// List of exchanges that are not allowed for this transaction
+    pub deny_exchanges: Option<Vec<String>>,
+    /// List of exchanges that should be preferred for this transaction
+    pub prefer_exchanges: Option<Vec<String>>,
+}
+
+/// The result of a swap
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SwapImmediateResponse {
+pub struct SwapResult {
     /// The quote that was executed
     pub quote: ExecutionQuote,
     /// The tx hash of the swap
     pub tx_hash: String,
+}
+
+/// The response body for executing an immediate swap
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SwapImmediateResponse {
+    /// The results of the swap
+    pub results: Vec<SwapResult>,
 }
 
 /// The request body for withdrawing USDC to Hyperliquid from the quoter hot

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -68,3 +68,4 @@ serde = "1.0"
 serde_json = "1.0"
 tracing = "0.1"
 uuid = "1.16"
+serde_qs = { version = "1.0.0-rc.3", features = ["warp"] }

--- a/funds-manager/funds-manager-server/src/execution_client/error.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/error.rs
@@ -13,6 +13,8 @@ pub enum ExecutionClientError {
     Http(String),
     /// An error parsing a value
     Parse(String),
+    /// A custom error
+    Custom(String),
 }
 
 impl ExecutionClientError {
@@ -33,6 +35,12 @@ impl ExecutionClientError {
     pub fn parse<T: ToString>(e: T) -> Self {
         ExecutionClientError::Parse(e.to_string())
     }
+
+    /// Create a new custom error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom<T: ToString>(e: T) -> Self {
+        ExecutionClientError::Custom(e.to_string())
+    }
 }
 
 impl Display for ExecutionClientError {
@@ -41,6 +49,7 @@ impl Display for ExecutionClientError {
             ExecutionClientError::Arbitrum(e) => format!("Arbitrum error: {e}"),
             ExecutionClientError::Http(e) => format!("HTTP error: {e}"),
             ExecutionClientError::Parse(e) => format!("Parse error: {e}"),
+            ExecutionClientError::Custom(e) => format!("Custom error: {e}"),
         };
 
         write!(f, "{}", msg)

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -48,27 +48,22 @@ impl ExecutionClient {
     }
 
     /// Get a full URL for a given endpoint
-    fn build_url(
-        &self,
-        endpoint: &str,
-        params: &[(&str, &str)],
-    ) -> Result<Url, ExecutionClientError> {
+    fn build_url(&self, endpoint: &str) -> Result<Url, ExecutionClientError> {
         let url = if !endpoint.starts_with('/') {
             format!("{}/{}", self.base_url, endpoint)
         } else {
             format!("{}{}", self.base_url, endpoint)
         };
 
-        Url::parse_with_params(&url, params).map_err(ExecutionClientError::parse)
+        Url::parse(&url).map_err(ExecutionClientError::parse)
     }
 
     /// Send a get request to the execution venue
     async fn send_get_request<T: for<'de> Deserialize<'de>>(
         &self,
         endpoint: &str,
-        params: &[(&str, &str)],
     ) -> Result<T, ExecutionClientError> {
-        let url = self.build_url(endpoint, params)?;
+        let url = self.build_url(endpoint)?;
 
         // Add an API key if present
         let mut request = self.http_client.get(url);

--- a/funds-manager/funds-manager-server/src/execution_client/quotes.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/quotes.rs
@@ -1,8 +1,6 @@
 //! Client methods for fetching quotes and prices from the execution venue
 
-use std::collections::HashMap;
-
-use funds_manager_api::quoters::ExecutionQuote;
+use funds_manager_api::quoters::{ExecutionQuote, LiFiQuoteParams};
 use funds_manager_api::venue::LiFiQuote;
 
 use super::{error::ExecutionClientError, ExecutionClient};
@@ -14,12 +12,13 @@ impl ExecutionClient {
     /// Fetch a quote by forwarding raw query parameters
     pub async fn get_quote(
         &self,
-        query_params: HashMap<String, String>,
+        params: LiFiQuoteParams,
     ) -> Result<ExecutionQuote, ExecutionClientError> {
-        let params: Vec<(&str, &str)> =
-            query_params.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+        let qs_config = serde_qs::Config::new().array_format(serde_qs::ArrayFormat::Unindexed);
+        let query_string = qs_config.serialize_string(&params).unwrap();
+        let url = format!("{}?{}", QUOTE_ENDPOINT, query_string);
 
-        let resp: LiFiQuote = self.send_get_request(QUOTE_ENDPOINT, &params).await?;
+        let resp: LiFiQuote = self.send_get_request(&url).await?;
         Ok(resp.into())
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -3,17 +3,24 @@
 use alloy::{
     eips::BlockId,
     network::TransactionBuilder,
-    providers::Provider,
+    providers::{DynProvider, Provider},
     rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::PrivateKeySigner,
 };
 use alloy_primitives::{Address, U256};
-use funds_manager_api::{quoters::ExecutionQuote, u256_try_into_u64};
-use tracing::info;
+use funds_manager_api::{
+    quoters::{AugmentedExecutionQuote, ExecutionQuote, LiFiQuoteParams},
+    u256_try_into_u64,
+};
+use renegade_common::types::chain::Chain;
+use tracing::{error, info, warn};
 
 use crate::helpers::IERC20;
 
 use super::{error::ExecutionClientError, ExecutionClient};
+
+/// The minimum amount of USDC that will be attempted to be swapped recursively
+const MIN_SWAP_QUOTE_AMOUNT: f64 = 10.0; // 10 USDC
 
 impl ExecutionClient {
     /// Execute a quoted swap
@@ -41,6 +48,28 @@ impl ExecutionClient {
         self.approve_erc20_allowance(quote.sell_token_address, quote.to, quote.sell_amount, wallet)
             .await?;
 
+        let tx = self.build_swap_tx(quote, &client).await?;
+
+        // Send the transaction
+        let pending_tx =
+            client.send_transaction(tx).await.map_err(ExecutionClientError::arbitrum)?;
+
+        let receipt = pending_tx.get_receipt().await.map_err(ExecutionClientError::arbitrum)?;
+
+        if !receipt.status() {
+            let error_msg = format!("tx ({:#x}) failed", receipt.transaction_hash);
+            return Err(ExecutionClientError::arbitrum(error_msg));
+        }
+
+        Ok(receipt)
+    }
+
+    /// Construct a swap transaction from an execution quote
+    async fn build_swap_tx(
+        &self,
+        quote: ExecutionQuote,
+        client: &DynProvider,
+    ) -> Result<TransactionRequest, ExecutionClientError> {
         let latest_block = client
             .get_block(BlockId::latest())
             .await
@@ -65,6 +94,33 @@ impl ExecutionClient {
             .with_max_priority_fee_per_gas(latest_basefee * 2)
             .with_gas_limit(gas_limit);
 
+        Ok(tx)
+    }
+
+    /// Attempt to execute a swap, recursively retrying failed swaps with
+    /// half-sized quotes down to a minimum trade size.
+    pub async fn swap_immediate_recursive(
+        &self,
+        chain: Chain,
+        params: LiFiQuoteParams,
+        wallet: PrivateKeySigner,
+    ) -> Result<Vec<(AugmentedExecutionQuote, TransactionReceipt)>, ExecutionClientError> {
+        let quote = self.get_quote(params.clone()).await?;
+        let augmented_quote = AugmentedExecutionQuote::new(quote.clone(), chain);
+
+        let quote_amount =
+            augmented_quote.get_quote_amount().map_err(ExecutionClientError::parse)?;
+
+        if quote_amount < MIN_SWAP_QUOTE_AMOUNT {
+            return Err(ExecutionClientError::custom(format!(
+                "Recursive swap amount of {quote_amount} USDC is less than minimum swap amount ({MIN_SWAP_QUOTE_AMOUNT})"
+            )));
+        }
+
+        let client = self.get_signing_provider(wallet.clone());
+
+        let tx = self.build_swap_tx(quote, &client).await?;
+
         // Send the transaction
         let pending_tx =
             client.send_transaction(tx).await.map_err(ExecutionClientError::arbitrum)?;
@@ -72,15 +128,47 @@ impl ExecutionClient {
         let receipt = pending_tx.get_receipt().await.map_err(ExecutionClientError::arbitrum)?;
 
         if !receipt.status() {
-            let error_msg = format!("tx ({:#x}) failed", receipt.transaction_hash);
-            return Err(ExecutionClientError::arbitrum(error_msg));
+            warn!("tx ({:#x}) failed, retrying w/ half-sized quotes", receipt.transaction_hash);
+            return Box::pin(self.swap_half_size_quotes(chain, params, wallet)).await;
         }
 
-        Ok(receipt)
+        Ok(vec![(augmented_quote, receipt)])
+    }
+
+    /// Attempt to execute a swap across two half-sized quotes
+    async fn swap_half_size_quotes(
+        &self,
+        chain: Chain,
+        original_params: LiFiQuoteParams,
+        wallet: PrivateKeySigner,
+    ) -> Result<Vec<(AugmentedExecutionQuote, TransactionReceipt)>, ExecutionClientError> {
+        let half_size_params = LiFiQuoteParams {
+            from_amount: original_params.from_amount / U256::from(2),
+            ..original_params
+        };
+
+        let mut results = vec![];
+
+        let first_half_results =
+            self.swap_immediate_recursive(chain, half_size_params.clone(), wallet.clone()).await;
+
+        let second_half_results =
+            self.swap_immediate_recursive(chain, half_size_params, wallet).await;
+
+        match first_half_results {
+            Ok(first_half_results) => results.extend(first_half_results),
+            Err(e) => error!("Failed to execute first half of swap: {e}"),
+        }
+        match second_half_results {
+            Ok(second_half_results) => results.extend(second_half_results),
+            Err(e) => error!("Failed to execute second half of swap: {e}"),
+        }
+
+        Ok(results)
     }
 
     /// Approve an erc20 allowance
-    async fn approve_erc20_allowance(
+    pub(crate) async fn approve_erc20_allowance(
         &self,
         token_address: Address,
         spender: Address,

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -3,8 +3,9 @@
 use crate::cli::Environment;
 use crate::custody_client::rpc_shim::JsonRpcRequest;
 use crate::custody_client::DepositWithdrawSource;
-use crate::error::ApiError;
+use crate::error::{ApiError, FundsManagerError};
 use crate::Server;
+use alloy_primitives::Address;
 use bytes::Bytes;
 use funds_manager_api::fees::{FeeWalletsResponse, WithdrawFeeBalanceRequest};
 use funds_manager_api::gas::{
@@ -17,8 +18,8 @@ use funds_manager_api::hot_wallets::{
 };
 use funds_manager_api::quoters::{
     AugmentedExecutionQuote, DepositAddressResponse, ExecuteSwapRequest, ExecuteSwapResponse,
-    GetExecutionQuoteResponse, SwapImmediateResponse, WithdrawFundsRequest,
-    WithdrawToHyperliquidRequest,
+    GetExecutionQuoteResponse, LiFiQuoteParams, SwapImmediateResponse, SwapResult,
+    WithdrawFundsRequest, WithdrawToHyperliquidRequest,
 };
 use funds_manager_api::vaults::{GetVaultBalancesRequest, VaultBalancesResponse};
 use itertools::Itertools;
@@ -186,14 +187,14 @@ pub(crate) async fn get_deposit_address_handler(
 pub(crate) async fn get_execution_quote_handler(
     chain: Chain,
     _body: Bytes, // no body
-    query_params: HashMap<String, String>,
+    params: LiFiQuoteParams,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
     let execution_client = server.get_execution_client(&chain)?;
 
     // Forward the query parameters to the execution client
     let quote = execution_client
-        .get_quote(query_params)
+        .get_quote(params)
         .await
         .map_err(|e| warp::reject::custom(ApiError::InternalError(e.to_string())))?;
 
@@ -250,32 +251,47 @@ pub(crate) async fn execute_swap_handler(
 #[instrument(skip_all)]
 pub(crate) async fn swap_immediate_handler(
     chain: Chain,
-    query_params: HashMap<String, String>,
+    params: LiFiQuoteParams,
     server: Arc<Server>,
 ) -> Result<Json, warp::Rejection> {
     let execution_client = server.get_execution_client(&chain)?;
     let custody_client = server.get_custody_client(&chain)?;
     let metrics_recorder = server.get_metrics_recorder(&chain)?;
 
-    // Fetch a quote using the provided query parameters
-    let quote = execution_client.get_quote(query_params).await?;
-    let augmented_quote = AugmentedExecutionQuote::new(quote.clone(), chain);
-
     // Top up the quoter hot wallet gas before swapping
     custody_client.top_up_quoter_hot_wallet_gas().await?;
 
-    // Execute the swap
     let hot_wallet = custody_client.get_quoter_hot_wallet().await?;
     let wallet = custody_client.get_hot_wallet_private_key(&hot_wallet.address).await?;
-    let receipt = execution_client.execute_swap(quote.clone(), &wallet).await?;
-    let tx_hash = receipt.transaction_hash;
+
+    // Approve the top-level sell amount
+    let sell_token_address: Address =
+        params.from_token.parse().map_err(FundsManagerError::parse)?;
+    let spender_address: Address = params.from_address.parse().map_err(FundsManagerError::parse)?;
+    let sell_token_amount = params.from_amount;
+    execution_client
+        .approve_erc20_allowance(sell_token_address, spender_address, sell_token_amount, &wallet)
+        .await?;
+
+    // Execute the swap recursively
+    let swap_results = execution_client.swap_immediate_recursive(chain, params, wallet).await?;
+    let api_swap_results = swap_results
+        .clone()
+        .into_iter()
+        .map(|(augmented_quote, receipt)| SwapResult {
+            quote: augmented_quote.quote,
+            tx_hash: format!("{:#x}", receipt.transaction_hash),
+        })
+        .collect_vec();
 
     // Record swap cost metrics
     tokio::spawn(async move {
-        metrics_recorder.record_swap_cost(&receipt, &augmented_quote).await;
+        for (augmented_quote, receipt) in swap_results {
+            metrics_recorder.record_swap_cost(&receipt, &augmented_quote).await;
+        }
     });
 
-    let resp = SwapImmediateResponse { quote, tx_hash: format!("{:#x}", tx_hash) };
+    let resp = SwapImmediateResponse { results: api_swap_results };
     Ok(warp::reply::json(&resp))
 }
 

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -23,7 +23,7 @@ pub mod server;
 
 use bytes::Bytes;
 use clap::Parser;
-use cli::{Cli, Environment};
+use cli::Cli;
 use custody_client::rpc_shim::JsonRpcRequest;
 use fee_indexer::Indexer;
 use funds_manager_api::fees::{
@@ -40,8 +40,8 @@ use funds_manager_api::hot_wallets::{
     TRANSFER_TO_VAULT_ROUTE, WITHDRAW_TO_HOT_WALLET_ROUTE,
 };
 use funds_manager_api::quoters::{
-    ExecuteSwapRequest, WithdrawFundsRequest, WithdrawToHyperliquidRequest, EXECUTE_SWAP_ROUTE,
-    GET_DEPOSIT_ADDRESS_ROUTE, GET_EXECUTION_QUOTE_ROUTE, SWAP_IMMEDIATE_ROUTE,
+    ExecuteSwapRequest, LiFiQuoteParams, WithdrawFundsRequest, WithdrawToHyperliquidRequest,
+    EXECUTE_SWAP_ROUTE, GET_DEPOSIT_ADDRESS_ROUTE, GET_EXECUTION_QUOTE_ROUTE, SWAP_IMMEDIATE_ROUTE,
     WITHDRAW_CUSTODY_ROUTE, WITHDRAW_TO_HYPERLIQUID_ROUTE,
 };
 use funds_manager_api::vaults::{GetVaultBalancesRequest, GET_VAULT_BALANCES_ROUTE};
@@ -66,6 +66,7 @@ use warp::Filter;
 use crate::custody_client::CustodyClient;
 use crate::error::ApiError;
 use crate::handlers::swap_immediate_handler;
+use crate::middleware::with_query_params;
 
 // -------
 // | Cli |
@@ -167,7 +168,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(warp::path("quoters"))
         .and(warp::path(GET_EXECUTION_QUOTE_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .and(warp::query::<HashMap<String, String>>())
+        .and(with_query_params::<LiFiQuoteParams>())
         .and(with_server(server.clone()))
         .and_then(get_execution_quote_handler);
 
@@ -189,13 +190,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(warp::path("quoters"))
         .and(warp::path(SWAP_IMMEDIATE_ROUTE))
         .and(with_hmac_auth(server.clone()))
-        .and(warp::query::<HashMap<String, String>>())
+        .and(with_query_params::<LiFiQuoteParams>())
         .and(with_server(server.clone()))
-        .and_then(
-            |chain: Chain, _body: Bytes, query: HashMap<String, String>, server: Arc<Server>| {
-                swap_immediate_handler(chain, query, server)
-            },
-        );
+        .and_then(|chain: Chain, _body: Bytes, params: LiFiQuoteParams, server: Arc<Server>| {
+            swap_immediate_handler(chain, params, server)
+        });
 
     let withdraw_to_hyperliquid = warp::post()
         .and(warp::path("custody"))
@@ -329,8 +328,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(rpc_handler);
 
-    let backwards_compatibility_routes = backwards_compatibility_routes(server.clone());
-
     let routes = ping
         .or(index_fees)
         .or(redeem_fees)
@@ -354,7 +351,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(get_hot_wallet_balances)
         .or(create_hot_wallet)
         .or(rpc)
-        .or(backwards_compatibility_routes)
         .boxed()
         .with(warp::trace::request())
         .recover(handle_rejection);
@@ -362,234 +358,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     warp::serve(routes).run(([0, 0, 0, 0], port)).await;
 
     Ok(())
-}
-
-/// Backwards-compatible route definitions, routing paths excluding the chain
-/// parameter to Arbitrum-specific handler invocations
-fn backwards_compatibility_routes(
-    server: Arc<Server>,
-) -> impl Filter<Extract: warp::Reply, Error = warp::Rejection> + Clone + Send {
-    // --- Fee Indexing --- //
-
-    let arb_chain = match server.environment {
-        Environment::Mainnet => Chain::ArbitrumOne,
-        Environment::Testnet => Chain::ArbitrumSepolia,
-    };
-
-    let index_fees = warp::post()
-        .and(warp::path("fees"))
-        .and(warp::path(INDEX_FEES_ROUTE))
-        .and(with_server(server.clone()))
-        .and_then(move |server: Arc<Server>| index_fees_handler(arb_chain, server));
-
-    let redeem_fees = warp::post()
-        .and(warp::path("fees"))
-        .and(warp::path(REDEEM_FEES_ROUTE))
-        .and(with_server(server.clone()))
-        .and_then(move |server: Arc<Server>| redeem_fees_handler(arb_chain, server));
-
-    let get_balances = warp::get()
-        .and(warp::path("fees"))
-        .and(warp::path(GET_FEE_WALLETS_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .and(with_server(server.clone()))
-        .and_then(move |body: Bytes, server: Arc<Server>| {
-            get_fee_wallets_handler(arb_chain, body, server)
-        });
-
-    let withdraw_fee_balance = warp::post()
-        .and(warp::path("fees"))
-        .and(warp::path(WITHDRAW_FEE_BALANCE_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawFeeBalanceRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: WithdrawFeeBalanceRequest, server: Arc<Server>| {
-            withdraw_fee_balance_handler(arb_chain, req, server)
-        });
-
-    // --- Quoters --- //
-
-    let withdraw_custody = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("quoters"))
-        .and(warp::path(WITHDRAW_CUSTODY_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawFundsRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: WithdrawFundsRequest, server: Arc<Server>| {
-            quoter_withdraw_handler(arb_chain, req, server)
-        });
-
-    let get_deposit_address = warp::get()
-        .and(warp::path("custody"))
-        .and(warp::path("quoters"))
-        .and(warp::path(GET_DEPOSIT_ADDRESS_ROUTE))
-        .and(with_server(server.clone()))
-        .and_then(move |server: Arc<Server>| get_deposit_address_handler(arb_chain, server));
-
-    let get_execution_quote = warp::get()
-        .and(warp::path("custody"))
-        .and(warp::path("quoters"))
-        .and(warp::path(GET_EXECUTION_QUOTE_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .and(warp::query::<HashMap<String, String>>())
-        .and(with_server(server.clone()))
-        .and_then(
-            move |body: Bytes, query_params: HashMap<String, String>, server: Arc<Server>| {
-                get_execution_quote_handler(arb_chain, body, query_params, server)
-            },
-        );
-
-    let execute_swap = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("quoters"))
-        .and(warp::path(EXECUTE_SWAP_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<ExecuteSwapRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: ExecuteSwapRequest, server: Arc<Server>| {
-            execute_swap_handler(arb_chain, req, server)
-        });
-
-    // --- Gas --- //
-
-    let withdraw_gas = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("gas"))
-        .and(warp::path(WITHDRAW_GAS_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawGasRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: WithdrawGasRequest, server: Arc<Server>| {
-            withdraw_gas_handler(arb_chain, req, server)
-        });
-
-    let refill_gas = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("gas"))
-        .and(warp::path(REFILL_GAS_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<RefillGasRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: RefillGasRequest, server: Arc<Server>| {
-            refill_gas_handler(arb_chain, req, server)
-        });
-
-    let add_gas_wallet = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("gas-wallets"))
-        .and(with_hmac_auth(server.clone()))
-        .and(with_server(server.clone()))
-        .and_then(move |body: Bytes, server: Arc<Server>| {
-            create_gas_wallet_handler(arb_chain, body, server)
-        });
-
-    let register_gas_wallet = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("gas-wallets"))
-        .and(warp::path(REGISTER_GAS_WALLET_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<RegisterGasWalletRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: RegisterGasWalletRequest, server: Arc<Server>| {
-            register_gas_wallet_handler(arb_chain, req, server)
-        });
-
-    let report_active_peers = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("gas-wallets"))
-        .and(warp::path(REPORT_ACTIVE_PEERS_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<ReportActivePeersRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: ReportActivePeersRequest, server: Arc<Server>| {
-            report_active_peers_handler(arb_chain, req, server)
-        });
-
-    let refill_gas_sponsor = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("gas"))
-        .and(warp::path(REFILL_GAS_SPONSOR_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .and(with_server(server.clone()))
-        .and_then(move |body: Bytes, server: Arc<Server>| {
-            refill_gas_sponsor_handler(arb_chain, body, server)
-        });
-
-    // --- Hot Wallets --- //
-
-    let create_hot_wallet = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("hot-wallets"))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<CreateHotWalletRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: CreateHotWalletRequest, server: Arc<Server>| {
-            create_hot_wallet_handler(arb_chain, req, server)
-        });
-
-    let get_hot_wallet_balances = warp::get()
-        .and(warp::path("custody"))
-        .and(warp::path("hot-wallets"))
-        .and(with_hmac_auth(server.clone()))
-        .and(warp::query::<HashMap<String, String>>())
-        .and(with_server(server.clone()))
-        .and_then(
-            move |body: Bytes, query_params: HashMap<String, String>, server: Arc<Server>| {
-                get_hot_wallet_balances_handler(arb_chain, body, query_params, server)
-            },
-        );
-
-    let transfer_to_vault = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("hot-wallets"))
-        .and(warp::path(TRANSFER_TO_VAULT_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<TransferToVaultRequest>)
-        .and_then(identity)
-        .and(with_server(server.clone()))
-        .and_then(move |req: TransferToVaultRequest, server: Arc<Server>| {
-            transfer_to_vault_handler(arb_chain, req, server)
-        });
-
-    let transfer_to_hot_wallet = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path("hot-wallets"))
-        .and(warp::path(WITHDRAW_TO_HOT_WALLET_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_json_body::<WithdrawToHotWalletRequest>)
-        .and_then(identity)
-        .and(with_server(server))
-        .and_then(move |req: WithdrawToHotWalletRequest, server: Arc<Server>| {
-            withdraw_from_vault_handler(arb_chain, req, server)
-        });
-
-    index_fees
-        .or(redeem_fees)
-        .or(withdraw_custody)
-        .or(get_deposit_address)
-        .or(get_execution_quote)
-        .or(execute_swap)
-        .or(withdraw_gas)
-        .or(refill_gas)
-        .or(report_active_peers)
-        .or(refill_gas_sponsor)
-        .or(register_gas_wallet)
-        .or(add_gas_wallet)
-        .or(get_balances)
-        .or(withdraw_fee_balance)
-        .or(transfer_to_vault)
-        .or(transfer_to_hot_wallet)
-        .or(get_hot_wallet_balances)
-        .or(create_hot_wallet)
 }
 
 // -----------


### PR DESCRIPTION
This PR upgrades the `swap-immediate` route to recursively attempt half-sized swaps, if a given swap failed. If any sub-swaps fail, the route handler will not error. Rather, failures are logged and any other successful swap results are collected, effectively allowing for partial filling of the total requested swap amount.

This requires us to construct the query parameters for calls to the LiFi API natively, for which we introduce the `serde_qs` dependency as it can handle the list-type query parameters using repeated key names, as expected by the LiFi API.

We remove the backwards compatibility routes from the multi-chain migration as all clients of the funds manager are migrated.

### Testing
- [ ] Test against mainnet using local funds manager & updated TS SDK