### PR TITLE
funds-manager: metrics: parse transfer logs directly from receipt

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -16,7 +16,10 @@ use crate::{serialization::u256_string_serialization, u256_try_into_u128};
 pub const GET_DEPOSIT_ADDRESS_ROUTE: &str = "deposit-address";
 /// The route to withdraw funds from custody
 pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
-/// The route to fetch an execution quote on the quoter hot wallet
+/// The route to withdraw USDC to Hyperliquid from the quoter hot wallet
+pub const WITHDRAW_TO_HYPERLIQUID_ROUTE: &str = "withdraw-to-hyperliquid";
+/// The route to swap immediately on the quoter hot wallet,
+/// fetching a quote and executing it without first returning it to the client
 ///
 /// Expected query parameters (proxied directly to LiFi API):
 /// - fromChain: Source chain ID
@@ -28,13 +31,6 @@ pub const WITHDRAW_CUSTODY_ROUTE: &str = "withdraw";
 /// - fromAmount: Source token amount
 /// - order: Order preference for routing (e.g. 'CHEAPEST')
 /// - slippage: Slippage tolerance as a decimal (e.g. 0.0001 for 0.01%)
-pub const GET_EXECUTION_QUOTE_ROUTE: &str = "get-execution-quote";
-/// The route to execute a swap on the quoter hot wallet
-pub const EXECUTE_SWAP_ROUTE: &str = "execute-swap";
-/// The route to withdraw USDC to Hyperliquid from the quoter hot wallet
-pub const WITHDRAW_TO_HYPERLIQUID_ROUTE: &str = "withdraw-to-hyperliquid";
-/// The route to swap immediately on the quoter hot wallet,
-/// fetching a quote and executing it without first returning it to the client
 pub const SWAP_IMMEDIATE_ROUTE: &str = "swap-immediate";
 
 // -------------
@@ -234,32 +230,6 @@ impl AugmentedExecutionQuote {
             Ok(self.get_buy_token().convert_to_decimal(buy_amount))
         }
     }
-}
-
-/// The request body for fetching a quote from the execution venue
-#[derive(Debug, Serialize, Deserialize)]
-pub struct GetExecutionQuoteResponse {
-    /// The quote, directly from the execution venue
-    pub quote: ExecutionQuote,
-    /// The HMAC of the quote
-    pub signature: String,
-}
-
-/// The request body for executing a swap on the execution venue
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ExecuteSwapRequest {
-    /// The quote, implicitly accepted by the caller by its presence in this
-    /// request
-    pub quote: ExecutionQuote,
-    /// The HMAC of the quote
-    pub signature: String,
-}
-
-/// The response body for executing a swap on the execution venue
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ExecuteSwapResponse {
-    /// The tx hash of the swap
-    pub tx_hash: String,
 }
 
 /// The subset of LiFi quote request query parameters that we support

--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -62,9 +62,6 @@ pub struct Cli {
     /// The HMAC key to use for authentication
     #[clap(long, conflicts_with = "disable_auth", env = "HMAC_KEY")]
     pub hmac_key: Option<String>,
-    /// The HMAC key to use for signing quotes
-    #[clap(long, env = "QUOTE_HMAC_KEY")]
-    pub quote_hmac_key: String,
     /// Whether to disable authentication
     #[clap(long, conflicts_with = "hmac_key")]
     pub disable_auth: bool,
@@ -145,11 +142,6 @@ impl Cli {
     /// Get the HMAC key
     pub fn get_hmac_key(&self) -> Option<HmacKey> {
         self.hmac_key.as_ref().map(|key| HmacKey::from_hex_string(key).expect("Invalid HMAC key"))
-    }
-
-    /// Get the quote HMAC key
-    pub fn get_quote_hmac_key(&self) -> HmacKey {
-        HmacKey::from_hex_string(&self.quote_hmac_key).expect("Invalid quote HMAC key")
     }
 
     /// Parse the chain configs

--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -56,10 +56,11 @@ const BASE_SEPOLIA_ETH_ASSET_ID: &str = "BASECHAIN_ETH_TEST5";
 
 /// The Fireblocks asset IDs for native assets on testnets
 pub const TESTNET_NATIVE_ASSET_IDS: &[&str] =
-    &[ARB_SEPOLIA_ETH_ASSET_ID, BASE_SEPOLIA_ETH_ASSET_ID];
+    &[ARB_SEPOLIA_ETH_ASSET_ID, BASE_SEPOLIA_ETH_ASSET_ID, "ETH_TEST5"];
 
 /// The Fireblocks asset IDs for native assets on mainnets
-pub const MAINNET_NATIVE_ASSET_IDS: &[&str] = &[ARB_ONE_ETH_ASSET_ID, BASE_MAINNET_ETH_ASSET_ID];
+pub const MAINNET_NATIVE_ASSET_IDS: &[&str] =
+    &[ARB_ONE_ETH_ASSET_ID, BASE_MAINNET_ETH_ASSET_ID, "ETH"];
 
 /// The number of confirmations Fireblocks requires to consider a contract call
 /// final

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -30,44 +30,6 @@ pub const LIFI_DIAMOND_ADDRESS: Address =
     Address::new(hex!("0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae"));
 
 impl ExecutionClient {
-    /// Execute a quoted swap
-    pub async fn execute_swap(
-        &self,
-        quote: ExecutionQuote,
-        wallet: &PrivateKeySigner,
-    ) -> Result<TransactionReceipt, ExecutionClientError> {
-        // Execute the swap
-        let receipt = self.execute_swap_tx(quote, wallet).await?;
-        let tx_hash = receipt.transaction_hash;
-        info!("Swap executed at {tx_hash:#x}");
-        Ok(receipt)
-    }
-
-    /// Execute a swap
-    async fn execute_swap_tx(
-        &self,
-        quote: ExecutionQuote,
-        wallet: &PrivateKeySigner,
-    ) -> Result<TransactionReceipt, ExecutionClientError> {
-        let client = self.get_signing_provider(wallet.clone());
-
-        // Set approval for the sell token
-        self.approve_erc20_allowance(quote.sell_token_address, quote.to, quote.sell_amount, wallet)
-            .await?;
-
-        let tx = self.build_swap_tx(quote, &client).await?;
-
-        // Send the transaction
-        let receipt = self.send_tx(tx, &client).await?;
-
-        if !receipt.status() {
-            let error_msg = format!("tx ({:#x}) failed", receipt.transaction_hash);
-            return Err(ExecutionClientError::arbitrum(error_msg));
-        }
-
-        Ok(receipt)
-    }
-
     /// Construct a swap transaction from an execution quote
     async fn build_swap_tx(
         &self,

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -39,21 +39,19 @@ use funds_manager_api::hot_wallets::{
     TRANSFER_TO_VAULT_ROUTE, WITHDRAW_TO_HOT_WALLET_ROUTE,
 };
 use funds_manager_api::quoters::{
-    ExecuteSwapRequest, LiFiQuoteParams, WithdrawFundsRequest, WithdrawToHyperliquidRequest,
-    EXECUTE_SWAP_ROUTE, GET_DEPOSIT_ADDRESS_ROUTE, GET_EXECUTION_QUOTE_ROUTE, SWAP_IMMEDIATE_ROUTE,
-    WITHDRAW_CUSTODY_ROUTE, WITHDRAW_TO_HYPERLIQUID_ROUTE,
+    LiFiQuoteParams, WithdrawFundsRequest, WithdrawToHyperliquidRequest, GET_DEPOSIT_ADDRESS_ROUTE,
+    SWAP_IMMEDIATE_ROUTE, WITHDRAW_CUSTODY_ROUTE, WITHDRAW_TO_HYPERLIQUID_ROUTE,
 };
 use funds_manager_api::vaults::{GetVaultBalancesRequest, GET_VAULT_BALANCES_ROUTE};
 use funds_manager_api::PING_ROUTE;
 use handlers::{
-    create_gas_wallet_handler, create_hot_wallet_handler, execute_swap_handler,
-    get_deposit_address_handler, get_execution_quote_handler, get_fee_hot_wallet_address_handler,
-    get_fee_wallets_handler, get_gas_wallets_handler, get_hot_wallet_balances_handler,
-    get_vault_balances_handler, index_fees_handler, quoter_withdraw_handler, redeem_fees_handler,
-    refill_gas_handler, refill_gas_sponsor_handler, register_gas_wallet_handler,
-    report_active_peers_handler, rpc_handler, transfer_to_vault_handler,
-    withdraw_fee_balance_handler, withdraw_from_vault_handler, withdraw_gas_handler,
-    withdraw_to_hyperliquid_handler,
+    create_gas_wallet_handler, create_hot_wallet_handler, get_deposit_address_handler,
+    get_fee_hot_wallet_address_handler, get_fee_wallets_handler, get_gas_wallets_handler,
+    get_hot_wallet_balances_handler, get_vault_balances_handler, index_fees_handler,
+    quoter_withdraw_handler, redeem_fees_handler, refill_gas_handler, refill_gas_sponsor_handler,
+    register_gas_wallet_handler, report_active_peers_handler, rpc_handler,
+    transfer_to_vault_handler, withdraw_fee_balance_handler, withdraw_from_vault_handler,
+    withdraw_gas_handler, withdraw_to_hyperliquid_handler,
 };
 use middleware::{identity, with_chain_and_json_body, with_hmac_auth, with_json_body};
 use renegade_common::types::chain::Chain;
@@ -66,7 +64,6 @@ use warp::Filter;
 use crate::custody_client::CustodyClient;
 use crate::error::ApiError;
 use crate::handlers::swap_immediate_handler;
-use crate::middleware::with_query_params;
 
 // -------
 // | Cli |
@@ -168,28 +165,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and(warp::path(GET_DEPOSIT_ADDRESS_ROUTE))
         .and(with_server(server.clone()))
         .and_then(get_deposit_address_handler);
-
-    let get_execution_quote = warp::get()
-        .and(warp::path("custody"))
-        .and(warp::path::param::<Chain>())
-        .and(warp::path("quoters"))
-        .and(warp::path(GET_EXECUTION_QUOTE_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .and(with_query_params::<LiFiQuoteParams>())
-        .and(with_server(server.clone()))
-        .and_then(get_execution_quote_handler);
-
-    let execute_swap = warp::post()
-        .and(warp::path("custody"))
-        .and(warp::path::param::<Chain>())
-        .and(warp::path("quoters"))
-        .and(warp::path(EXECUTE_SWAP_ROUTE))
-        .and(with_hmac_auth(server.clone()))
-        .map(with_chain_and_json_body::<ExecuteSwapRequest>)
-        .and_then(identity)
-        .untuple_one()
-        .and(with_server(server.clone()))
-        .and_then(execute_swap_handler);
 
     let swap_immediate = warp::post()
         .and(warp::path("custody"))
@@ -349,8 +324,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .or(get_vault_balances)
         .or(withdraw_custody)
         .or(get_deposit_address)
-        .or(get_execution_quote)
-        .or(execute_swap)
         .or(swap_immediate)
         .or(withdraw_to_hyperliquid)
         .or(withdraw_gas)

--- a/funds-manager/funds-manager-server/src/middleware.rs
+++ b/funds-manager/funds-manager-server/src/middleware.rs
@@ -52,14 +52,6 @@ pub(crate) fn with_query_string() -> impl FilterExtracts<(String,)> {
         .or_else(|_| async move { Ok::<(String,), warp::Rejection>(("".to_string(),)) })
 }
 
-/// Deserialize query parameters from the request
-pub(crate) fn with_query_params<T: DeserializeOwned + Send + 'static>() -> impl FilterExtracts<(T,)>
-{
-    serde_qs::warp::query::<T>(
-        serde_qs::Config::new().array_format(serde_qs::ArrayFormat::Unindexed),
-    )
-}
-
 /// Verify the HMAC signature
 async fn verify_hmac(
     server: Arc<Server>,


### PR DESCRIPTION
This PR tweaks the way in which we deduce the actual buy amount in a swap by parsing logs directly from the received transaction receipt, instead of querying the RPC provider for logs in the given block range. This is an attempt at obviating more variables from this code path, which still occasionally throws the `no matching transfer event found` error despite using the correct buy token address.

Additionally, we remove the deprecated `get-quote` and `execute-swap` routes, as they are no longer in use by any clients.

### Testing
- [x] Run local funds manager + admin panel w/ mainnet params, execute swaps and assert that swap costs were recorded without failure.