### PR TITLE
auth-server: setup: Create execution cost rate limiter

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -154,6 +154,12 @@ impl From<AuthServerError> for ApiError {
     }
 }
 
+impl From<redis::RedisError> for AuthServerError {
+    fn from(err: redis::RedisError) -> Self {
+        Self::redis(err)
+    }
+}
+
 impl From<alloy_sol_types::Error> for AuthServerError {
     fn from(err: alloy_sol_types::Error) -> Self {
         Self::custom(err)

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -102,7 +102,10 @@ pub struct Cli {
     pub price_reporter_url: String,
     /// The URL of the Redis cluster
     #[arg(long, env = "REDIS_URL")]
-    pub redis_url: String,
+    pub gas_sponsorship_redis_url: String,
+    /// The URL of the execution cost Redis cluster
+    #[arg(long, env = "EXECUTION_COST_REDIS_URL")]
+    pub execution_cost_redis_url: String,
 
     // -------------------
     // | Gas Sponsorship |

--- a/auth/auth-server/src/server/rate_limiter/execution_cost_rate_limiter.rs
+++ b/auth/auth-server/src/server/rate_limiter/execution_cost_rate_limiter.rs
@@ -8,6 +8,7 @@ use crate::{error::AuthServerError, server::db::create_redis_client};
 
 /// A rate limiter that measures the bot server's per-asset execution costs and
 /// rate limits external match flow that crosses with quoter orders
+#[derive(Clone)]
 pub struct ExecutionCostRateLimiter {
     /// The Redis connection manager
     redis: RedisConnection,
@@ -21,7 +22,7 @@ impl ExecutionCostRateLimiter {
     }
 
     /// Check if the rate limit has been exceeded for the given ticker
-    pub async fn check_rate_limit(&self, ticker: &str) -> Result<bool, AuthServerError> {
+    pub async fn rate_limit_exceeded(&self, ticker: &str) -> Result<bool, AuthServerError> {
         let key = Self::get_rate_limit_exceeded_key(ticker);
         let result: Option<bool> = self.redis().get(key).await?;
         Ok(result.unwrap_or(false))

--- a/auth/auth-server/src/server/rate_limiter/execution_cost_rate_limiter.rs
+++ b/auth/auth-server/src/server/rate_limiter/execution_cost_rate_limiter.rs
@@ -1,0 +1,50 @@
+//! A rate limiter that routes external match flow based on whether the bot
+//! server's execution costs have been exceeded
+
+use chrono::Utc;
+use redis::{aio::ConnectionManager as RedisConnection, AsyncCommands};
+
+use crate::{error::AuthServerError, server::db::create_redis_client};
+
+/// A rate limiter that measures the bot server's per-asset execution costs and
+/// rate limits external match flow that crosses with quoter orders
+pub struct ExecutionCostRateLimiter {
+    /// The Redis connection manager
+    redis: RedisConnection,
+}
+
+impl ExecutionCostRateLimiter {
+    /// Constructor
+    pub async fn new(redis_url: &str) -> Result<Self, AuthServerError> {
+        let conn = create_redis_client(redis_url).await?;
+        Ok(Self { redis: conn })
+    }
+
+    /// Check if the rate limit has been exceeded for the given ticker
+    pub async fn check_rate_limit(&self, ticker: &str) -> Result<bool, AuthServerError> {
+        let key = Self::get_rate_limit_exceeded_key(ticker);
+        let result: Option<bool> = self.redis().get(key).await?;
+        Ok(result.unwrap_or(false))
+    }
+
+    // -----------
+    // | Helpers |
+    // -----------
+
+    /// Get the Redis connection manager
+    fn redis(&self) -> RedisConnection {
+        self.redis.clone()
+    }
+
+    /// Get the rate limit exceeded key for the given ticker
+    fn get_rate_limit_exceeded_key(ticker: &str) -> String {
+        let date = Self::get_current_date_string();
+        format!("execution_cost_exceeded:{ticker}#{date}")
+    }
+
+    /// Get the current date string in the format YYYY-MM-DD
+    fn get_current_date_string() -> String {
+        let now = Utc::now();
+        now.format("%Y-%m-%d").to_string()
+    }
+}

--- a/auth/auth-server/src/server/rate_limiter/mod.rs
+++ b/auth/auth-server/src/server/rate_limiter/mod.rs
@@ -30,6 +30,7 @@ use crate::error::AuthServerError;
 
 use super::Server;
 
+mod execution_cost_rate_limiter;
 mod gas_sponsorship_rate_limiter;
 mod user_rate_limiter;
 

--- a/auth/auth-server/src/server/setup.rs
+++ b/auth/auth-server/src/server/setup.rs
@@ -59,7 +59,7 @@ impl Server {
 
         // Setup the DB connection pool and the Redis client
         let db_pool = create_db_pool(&args.database_url).await?;
-        let redis_client = create_redis_client(&args.redis_url).await?;
+        let redis_client = create_redis_client(&args.gas_sponsorship_redis_url).await?;
         let (encryption_key, management_key, relayer_admin_key, gas_sponsor_auth_key) =
             parse_auth_server_keys(&args)?;
 
@@ -68,7 +68,9 @@ impl Server {
             args.bundle_rate_limit,
             args.shared_bundle_rate_limit,
             args.max_gas_sponsorship_value,
-        );
+            &args.execution_cost_redis_url,
+        )
+        .await?;
 
         let price_reporter_client =
             Arc::new(PriceReporterClient::new(args.price_reporter_url.clone())?);


### PR DESCRIPTION
### Purpose
This PR adds a Redis-based execution cost rate limiter to the auth server. This rate limiter will read from the redis cluster written to by the bot server when it reports its execution costs.

Notably we don't fail the API execution if the rate limit check fails, we emit a warning for now. I will change this later if we see fit, but I'm planning to test this with live rate limits before changing routing behavior.

Routing decisions will come in a follow-up.

### Testing
- [x] Tested locally 