### PR TITLE
renegade-solver: uniswapx: abis: Add ABI definitions

### DIFF
--- a/renegade-solver/src/error.rs
+++ b/renegade-solver/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for the solver
 
+use alloy::primitives::U256;
 use renegade_sdk::ExternalMatchClientError;
 use serde_json::json;
 use thiserror::Error;
@@ -16,12 +17,15 @@ pub type SolverResult<T> = Result<T, SolverError>;
 /// The generic solver error
 #[derive(Error, Debug)]
 pub enum SolverError {
+    /// An error ABI encoding/decoding a value
+    #[error("ABI encoding/decoding error: {0}")]
+    AbiEncoding(String),
     /// HTTP error occurred
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
-    /// An invalid address was provided
-    #[error("Invalid address: {0}")]
-    InvalidAddress(String),
+    /// An invalid u256 was provided
+    #[error("Invalid u256: {0}")]
+    InvalidU256(U256),
     /// JSON serialization/deserialization error
     #[error("JSON error: {0}")]
     Serialization(#[from] serde_json::Error),
@@ -31,10 +35,10 @@ pub enum SolverError {
 }
 
 impl SolverError {
-    /// Create an invalid address error
+    /// Create an ABI encoding/decoding error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn invalid_address<S: ToString>(s: S) -> Self {
-        Self::InvalidAddress(s.to_string())
+    pub fn abi_encoding<S: ToString>(msg: S) -> Self {
+        Self::AbiEncoding(msg.to_string())
     }
 }
 

--- a/renegade-solver/src/uniswapx/abis/conversion.rs
+++ b/renegade-solver/src/uniswapx/abis/conversion.rs
@@ -1,0 +1,14 @@
+//! Conversion helpers for UniswapX ABI types
+
+use alloy::primitives::U256;
+
+use crate::error::{SolverError, SolverResult};
+
+// ----------------------
+// | Conversion Helpers |
+// ----------------------
+
+/// Parse a u128 from a U256
+pub(crate) fn u256_to_u128(u256: U256) -> SolverResult<u128> {
+    u256.try_into().map_err(|_| SolverError::InvalidU256(u256))
+}

--- a/renegade-solver/src/uniswapx/abis/mod.rs
+++ b/renegade-solver/src/uniswapx/abis/mod.rs
@@ -1,0 +1,4 @@
+//! ABI types for UniswapX and our filler contract
+
+pub(crate) mod conversion;
+pub mod uniswapx;

--- a/renegade-solver/src/uniswapx/abis/uniswapx.rs
+++ b/renegade-solver/src/uniswapx/abis/uniswapx.rs
@@ -1,0 +1,65 @@
+//! ABI types for UniswapX
+
+use alloy::sol;
+
+// Copied from [UniswapX PriorityOrderReactor.sol](https://github.com/Uniswap/uniswapx/blob/main/src/lib/PriorityOrderLib.sol)
+sol! {
+    #[derive(Debug)]
+    /// @dev UniswapX Priority Order Reactor interface
+    contract PriorityOrderReactor {
+        struct OrderInfo {
+            address reactor;
+            address swapper;
+            uint256 nonce;
+            uint256 deadline;
+            address additionalValidationContract;
+            bytes additionalValidationData;
+        }
+
+        struct PriorityCosignerData {
+            // the block at which the order can be executed (overrides auctionStartBlock)
+            uint256 auctionTargetBlock;
+        }
+
+        struct PriorityInput {
+            address token;
+            uint256 amount;
+            // the less amount of input to be received per wei of priority fee
+            uint256 mpsPerPriorityFeeWei;
+        }
+
+        struct PriorityOutput {
+
+            address token;
+            uint256 amount;
+            // the extra amount of output to be paid per wei of priority fee
+            uint256 mpsPerPriorityFeeWei;
+            address recipient;
+        }
+
+        /// @dev External struct used to specify priority orders
+        struct PriorityOrder {
+            // generic order information
+            OrderInfo info;
+            // The address which may cosign the order
+            address cosigner;
+            // the block at which the order can be executed
+            uint256 auctionStartBlock;
+            // the baseline priority fee for the order, above which additional taxes are applied
+            uint256 baselinePriorityFeeWei;
+            // The tokens that the swapper will provide when settling the order
+            PriorityInput input;
+            // The tokens that must be received to satisfy the order
+            PriorityOutput[] outputs;
+            // signed over by the cosigner
+            PriorityCosignerData cosignerData;
+            // signature from the cosigner over (orderHash || cosignerData)
+            bytes cosignature;
+        }
+
+        struct SignedOrder {
+            bytes order;
+            bytes signature;
+        }
+    }
+}

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -10,12 +10,9 @@ use reqwest::Client as ReqwestClient;
 use tokio::sync::RwLock;
 use tracing::error;
 
-use crate::{
-    cli::Cli,
-    error::{SolverError, SolverResult},
-    uniswapx::uniswap_api::types::OrderEntity,
-};
+use crate::{cli::Cli, error::SolverResult, uniswapx::uniswap_api::types::OrderEntity};
 
+mod abis;
 mod renegade_api;
 mod solve;
 mod uniswap_api;
@@ -48,12 +45,6 @@ type OrderCache = Arc<RwLock<LruCache<String, ()>>>;
 fn new_order_cache() -> OrderCache {
     let cache_size = std::num::NonZeroUsize::new(ORDER_CACHE_SIZE).unwrap();
     Arc::new(RwLock::new(LruCache::new(cache_size)))
-}
-
-/// Parse an address from a string
-fn parse_address(s: &str) -> SolverResult<Address> {
-    let addr = Address::from_str(s).map_err(|_| SolverError::invalid_address(s))?;
-    Ok(addr)
 }
 
 // ----------

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -1,17 +1,27 @@
 //! Code for solving order routes
 
+use alloy::primitives::Address;
 use tracing::info;
 
 use crate::{
     error::SolverResult,
-    uniswapx::{parse_address, uniswap_api::types::OrderEntity, UniswapXSolver},
+    uniswapx::{
+        abis::{conversion::u256_to_u128, uniswapx::PriorityOrderReactor::PriorityOrder},
+        uniswap_api::types::OrderEntity,
+        UniswapXSolver,
+    },
 };
 
 impl UniswapXSolver {
     /// Solve a set of orders and submit solutions to the reactor
-    pub(crate) async fn solve_order(&self, order: OrderEntity) -> SolverResult<()> {
+    pub(crate) async fn solve_order(&self, api_order: OrderEntity) -> SolverResult<()> {
+        // Decode the ABI encoded order
+        // The order amounts in the raw API response are currently incorrect, so we need
+        // to pull them from the ABI encoded order
+        let order = api_order.decode_priority_order()?;
+
         // Check if the order is serviceable
-        if !self.is_order_serviceable(&order).await? || !self.temporary_order_filter(&order)? {
+        if !self.is_order_serviceable(&order)? || !self.temporary_order_filter(&order)? {
             return Ok(());
         }
 
@@ -24,9 +34,9 @@ impl UniswapXSolver {
         );
 
         // Find a solution for the order
-        let in_token = parse_address(&order.input.token)?;
-        let out_token = parse_address(&order.outputs[0].token)?;
-        let amount: u128 = order.input.amount.parse().unwrap();
+        let in_token = order.input.token;
+        let out_token = order.outputs[0].token;
+        let amount = u256_to_u128(order.input.amount)?;
         let renegade_bundle = self.solve_renegade_leg(in_token, out_token, amount).await?;
         if let Some(bundle) = renegade_bundle {
             info!("Found renegade solution with receive amount: {}", bundle.receive.amount);
@@ -41,7 +51,7 @@ impl UniswapXSolver {
     /// solver simple
     ///
     /// TODO: Loosen and remove this method's checks in follow-ups
-    fn temporary_order_filter(&self, order: &OrderEntity) -> SolverResult<bool> {
+    fn temporary_order_filter(&self, order: &PriorityOrder) -> SolverResult<bool> {
         // For now we only support single-leg routes
         if order.outputs.len() != 1 {
             return Ok(false);
@@ -49,8 +59,8 @@ impl UniswapXSolver {
 
         // For now, we only support trades that can be entirely filled by Renegade
         // This is a pair of supported tokens in which one is USDC
-        let input_token = parse_address(&order.input.token)?;
-        let output_token = parse_address(&order.outputs[0].token)?;
+        let input_token = order.input.token;
+        let output_token = order.outputs[0].token;
         let is_input_usdc = self.is_usdc(input_token);
         let is_output_usdc = self.is_usdc(output_token);
         let input_supported = self.is_token_supported(input_token);
@@ -62,10 +72,10 @@ impl UniswapXSolver {
     }
 
     /// Decide whether an order is serviceable by the solver
-    async fn is_order_serviceable(&self, order: &OrderEntity) -> SolverResult<bool> {
-        let input_token = &order.input.token;
+    fn is_order_serviceable(&self, order: &PriorityOrder) -> SolverResult<bool> {
+        let input_token = order.input.token;
         for output in order.outputs.iter() {
-            if self.is_pair_serviceable(input_token, &output.token).await? {
+            if self.is_pair_serviceable(input_token, output.token)? {
                 return Ok(true);
             }
         }
@@ -87,15 +97,11 @@ impl UniswapXSolver {
     /// through USDC
     ///
     /// Note that if the only known token is USDC, the pair is not serviceable.
-    async fn is_pair_serviceable(
+    fn is_pair_serviceable(
         &self,
-        input_token: &str,
-        output_token: &str,
+        input_token: Address,
+        output_token: Address,
     ) -> SolverResult<bool> {
-        // Parse the tokens, return false if they are not valid addresses
-        let input_token = parse_address(input_token)?;
-        let output_token = parse_address(output_token)?;
-
         // At least one of the input or output token must be supported and not USDC
         let input_usdc = self.is_usdc(input_token);
         let output_usdc = self.is_usdc(output_token);

--- a/renegade-solver/src/uniswapx/uniswap_api/types.rs
+++ b/renegade-solver/src/uniswapx/uniswap_api/types.rs
@@ -3,7 +3,13 @@
 //! These types are based on the UniswapX API OpenAPI specification
 //! [here](https://github.com/Uniswap/uniswapx-service/blob/main/swagger.json)
 
+use alloy::{hex, sol_types::SolValue};
 use serde::{Deserialize, Serialize};
+
+use crate::{
+    error::{SolverError, SolverResult},
+    uniswapx::abis::uniswapx::PriorityOrderReactor::PriorityOrder,
+};
 
 /// The response from the orders endpoint
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,6 +60,16 @@ pub struct OrderEntity {
     pub created_at: u64,
     /// Routing information
     pub route: Route,
+}
+
+impl OrderEntity {
+    /// Decode the encoded order
+    pub fn decode_priority_order(&self) -> SolverResult<PriorityOrder> {
+        let order_bytes =
+            hex::decode(self.encoded_order.clone()).map_err(SolverError::abi_encoding)?;
+        let order = PriorityOrder::abi_decode(&order_bytes).unwrap();
+        Ok(order)
+    }
 }
 
 /// Order input information


### PR DESCRIPTION
### Purpose
This PR adds UniswapX `PriorityOrderReactor` types to the repo and replaces all uses of the `OrderEntity` with the decoded `PriorityOrder`. The amounts on the `OrderEntity` are incorrect for an unknown reason, so we directly decode the solidity type used to parameterize the order.

### Testing
- [x] Tested server locally