### PR TITLE
 funds-manager: execution-client: Wrap transactions in retry loop

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -16,7 +16,7 @@ use reqwest::{Client, Url};
 use serde::Deserialize;
 use tracing::{error, instrument};
 
-use crate::helpers::{build_provider, send_tx_with_retry};
+use crate::helpers::{build_provider, send_tx_with_retry, ONE_CONFIRMATION};
 
 use self::error::ExecutionClientError;
 
@@ -98,6 +98,8 @@ impl ExecutionClient {
         tx: TransactionRequest,
         client: &DynProvider,
     ) -> Result<TransactionReceipt, ExecutionClientError> {
-        send_tx_with_retry(tx, client).await.map_err(ExecutionClientError::arbitrum)
+        send_tx_with_retry(tx, client, ONE_CONFIRMATION)
+            .await
+            .map_err(ExecutionClientError::arbitrum)
     }
 }

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -14,8 +14,8 @@ use crate::{
     error::FundsManagerError,
     helpers::IERC20::Transfer,
     metrics::labels::{
-        ASSET_TAG, HASH_TAG, SWAP_EXECUTION_COST_METRIC_NAME, SWAP_NOTIONAL_VOLUME_METRIC_NAME,
-        SWAP_RELATIVE_SPREAD_METRIC_NAME, TRADE_SIDE_FACTOR_TAG,
+        ASSET_TAG, HASH_TAG, SWAP_EXECUTION_COST_METRIC_NAME, SWAP_GAS_COST_METRIC_NAME,
+        SWAP_NOTIONAL_VOLUME_METRIC_NAME, SWAP_RELATIVE_SPREAD_METRIC_NAME, TRADE_SIDE_FACTOR_TAG,
     },
 };
 
@@ -187,6 +187,7 @@ impl MetricsRecorder {
 
         metrics::gauge!(SWAP_EXECUTION_COST_METRIC_NAME, &labels)
             .set(cost_data.execution_cost_usdc);
+        metrics::gauge!(SWAP_GAS_COST_METRIC_NAME, &labels).set(cost_data.gas_cost_usd);
         metrics::gauge!(SWAP_NOTIONAL_VOLUME_METRIC_NAME, &labels)
             .set(cost_data.notional_volume_usdc);
         metrics::gauge!(SWAP_RELATIVE_SPREAD_METRIC_NAME, &labels).set(cost_data.relative_spread);

--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -3,6 +3,9 @@
 /// Metric for the net execution cost of the swap in USD
 pub const SWAP_EXECUTION_COST_METRIC_NAME: &str = "swap_execution_cost";
 
+/// Metric for the gas cost of execution in USD
+pub const SWAP_GAS_COST_METRIC_NAME: &str = "swap_gas_cost";
+
 /// Metric for the notional volume of the swap in USD
 pub const SWAP_NOTIONAL_VOLUME_METRIC_NAME: &str = "swap_notional_volume";
 


### PR DESCRIPTION
### Purpose
This PR makes the following changes:
1. Reports gas cost of swap transactions as a new metric. I confirmed via the log attributes that the computed gas costs were correct.
2. Wraps all on-chain transactions in a retry loop. This will ameliorate nonce issues that happen by virtue of us using different instantiations of an alloy client throughout the funds manager. The nonce middleware will re-fetch in between transaction retries, so no extra work is needed beyond retrying.

### Testing
- [ ] Test in testnet