### PR TITLE
funds-manager: custody_client: include native assets in vault balances endpoint

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -53,6 +53,14 @@ const ARB_SEPOLIA_ETH_ASSET_ID: &str = "ETH-AETH_SEPOLIA";
 const BASE_MAINNET_ETH_ASSET_ID: &str = "BASECHAIN_ETH";
 /// The Fireblocks asset ID for ETH on Base Sepolia
 const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
+
+/// The Fireblocks asset IDs for native assets on testnets
+pub const TESTNET_NATIVE_ASSET_IDS: &[&str] =
+    &[ARB_SEPOLIA_ETH_ASSET_ID, BASE_SEPOLIA_ETH_ASSET_ID];
+
+/// The Fireblocks asset IDs for native assets on mainnets
+pub const MAINNET_NATIVE_ASSET_IDS: &[&str] = &[ARB_ONE_ETH_ASSET_ID, BASE_MAINNET_ETH_ASSET_ID];
+
 /// The number of confirmations Fireblocks requires to consider a contract call
 /// final
 const FB_CONTRACT_CONFIRMATIONS: u64 = 3;
@@ -222,6 +230,15 @@ impl CustodyClient {
             Chain::ArbitrumSepolia => Ok(ARB_SEPOLIA_ETH_ASSET_ID.to_string()),
             Chain::BaseMainnet => Ok(BASE_MAINNET_ETH_ASSET_ID.to_string()),
             Chain::BaseSepolia => Ok(BASE_SEPOLIA_ETH_ASSET_ID.to_string()),
+            _ => Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
+        }
+    }
+
+    /// Get the Fireblocks asset IDs for native assets on the current chain
+    pub(crate) fn get_current_env_native_asset_ids(&self) -> Result<&[&str], FundsManagerError> {
+        match self.chain {
+            Chain::ArbitrumOne | Chain::BaseMainnet => Ok(MAINNET_NATIVE_ASSET_IDS),
+            Chain::ArbitrumSepolia | Chain::BaseSepolia => Ok(TESTNET_NATIVE_ASSET_IDS),
             _ => Err(FundsManagerError::custom(ERR_UNSUPPORTED_CHAIN)),
         }
     }


### PR DESCRIPTION
This PR tweaks the `get_vault_balances_handler` to include balances of native assets (e.g. ETH). For simplicity, we assume that any vault whose balances are queried only holds the native asset of one chain, so we simply use the zero address to represent any native asset balances held in the vault.

If we start using cross-chain vaults, we can use a more intelligent "pseudo-addressing" scheme for these balances.

### Testing
- [x] Tested by invoking the endpoint on a local funds manager running against testnet