### PR TITLE
auth-server: record price staleness metric

### DIFF
--- a/auth/auth-server/src/bundle_store/mod.rs
+++ b/auth/auth-server/src/bundle_store/mod.rs
@@ -30,6 +30,8 @@ pub struct BundleContext {
     pub nullifier: Nullifier,
     /// Whether the bundle was shared
     pub shared: bool,
+    /// The timestamp of the price of the match in milliseconds
+    pub price_timestamp: u64,
 }
 
 struct StoreInner {

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -240,6 +240,9 @@ impl OnChainEventListenerExecutor {
 
                 // Cleanup the bundle context
                 self.bundle_store.cleanup_by_nullifier(&bundle_ctx.nullifier).await?;
+
+                // Record price staleness
+                self.record_price_staleness(&bundle_ctx, tx, self.darkpool_client()).await?;
             }
         }
 

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -241,8 +241,8 @@ impl OnChainEventListenerExecutor {
                 // Cleanup the bundle context
                 self.bundle_store.cleanup_by_nullifier(&bundle_ctx.nullifier).await?;
 
-                // Record price staleness
-                self.record_price_staleness(&bundle_ctx, tx, self.darkpool_client()).await?;
+                // Record settlement delay
+                self.record_settlement_delay(tx, &bundle_ctx, self.darkpool_client()).await?;
             }
         }
 

--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -8,7 +8,7 @@ use renegade_circuit_types::order::OrderSide;
 use renegade_common::types::token::Token;
 use renegade_darkpool_client::DarkpoolClient;
 
-use crate::telemetry::labels::EXTERNAL_MATCH_PRICE_STALENESS;
+use crate::telemetry::labels::EXTERNAL_MATCH_SETTLEMENT_DELAY;
 use crate::{bundle_store::BundleContext, chain_events::listener::OnChainEventListenerExecutor};
 use crate::{
     error::AuthServerError,
@@ -177,10 +177,10 @@ impl OnChainEventListenerExecutor {
 
     /// Record the time between the canonical exchange midpoint sample time and
     /// the time of settlement
-    pub async fn record_price_staleness(
+    pub async fn record_settlement_delay(
         &self,
-        ctx: &BundleContext,
         tx: TxHash,
+        ctx: &BundleContext,
         darkpool_client: &DarkpoolClient,
     ) -> Result<(), AuthServerError> {
         // Get the price sample time
@@ -204,7 +204,7 @@ impl OnChainEventListenerExecutor {
         // Calculate and record the time difference
         let time_diff = settlement_time.saturating_sub(price_timestamp);
         let labels = self.get_labels(ctx);
-        metrics::gauge!(EXTERNAL_MATCH_PRICE_STALENESS, &labels).set(time_diff as f64);
+        metrics::gauge!(EXTERNAL_MATCH_SETTLEMENT_DELAY, &labels).set(time_diff as f64);
 
         Ok(())
     }

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -217,7 +217,8 @@ impl Server {
     ) -> Result<(), AuthServerError> {
         // Record the bundle context in the store
         let shared = ctx.request().allow_shared;
-        self.write_bundle_context(shared, ctx).await?;
+        let price_timestamp = ctx.request().signed_quote.quote.price.timestamp;
+        self.write_bundle_context(shared, price_timestamp, ctx).await?;
 
         let req = ctx.request();
         if req.updated_order.is_some() {

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -2,6 +2,7 @@
 
 use auth_server_api::{GasSponsorshipInfo, SponsoredMatchResponse};
 use bytes::Bytes;
+use chrono::Utc;
 use http::Response;
 use renegade_api::http::external_match::{ExternalMatchRequest, ExternalMatchResponse};
 use tracing::{info, instrument, warn};
@@ -177,8 +178,11 @@ impl Server {
         &self,
         ctx: &SponsoredDirectMatchResponseCtx,
     ) -> Result<(), AuthServerError> {
+        // Because there is no price timestamp associated with a direct match,
+        // we approximate it with the current time
+        let price_timestamp = Utc::now().timestamp() as u64;
         // Record the bundle context in the store
-        self.write_bundle_context(true /* shared */, ctx).await?;
+        self.write_bundle_context(true /* shared */, price_timestamp, ctx).await?;
 
         let req = ctx.request();
         let order = &req.external_order;

--- a/auth/auth-server/src/server/api_handlers/settlement.rs
+++ b/auth/auth-server/src/server/api_handlers/settlement.rs
@@ -20,6 +20,7 @@ impl Server {
     pub async fn write_bundle_context<Req>(
         &self,
         shared_bundle: bool,
+        price_timestamp: u64,
         ctx: &MatchBundleResponseCtx<Req>,
     ) -> Result<String, AuthServerError>
     where
@@ -46,6 +47,7 @@ impl Server {
             is_sponsored,
             nullifier,
             shared: shared_bundle,
+            price_timestamp,
         };
 
         // Write to bundle store
@@ -70,6 +72,7 @@ impl Server {
         let gas_sponsorship_info = ctx.sponsorship_info();
         let is_sponsored = gas_sponsorship_info.is_some();
         let shared = req.allow_shared;
+        let price_timestamp = req.signed_quote.quote.price.timestamp;
 
         let bundle_ctx = BundleContext {
             key_description: ctx.user(),
@@ -79,6 +82,7 @@ impl Server {
             is_sponsored,
             nullifier,
             shared,
+            price_timestamp,
         };
 
         if let Err(e) = self.bundle_store.write(bundle_id.clone(), bundle_ctx).await {

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -29,6 +29,10 @@ pub const EXTERNAL_MATCH_SETTLED_BASE_VOLUME: &str = "external_match_settled_bas
 /// Metric describing the volume of the quote asset in an external match
 pub const EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME: &str = "external_match_settled_quote_volume";
 
+/// Metric describing the time between the price sample time and the time of
+/// settlement
+pub const EXTERNAL_MATCH_PRICE_STALENESS: &str = "external_match_price_staleness";
+
 /// Metric describing the difference in price between our quote and the source
 /// quote, in basis points
 pub const QUOTE_PRICE_DIFF_BPS_METRIC: &str = "quote.price_diff_bps";

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -31,7 +31,7 @@ pub const EXTERNAL_MATCH_SETTLED_QUOTE_VOLUME: &str = "external_match_settled_qu
 
 /// Metric describing the time between the price sample time and the time of
 /// settlement
-pub const EXTERNAL_MATCH_PRICE_STALENESS: &str = "external_match_price_staleness";
+pub const EXTERNAL_MATCH_SETTLEMENT_DELAY: &str = "external_match_settlement_delay";
 
 /// Metric describing the difference in price between our quote and the source
 /// quote, in basis points


### PR DESCRIPTION
### Purpose
This PR adds metrics recording for the price staleness of a bundle. Price staleness is calculated as the time between time of price sample and the time of settlement. For direct match bundles, which do not have a TimestampedPrice, we approximate by using the time the post-request subroutines are run. 

Metric added is `auth_server.external_match_price_staleness` in milliseconds.

### Testing
- [x] Test locally that price staleness is correctly calculated for basic match
- [ ] Test malleable match + direct match