### PR TITLE
funds-manager: handlers: add gas wallet addresses route

### DIFF
--- a/funds-manager/funds-manager-api/src/types/gas.rs
+++ b/funds-manager/funds-manager-api/src/types/gas.rs
@@ -69,3 +69,10 @@ pub struct ReportActivePeersRequest {
     /// The list of active peers
     pub peers: Vec<String>,
 }
+
+/// The response containing gas wallet addresses
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GasWalletsResponse {
+    /// The list of gas wallet addresses
+    pub addresses: Vec<String>,
+}

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -10,8 +10,8 @@ use alloy_primitives::Address;
 use bytes::Bytes;
 use funds_manager_api::fees::{FeeWalletsResponse, WithdrawFeeBalanceRequest};
 use funds_manager_api::gas::{
-    CreateGasWalletResponse, RefillGasRequest, RegisterGasWalletRequest, RegisterGasWalletResponse,
-    ReportActivePeersRequest, WithdrawGasRequest,
+    CreateGasWalletResponse, GasWalletsResponse, RefillGasRequest, RegisterGasWalletRequest,
+    RegisterGasWalletResponse, ReportActivePeersRequest, WithdrawGasRequest,
 };
 use funds_manager_api::hot_wallets::{
     CreateHotWalletRequest, CreateHotWalletResponse, HotWalletBalancesResponse,
@@ -425,6 +425,21 @@ pub(crate) async fn refill_gas_sponsor_handler(
     custody_client.refill_gas_sponsor().await?;
 
     let resp = json!({});
+    Ok(warp::reply::json(&resp))
+}
+
+/// Handler for getting all gas wallet addresses
+pub(crate) async fn get_gas_wallets_handler(
+    chain: Chain,
+    _body: Bytes, // no body
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let custody_client = server.get_custody_client(&chain)?;
+    let gas_wallets = custody_client.get_all_gas_wallets().await?;
+
+    let addresses = gas_wallets.into_iter().map(|wallet| wallet.address).collect();
+    let resp = GasWalletsResponse { addresses };
+
     Ok(warp::reply::json(&resp))
 }
 

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -48,11 +48,11 @@ use funds_manager_api::PING_ROUTE;
 use handlers::{
     create_gas_wallet_handler, create_hot_wallet_handler, execute_swap_handler,
     get_deposit_address_handler, get_execution_quote_handler, get_fee_wallets_handler,
-    get_hot_wallet_balances_handler, get_vault_balances_handler, index_fees_handler,
-    quoter_withdraw_handler, redeem_fees_handler, refill_gas_handler, refill_gas_sponsor_handler,
-    register_gas_wallet_handler, report_active_peers_handler, rpc_handler,
-    transfer_to_vault_handler, withdraw_fee_balance_handler, withdraw_from_vault_handler,
-    withdraw_gas_handler, withdraw_to_hyperliquid_handler,
+    get_gas_wallets_handler, get_hot_wallet_balances_handler, get_vault_balances_handler,
+    index_fees_handler, quoter_withdraw_handler, redeem_fees_handler, refill_gas_handler,
+    refill_gas_sponsor_handler, register_gas_wallet_handler, report_active_peers_handler,
+    rpc_handler, transfer_to_vault_handler, withdraw_fee_balance_handler,
+    withdraw_from_vault_handler, withdraw_gas_handler, withdraw_to_hyperliquid_handler,
 };
 use middleware::{identity, with_chain_and_json_body, with_hmac_auth, with_json_body};
 use renegade_common::types::chain::Chain;
@@ -272,6 +272,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(with_server(server.clone()))
         .and_then(refill_gas_sponsor_handler);
 
+    let get_gas_wallets = warp::get()
+        .and(warp::path("custody"))
+        .and(warp::path::param::<Chain>())
+        .and(warp::path("gas-wallets"))
+        .and(with_hmac_auth(server.clone()))
+        .and(with_server(server.clone()))
+        .and_then(get_gas_wallets_handler);
+
     // --- Hot Wallets --- //
 
     let create_hot_wallet = warp::post()
@@ -343,6 +351,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(refill_gas_sponsor)
         .or(register_gas_wallet)
         .or(add_gas_wallet)
+        .or(get_gas_wallets)
         .or(get_balances)
         .or(withdraw_fee_balance)
         .or(transfer_to_vault)


### PR DESCRIPTION
This PR adds a `GET` handler at `/custody/<chain>/gas-wallets` which returns all of the gas wallet addresses for the given chain. This will be used to record ETH holdings of the gas wallets in the NAV metrics.

### Testing
- [x] Run local funds manager w/ testnet params & invoke endpoint