### PR TITLE
auth-server: api-handlers: Add `GET /api-keys` method

### DIFF
--- a/auth/auth-server-api/src/key_management.rs
+++ b/auth/auth-server-api/src/key_management.rs
@@ -1,0 +1,30 @@
+//! Key management API endpoints
+
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// An API key entry
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiKey {
+    /// The API key id
+    pub id: Uuid,
+    /// A description of the API key's purpose
+    pub description: String,
+    /// Whether the API key is active
+    pub is_active: bool,
+    /// Whether the API key is whitelisted for external match flow rate limiting
+    pub rate_limit_whitelisted: bool,
+    /// The date and time the API key was created
+    ///
+    /// In seconds since epoch
+    pub created_at: u64,
+}
+
+/// A response containing all API keys
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AllKeysResponse {
+    /// The list of API keys
+    pub keys: Vec<ApiKey>,
+}

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -6,6 +6,8 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![feature(trivial_bounds)]
 
+pub mod key_management;
+
 use alloy_primitives::{ruint::FromUintError, Address, U256};
 use renegade_api::http::external_match::{
     AtomicMatchApiBundle, MalleableAtomicMatchApiBundle, SignedExternalQuote,

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -221,6 +221,17 @@ async fn main() {
         .and(warp::get())
         .map(|| warp::reply::with_status("PONG", StatusCode::OK));
 
+    // Get all API keys
+    let get_all_keys = warp::path(API_KEYS_PATH)
+        .and(warp::path::end())
+        .and(warp::get())
+        .and(warp::path::full())
+        .and(warp::header::headers_cloned())
+        .and(with_server(server.clone()))
+        .and_then(|path, headers, server: Arc<Server>| async move {
+            server.get_all_keys(path, headers).await
+        });
+
     // Add an API key
     let add_api_key = warp::path(API_KEYS_PATH)
         .and(warp::path::end())
@@ -362,6 +373,7 @@ async fn main() {
         .or(whitelist_api_key)
         .or(remove_whitelist_entry)
         .or(add_api_key)
+        .or(get_all_keys)
         .or(order_book_depth_with_mint)
         .or(order_book_depth)
         .boxed()

--- a/auth/auth-server/src/server/db/models.rs
+++ b/auth/auth-server/src/server/db/models.rs
@@ -4,6 +4,7 @@
 
 use std::time::SystemTime;
 
+use auth_server_api::key_management::ApiKey as UserFacingApiKey;
 use diesel::prelude::*;
 use uuid::Uuid;
 
@@ -20,6 +21,19 @@ pub struct ApiKey {
     pub created_at: SystemTime,
     pub is_active: bool,
     pub rate_limit_whitelisted: bool,
+}
+
+impl From<ApiKey> for UserFacingApiKey {
+    fn from(key: ApiKey) -> Self {
+        let created_at = key.created_at.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        Self {
+            id: key.id,
+            description: key.description,
+            is_active: key.is_active,
+            rate_limit_whitelisted: key.rate_limit_whitelisted,
+            created_at: created_at.as_secs(),
+        }
+    }
 }
 
 #[derive(Insertable)]

--- a/auth/auth-server/src/server/db/queries.rs
+++ b/auth/auth-server/src/server/db/queries.rs
@@ -17,6 +17,12 @@ const ERR_NO_KEY: &str = "API key not found";
 impl Server {
     // --- Getters --- //
 
+    /// Get all API keys from the database
+    pub async fn get_all_api_keys(&self) -> Result<Vec<ApiKey>, AuthServerError> {
+        let mut conn = self.get_db_conn().await?;
+        api_keys::table.load::<ApiKey>(&mut conn).await.map_err(AuthServerError::db)
+    }
+
     /// Get the API key entry for a given key
     pub async fn get_api_key_entry(&self, api_key: Uuid) -> Result<ApiKey, AuthServerError> {
         // Check the cache first


### PR DESCRIPTION
### Purpose
This PR adds a `GET /api-keys` method which returns all API keys registered to the auth server. This will be used in the admin panel to view API keys and their whitelist status.

### Testing
- [x] Tested locally