### PR TITLE
auth-server: Handle bad request errors properly

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -6,11 +6,14 @@ use crate::ApiError;
 use price_reporter_client::error::PriceReporterClientError;
 
 /// Custom error type for server errors
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum AuthServerError {
     /// API key inactive
     #[error("API key inactive")]
     ApiKeyInactive,
+    /// A bad request error
+    #[error("Bad request: {0}")]
+    BadRequest(String),
     /// Bundle store error
     #[error("Bundle store error: {0}")]
     BundleStore(String),
@@ -62,6 +65,12 @@ pub enum AuthServerError {
 }
 
 impl AuthServerError {
+    /// Create a new bad request error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn bad_request<T: ToString>(msg: T) -> Self {
+        Self::BadRequest(msg.to_string())
+    }
+
     /// Create a new database connection error
     #[allow(clippy::needless_pass_by_value)]
     pub fn db<T: ToString>(msg: T) -> Self {
@@ -149,6 +158,7 @@ impl From<AuthServerError> for ApiError {
             AuthServerError::ApiKeyInactive | AuthServerError::Unauthorized(_) => {
                 ApiError::Unauthorized
             },
+            AuthServerError::BadRequest(e) => ApiError::BadRequest(e),
             _ => ApiError::InternalError(err.to_string()),
         }
     }

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -3,6 +3,7 @@
 use auth_server_api::{GasSponsorshipInfo, SponsoredMatchResponse};
 use bytes::Bytes;
 use http::Response;
+use num_bigint::BigUint;
 use renegade_api::http::external_match::{AssembleExternalMatchRequest, ExternalMatchResponse};
 use renegade_util::get_current_time_millis;
 use tracing::{error, info, instrument, warn};
@@ -12,7 +13,9 @@ use crate::{
     error::AuthServerError,
     http_utils::overwrite_response_body,
     server::{
-        api_handlers::{ticker_from_biguint, GLOBAL_MATCHING_POOL},
+        api_handlers::{
+            external_match::ExternalMatchRequestType, ticker_from_biguint, GLOBAL_MATCHING_POOL,
+        },
         gas_sponsorship::refund_calculation::{
             apply_gas_sponsorship_to_exact_output_amount, remove_gas_sponsorship_from_quote,
             requires_exact_output_amount_update,
@@ -34,6 +37,16 @@ impl AssembleQuoteRequestCtx {
     /// Get the ticker from the request
     pub fn ticker(&self) -> Result<String, AuthServerError> {
         ticker_from_biguint(&self.body.signed_quote.quote.order.base_mint)
+    }
+}
+
+impl ExternalMatchRequestType for AssembleExternalMatchRequest {
+    fn base_mint(&self) -> &BigUint {
+        &self.signed_quote.quote.order.base_mint
+    }
+
+    fn quote_mint(&self) -> &BigUint {
+        &self.signed_quote.quote.order.quote_mint
     }
 }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -3,6 +3,7 @@
 use auth_server_api::{GasSponsorshipInfo, SponsoredMatchResponse};
 use bytes::Bytes;
 use http::Response;
+use num_bigint::BigUint;
 use renegade_api::http::external_match::{ExternalMatchRequest, ExternalMatchResponse};
 use renegade_util::get_current_time_millis;
 use tracing::{info, instrument, warn};
@@ -12,7 +13,9 @@ use crate::{
     error::AuthServerError,
     http_utils::overwrite_response_body,
     server::{
-        api_handlers::{ticker_from_biguint, GLOBAL_MATCHING_POOL},
+        api_handlers::{
+            external_match::ExternalMatchRequestType, ticker_from_biguint, GLOBAL_MATCHING_POOL,
+        },
         Server,
     },
 };
@@ -29,6 +32,16 @@ impl DirectMatchRequestCtx {
     /// Get the ticker from the request
     pub fn ticker(&self) -> Result<String, AuthServerError> {
         ticker_from_biguint(&self.body.external_order.base_mint)
+    }
+}
+
+impl ExternalMatchRequestType for ExternalMatchRequest {
+    fn base_mint(&self) -> &BigUint {
+        &self.external_order.base_mint
+    }
+
+    fn quote_mint(&self) -> &BigUint {
+        &self.external_order.quote_mint
     }
 }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/quote.rs
@@ -3,6 +3,7 @@
 use auth_server_api::{GasSponsorshipInfo, SponsoredQuoteResponse};
 use bytes::Bytes;
 use http::{Response, StatusCode};
+use num_bigint::BigUint;
 use renegade_api::http::external_match::{ExternalQuoteRequest, ExternalQuoteResponse};
 use renegade_circuit_types::fixed_point::FixedPoint;
 use renegade_common::types::{price::TimestampedPrice, token::Token};
@@ -15,7 +16,9 @@ use crate::{
     error::AuthServerError,
     http_utils::overwrite_response_body,
     server::{
-        api_handlers::{ticker_from_biguint, GLOBAL_MATCHING_POOL},
+        api_handlers::{
+            external_match::ExternalMatchRequestType, ticker_from_biguint, GLOBAL_MATCHING_POOL,
+        },
         Server,
     },
     telemetry::{
@@ -41,6 +44,16 @@ impl QuoteRequestCtx {
     /// Get the ticker for the quote request
     pub fn ticker(&self) -> Result<String, AuthServerError> {
         ticker_from_biguint(&self.body.external_order.base_mint)
+    }
+}
+
+impl ExternalMatchRequestType for ExternalQuoteRequest {
+    fn base_mint(&self) -> &BigUint {
+        &self.external_order.base_mint
+    }
+
+    fn quote_mint(&self) -> &BigUint {
+        &self.external_order.quote_mint
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a rejection handler branch for the `AuthServerError` type and adds a `BadRequest` variant to this error. We use this error type to return HTTP 400 when an address is not in the token mapping. 

Previously the auth server would return an opaque "500: Internal Server Error" because the `AuthServerError` type was not handled.

### Testing
- [x] Tested locally with an invalid token address.