### PR TITLE
funds-manager: execution-client: swap: Add better request tracing

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -93,7 +93,7 @@ impl ExecutionClient {
     }
 
     /// Send a transaction, awaiting its receipt
-    #[instrument(skip(self, tx, client))]
+    #[instrument(skip_all)]
     async fn send_tx(
         &self,
         tx: TransactionRequest,

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -12,9 +12,10 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use http::StatusCode;
+use renegade_util::telemetry::helpers::backfill_trace_field;
 use reqwest::{Client, Url};
 use serde::Deserialize;
-use tracing::error;
+use tracing::{error, instrument};
 
 use crate::helpers::build_provider;
 
@@ -92,6 +93,7 @@ impl ExecutionClient {
     }
 
     /// Send a transaction, awaiting its receipt
+    #[instrument(skip(self, tx, client))]
     async fn send_tx(
         &self,
         tx: TransactionRequest,
@@ -100,6 +102,7 @@ impl ExecutionClient {
         let pending_tx =
             client.send_transaction(tx).await.map_err(ExecutionClientError::arbitrum)?;
 
+        backfill_trace_field("tx_hash", pending_tx.tx_hash().to_string());
         pending_tx.get_receipt().await.map_err(ExecutionClientError::arbitrum)
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/quotes.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/quotes.rs
@@ -2,7 +2,7 @@
 
 use funds_manager_api::quoters::{ExecutionQuote, LiFiQuoteParams};
 use funds_manager_api::venue::LiFiQuote;
-use tracing::info;
+use tracing::{info, instrument};
 
 use super::{error::ExecutionClientError, ExecutionClient};
 
@@ -11,6 +11,14 @@ const QUOTE_ENDPOINT: &str = "v1/quote";
 
 impl ExecutionClient {
     /// Fetch a quote by forwarding raw query parameters
+    #[instrument(
+        skip(self, params),
+        fields(
+            from_token = %params.from_token,
+            to_token = %params.to_token,
+            from_amount = %params.from_amount
+        )
+    )]
     pub async fn get_quote(
         &self,
         params: LiFiQuoteParams,

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -14,7 +14,7 @@ use funds_manager_api::{
     u256_try_into_u64,
 };
 use renegade_common::types::chain::Chain;
-use tracing::{info, warn};
+use tracing::{info, instrument, warn};
 
 use crate::helpers::IERC20;
 
@@ -100,6 +100,7 @@ impl ExecutionClient {
     }
 
     /// Approve an erc20 allowance
+    #[instrument(skip(self, wallet))]
     pub(crate) async fn approve_erc20_allowance(
         &self,
         token_address: Address,


### PR DESCRIPTION
### Purpose
This PR adds fine grained request tracing to swap requests in the funds manager. This will help us understand and debug the recursive trade execution better.

I also added a small optimization to over-approve ERC20 tokens by a constant amplification factor. This removes the need for sending an approval on _every_ swap.

### Testing
- [ ] Will test in mainnet where this path is active.