### PR TITLE
auth-server: api-handlers: order-book: Add "all pairs" order book helper

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -291,15 +291,26 @@ async fn main() {
             server.handle_external_match_request(path, headers, body, query_str).await
         });
 
-    let order_book_depth = warp::path("v0")
+    let order_book_depth_with_mint = warp::path("v0")
         .and(warp::path("order_book"))
         .and(warp::path("depth"))
         .and(warp::path::param::<String>())
         .and(warp::path::full())
         .and(warp::header::headers_cloned())
         .and(with_server(server.clone()))
-        .and_then(|mint, path, headers, server: Arc<Server>| async move {
-            server.handle_order_book_depth_request(path, headers, mint).await
+        .and_then(|_mint, path, headers, server: Arc<Server>| async move {
+            server.handle_order_book_request(path, headers).await
+        });
+
+    let order_book_depth = warp::path("v0")
+        .and(warp::path("order_book"))
+        .and(warp::path("depth"))
+        .and(warp::path::end())
+        .and(warp::path::full())
+        .and(warp::header::headers_cloned())
+        .and(with_server(server.clone()))
+        .and_then(|path, headers, server: Arc<Server>| async move {
+            server.handle_order_book_request(path, headers).await
         });
 
     // Bind the server and listen
@@ -311,6 +322,7 @@ async fn main() {
         .or(external_malleable_assembly_path)
         .or(expire_api_key)
         .or(add_api_key)
+        .or(order_book_depth_with_mint)
         .or(order_book_depth)
         .boxed()
         .with(with_tracing())

--- a/auth/auth-server/src/server/api_handlers/order_book.rs
+++ b/auth/auth-server/src/server/api_handlers/order_book.rs
@@ -8,13 +8,12 @@ use super::{log_unsuccessful_relayer_request, Server};
 use crate::telemetry::helpers::record_relayer_request_500;
 
 impl Server {
-    /// Proxy GET /v0/order_book/depth/:mint to the relayer
+    /// Proxy GET requests to /v0/order_book/* endpoints to the relayer
     #[instrument(skip(self, path, headers))]
-    pub async fn handle_order_book_depth_request(
+    pub async fn handle_order_book_request(
         &self,
         path: warp::path::FullPath,
         headers: HeaderMap,
-        mint: String,
     ) -> Result<impl Reply, Rejection> {
         // Authorize the request
         let path_str = path.as_str();


### PR DESCRIPTION
### Purpose
This PR adds a proxy endpoint for the `/v0/order_book/depth` endpoint on the relayer which returns book depth for all supported pairs.

### Testing
- [x] Tested locally
- [ ] Test in testnet