### PR TITLE
auth-server: api-handlers: key-management: Add whitelist commands

### DIFF
--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -22,7 +22,6 @@ pub mod http_utils;
 mod server;
 mod telemetry;
 
-use bytes::Bytes;
 use renegade_common::types::chain::Chain;
 use renegade_system_clock::SystemClock;
 
@@ -224,6 +223,7 @@ async fn main() {
 
     // Add an API key
     let add_api_key = warp::path(API_KEYS_PATH)
+        .and(warp::path::end())
         .and(warp::post())
         .and(warp::path::full())
         .and(warp::header::headers_cloned())
@@ -237,6 +237,7 @@ async fn main() {
     let expire_api_key = warp::path(API_KEYS_PATH)
         .and(warp::path::param::<Uuid>())
         .and(warp::path("deactivate"))
+        .and(warp::path::end())
         .and(warp::post())
         .and(warp::path::full())
         .and(warp::header::headers_cloned())
@@ -250,6 +251,7 @@ async fn main() {
     let whitelist_api_key = warp::path(API_KEYS_PATH)
         .and(warp::path::param::<Uuid>())
         .and(warp::path("whitelist"))
+        .and(warp::path::end())
         .and(warp::post())
         .and(warp::path::full())
         .and(warp::header::headers_cloned())
@@ -263,6 +265,7 @@ async fn main() {
     let remove_whitelist_entry = warp::path(API_KEYS_PATH)
         .and(warp::path::param::<Uuid>())
         .and(warp::path("remove-whitelist"))
+        .and(warp::path::end())
         .and(warp::post())
         .and(warp::path::full())
         .and(warp::header::headers_cloned())

--- a/auth/auth-server/src/server/api_auth.rs
+++ b/auth/auth-server/src/server/api_auth.rs
@@ -20,7 +20,6 @@ impl Server {
         headers: &HeaderMap,
         body: &[u8],
     ) -> Result<(), ApiError> {
-        return Ok(());
         let auth_headers = convert_headers(headers);
         validate_expiring_auth(path.as_str(), &auth_headers, body, &self.management_key)
             .map_err(|_| ApiError::Unauthorized)

--- a/auth/auth-server/src/server/api_handlers/key_management.rs
+++ b/auth/auth-server/src/server/api_handlers/key_management.rs
@@ -7,14 +7,9 @@ use crate::{
 use auth_server_api::CreateApiKeyRequest;
 use bytes::Bytes;
 use http::HeaderMap;
-use serde_json::json;
 use tracing::instrument;
 use uuid::Uuid;
-use warp::{
-    filters::path::FullPath,
-    reject::Rejection,
-    reply::{Reply, WithStatus},
-};
+use warp::{filters::path::FullPath, reject::Rejection, reply::Reply};
 
 use crate::ApiError;
 
@@ -78,10 +73,8 @@ impl Server {
     ) -> Result<impl Reply, Rejection> {
         // Check management auth on the request
         self.authorize_management_request(&path, &headers, &body)?;
-        let reply = warp::reply::json(&json!({
-            "whitelisted": true,
-        }));
-        Ok(reply)
+        self.whitelist_api_key_query(key_id).await?;
+        Ok(empty_json_reply())
     }
 
     /// Remove a whitelist entry for an API key
@@ -98,9 +91,7 @@ impl Server {
     ) -> Result<impl Reply, Rejection> {
         // Check management auth on the request
         self.authorize_management_request(&path, &headers, &body)?;
-        let reply = warp::reply::json(&json!({
-            "whitelisted": false,
-        }));
-        Ok(reply)
+        self.remove_whitelist_entry_query(key_id).await?;
+        Ok(empty_json_reply())
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds whitelist commands via the API to the auth server. These allow for both setting and removing a whitelist entry. In a follow-up, I'll add a `GET` endpoint; we'll use the combination of these endpoints in a new admin panel page.

### Testing
- [x] Tested locally whitelisting and de-whitelisting my own key.