### PR TITLE
migrations: Add whitelisted column to `api_keys` table

### DIFF
--- a/auth/auth-server/diesel.toml
+++ b/auth/auth-server/diesel.toml
@@ -2,7 +2,7 @@
 # see https://diesel.rs/guides/configuring-diesel-cli
 
 [print_schema]
-file = "src/schema.rs"
+file = "src/server/db/schema.rs"
 custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
 
 [migrations_directory]

--- a/auth/auth-server/migrations/2025-07-01-210135_add_whitelist_flag/down.sql
+++ b/auth/auth-server/migrations/2025-07-01-210135_add_whitelist_flag/down.sql
@@ -1,0 +1,2 @@
+-- Drop the whitelist flag
+ALTER TABLE api_keys DROP COLUMN rate_limit_whitelisted;

--- a/auth/auth-server/migrations/2025-07-01-210135_add_whitelist_flag/up.sql
+++ b/auth/auth-server/migrations/2025-07-01-210135_add_whitelist_flag/up.sql
@@ -1,0 +1,2 @@
+-- Add the whitelist flag
+ALTER TABLE api_keys ADD COLUMN rate_limit_whitelisted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/auth/auth-server/src/server/db/models.rs
+++ b/auth/auth-server/src/server/db/models.rs
@@ -19,6 +19,7 @@ pub struct ApiKey {
     #[allow(dead_code)]
     pub created_at: SystemTime,
     pub is_active: bool,
+    pub rate_limit_whitelisted: bool,
 }
 
 #[derive(Insertable)]
@@ -44,6 +45,7 @@ impl From<NewApiKey> for ApiKey {
             description: key.description,
             created_at: SystemTime::now(),
             is_active: true,
+            rate_limit_whitelisted: false,
         }
     }
 }

--- a/auth/auth-server/src/server/db/schema.rs
+++ b/auth/auth-server/src/server/db/schema.rs
@@ -7,5 +7,6 @@ diesel::table! {
         description -> Varchar,
         created_at -> Timestamp,
         is_active -> Bool,
+        rate_limit_whitelisted -> Bool,
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds a `rate_limit_whitelisted` column to the `api_keys` table. This will let us selectively bypass execution swap cost rate limits on a per-key basis.

### Testing
- [x] Applied the migration in testnet