### PR TITLE
funds-manager: metrics: handle non-transfer logs & add chain tag

### DIFF
--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -258,7 +258,7 @@ impl ChainConfig {
         .map_err(FundsManagerError::custom)?;
 
         // Build a metrics recorder
-        let metrics_recorder = MetricsRecorder::new(price_reporter.clone(), &self.rpc_url);
+        let metrics_recorder = MetricsRecorder::new(price_reporter.clone(), &self.rpc_url, chain);
 
         // Build a fee indexer
         let mut decryption_keys = vec![DecryptionKey::from_hex_str(&self.relayer_decryption_key)

--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -20,3 +20,6 @@ pub const TRADE_SIDE_FACTOR_TAG: &str = "side";
 
 /// Metric tag for the transaction hash of the swap
 pub const HASH_TAG: &str = "hash";
+
+/// Metric tag for the (environment-agnostic) chain name
+pub const CHAIN_TAG: &str = "chain";

--- a/funds-manager/funds-manager-server/src/metrics/mod.rs
+++ b/funds-manager/funds-manager-server/src/metrics/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use alloy::providers::DynProvider;
 use price_reporter_client::PriceReporterClient;
+use renegade_common::types::chain::Chain;
 
 use crate::helpers::build_provider;
 
@@ -18,13 +19,15 @@ pub struct MetricsRecorder {
     pub price_reporter: Arc<PriceReporterClient>,
     /// Ethereum provider for querying chain events
     pub provider: DynProvider,
+    /// The chain for which metrics are being recorded
+    pub chain: Chain,
 }
 
 impl MetricsRecorder {
     /// Create a new metrics recorder
-    pub fn new(price_reporter: Arc<PriceReporterClient>, rpc_url: &str) -> Self {
+    pub fn new(price_reporter: Arc<PriceReporterClient>, rpc_url: &str, chain: Chain) -> Self {
         let provider = build_provider(rpc_url).expect("invalid RPC URL");
 
-        MetricsRecorder { price_reporter, provider }
+        MetricsRecorder { price_reporter, provider, chain }
     }
 }


### PR DESCRIPTION
This PR makes a couple misc tweaks to swap cost recording in the funds manager:
1. We _attempt_ to decode all ERC20 logs as transfers, rather than _assuming_ they all are, skipping over non-transfer logs
2. We tag swap cost metrics with the (env-agnostic) chain on which they occurred

### Testing
- [ ] Test by running local funds manager w/ mainnet params & invoking swaps via local admin panel