### PR TITLE
funds-manager: handlers: Return execution cost in `/swap-immediate`

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -286,6 +286,11 @@ pub struct SwapImmediateResponse {
     pub quote: ExecutionQuote,
     /// The tx hash of the swap
     pub tx_hash: String,
+    /// The execution cost in USD
+    ///
+    /// This is in whole USD as a floating point value, i.e. $10 will be
+    /// represented as 10.0
+    pub execution_cost: f64,
 }
 
 /// The request body for withdrawing USDC to Hyperliquid from the quoter hot


### PR DESCRIPTION
### Purpose
This PR returns execution cost in the API response from the funds manager on the `/swap-immediate` route. This cost represents the USD denominated cost of executing on LiFi versus Binance for the swap.

This will be used in the bot server to enable per-asset execution cost rate limits.

I moved the metrics recorder out of a thread to enable using the swap costs in the hot path. This operation is not latency expensive, and the endpoint in generally does not have stringent latency constraints on it. 

### Testing
- [ ] Have to test in mainnet, swaps only happen there