### PR TITLE
auth-server: api-handlers: Do not re-route whitelisted api keys

### DIFF
--- a/auth/auth-server-api/src/key_management.rs
+++ b/auth/auth-server-api/src/key_management.rs
@@ -1,7 +1,5 @@
 //! Key management API endpoints
 
-use std::time::SystemTime;
-
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 

--- a/auth/auth-server/src/server/api_auth.rs
+++ b/auth/auth-server/src/server/api_auth.rs
@@ -28,7 +28,7 @@ impl Server {
     /// Authorize a request
     ///
     /// Returns the description for the API key, i.e. a human readable name for
-    /// the entity that is making the request
+    /// the entity that is making the request, and the API key id
     #[instrument(skip_all)]
     pub(crate) async fn authorize_request(
         &self,
@@ -36,7 +36,7 @@ impl Server {
         query_str: &str,
         headers: &HeaderMap,
         body: &[u8],
-    ) -> Result<String, ApiError> {
+    ) -> Result<(String, Uuid), ApiError> {
         let auth_path =
             if query_str.is_empty() { path } else { &format!("{}?{}", path, query_str) };
 
@@ -49,7 +49,7 @@ impl Server {
 
         let key_description = self.check_api_key_auth(api_key, auth_path, headers, body).await?;
         info!("Authorized request for entity: {key_description}");
-        Ok(key_description)
+        Ok((key_description, api_key))
     }
 
     /// Check that a request is authorized with a given API key and an HMAC of

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -162,8 +162,8 @@ impl Server {
         ctx: &mut AssembleQuoteRequestCtx,
     ) -> Result<(), AuthServerError> {
         let ticker = ctx.ticker()?;
-        let limit_exceeded = self.check_execution_cost_exceeded(&ticker).await;
-        if limit_exceeded {
+        let should_route_to_global = self.should_route_to_global(ctx.key_id(), &ticker).await?;
+        if should_route_to_global {
             info!("Routing order to global matching pool");
             ctx.body_mut().matching_pool = Some(GLOBAL_MATCHING_POOL.to_string());
         }

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -156,8 +156,8 @@ impl Server {
         ctx: &mut DirectMatchRequestCtx,
     ) -> Result<(), AuthServerError> {
         let ticker = ctx.ticker()?;
-        let limit_exceeded = self.check_execution_cost_exceeded(&ticker).await;
-        if limit_exceeded {
+        let should_route_to_global = self.should_route_to_global(ctx.key_id(), &ticker).await?;
+        if should_route_to_global {
             info!("Routing order to global matching pool");
             ctx.body_mut().matching_pool = Some(GLOBAL_MATCHING_POOL.to_string());
         }

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -41,6 +41,8 @@ pub struct RequestContext<Req: Serialize + for<'de> Deserialize<'de>> {
     ///
     /// Derived from the API key
     pub user: String,
+    /// The API key id
+    pub key_id: Uuid,
     /// The version of the SDK used to make the request
     pub sdk_version: String,
     /// The headers of the request
@@ -57,6 +59,11 @@ impl<Req: Serialize + for<'de> Deserialize<'de>> RequestContext<Req> {
     /// Get the user description for the request
     pub fn user(&self) -> String {
         self.user.to_string()
+    }
+
+    /// Get the API key id for the request
+    pub fn key_id(&self) -> Uuid {
+        self.key_id
     }
 
     /// Get a reference to the query string
@@ -203,7 +210,7 @@ impl Server {
     {
         // Authorize the request
         let path = path.as_str().to_string();
-        let key_desc = self.authorize_request(&path, &query_str, &headers, &body).await?;
+        let (key_desc, key_id) = self.authorize_request(&path, &query_str, &headers, &body).await?;
         let sdk_version = get_sdk_version(&headers);
 
         // Deserialize the request body, then build the context
@@ -216,6 +223,7 @@ impl Server {
             sdk_version,
             headers,
             user: key_desc,
+            key_id,
             body,
             sponsorship_info: None,
             request_id: Uuid::new_v4(),

--- a/auth/auth-server/src/server/api_handlers/external_match/quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/quote.rs
@@ -166,8 +166,8 @@ impl Server {
     /// to the global pool to take pressure off the quoters
     async fn route_quote_req(&self, ctx: &mut QuoteRequestCtx) -> Result<(), AuthServerError> {
         let ticker = ctx.ticker()?;
-        let limit_exceeded = self.check_execution_cost_exceeded(&ticker).await;
-        if limit_exceeded {
+        let should_route_to_global = self.should_route_to_global(ctx.key_id(), &ticker).await?;
+        if should_route_to_global {
             info!("Routing order to global matching pool");
             ctx.body_mut().matching_pool = Some(GLOBAL_MATCHING_POOL.to_string());
         }

--- a/auth/auth-server/src/server/api_handlers/key_management.rs
+++ b/auth/auth-server/src/server/api_handlers/key_management.rs
@@ -97,6 +97,8 @@ impl Server {
         // Check management auth on the request
         self.authorize_management_request(&path, &headers, &body)?;
         self.whitelist_api_key_query(key_id).await?;
+        self.clear_cached_key(key_id).await;
+
         Ok(empty_json_reply())
     }
 
@@ -115,6 +117,8 @@ impl Server {
         // Check management auth on the request
         self.authorize_management_request(&path, &headers, &body)?;
         self.remove_whitelist_entry_query(key_id).await?;
+        self.clear_cached_key(key_id).await;
+
         Ok(empty_json_reply())
     }
 }

--- a/auth/auth-server/src/server/api_handlers/order_book.rs
+++ b/auth/auth-server/src/server/api_handlers/order_book.rs
@@ -17,7 +17,7 @@ impl Server {
     ) -> Result<impl Reply, Rejection> {
         // Authorize the request
         let path_str = path.as_str();
-        let key_desc = self
+        let (key_desc, _key_id) = self
             .authorize_request(path_str, "" /* query_str */, &headers, &[] /* body */)
             .await?;
 

--- a/auth/auth-server/src/server/caching.rs
+++ b/auth/auth-server/src/server/caching.rs
@@ -15,7 +15,7 @@ pub type ApiKeyCache = Arc<RwLock<UnboundCache<Uuid, ApiKey>>>;
 
 impl Server {
     /// Check the cache for an API key
-    pub async fn get_cached_api_secret(&self, id: Uuid) -> Option<ApiKey> {
+    pub async fn get_cached_api_key(&self, id: Uuid) -> Option<ApiKey> {
         let cache = self.api_key_cache.read().await;
         cache.get_store().get(&id).cloned()
     }
@@ -32,5 +32,14 @@ impl Server {
         if let Some(key) = cache.cache_get_mut(&id) {
             key.is_active = false;
         }
+    }
+
+    /// Clear the cache entry for a given API key
+    ///
+    /// We use this as a simpler way to invalidate a key so that it is
+    /// re-hydrated from the DB
+    pub async fn clear_cached_key(&self, id: Uuid) {
+        let mut cache = self.api_key_cache.write().await;
+        cache.cache_remove(&id);
     }
 }

--- a/auth/auth-server/src/server/db/queries.rs
+++ b/auth/auth-server/src/server/db/queries.rs
@@ -26,7 +26,7 @@ impl Server {
     /// Get the API key entry for a given key
     pub async fn get_api_key_entry(&self, api_key: Uuid) -> Result<ApiKey, AuthServerError> {
         // Check the cache first
-        if let Some(key) = self.get_cached_api_secret(api_key).await {
+        if let Some(key) = self.get_cached_api_key(api_key).await {
             return Ok(key);
         }
 


### PR DESCRIPTION
### Purpose
This PR checks the whitelist status for an API key before routing the order to the global matching pool. If an API key has the whitelist flag set, it will never be routed to the global matching pool. Orders without the whitelist flag set will still be routed according to the rate limits reported by the bot server.

### Testing
- [x] Tested whitelisted/non-whitelisted with rate-limited/non-rate-limited locally on my personal key.