### PR TITLE
funds-manager: execution_client: swap: Track cumulative gas cost

### DIFF
--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -247,7 +247,7 @@ pub(crate) async fn swap_immediate_handler(
         .await?;
 
     // Execute the swap, decaying the size of the swap each time it fails to execute
-    let (augmented_quote, receipt) =
+    let (augmented_quote, receipt, swap_gas_cost) =
         execution_client.swap_immediate_decaying(chain, params, wallet).await?;
 
     let resp = SwapImmediateResponse {
@@ -257,7 +257,7 @@ pub(crate) async fn swap_immediate_handler(
 
     // Record swap cost metrics
     tokio::spawn(async move {
-        metrics_recorder.record_swap_cost(&receipt, &augmented_quote).await;
+        metrics_recorder.record_swap_cost(&receipt, &augmented_quote, swap_gas_cost).await;
     });
 
     Ok(warp::reply::json(&resp))


### PR DESCRIPTION
### Purpose
This PR tracks the cumulative gas cost in the swap execution metrics. I only log for now, and don't record the metrics because I want to test this value in mainnet before we start recording real metrics to the NAV dashboard.

### Testing
- [ ] Will test in mainnet