### PR TITLE
auth-server: api-handlers: Return more complete 400 responses

### DIFF
--- a/auth/auth-server/src/error.rs
+++ b/auth/auth-server/src/error.rs
@@ -158,7 +158,8 @@ impl From<AuthServerError> for ApiError {
             AuthServerError::ApiKeyInactive | AuthServerError::Unauthorized(_) => {
                 ApiError::Unauthorized
             },
-            AuthServerError::BadRequest(e) => ApiError::BadRequest(e),
+            AuthServerError::BadRequest(e) | AuthServerError::Serde(e) => ApiError::BadRequest(e),
+            AuthServerError::RateLimit => ApiError::TooManyRequests,
             _ => ApiError::InternalError(err.to_string()),
         }
     }

--- a/auth/auth-server/src/server/api_auth.rs
+++ b/auth/auth-server/src/server/api_auth.rs
@@ -36,7 +36,7 @@ impl Server {
         query_str: &str,
         headers: &HeaderMap,
         body: &[u8],
-    ) -> Result<(String, Uuid), ApiError> {
+    ) -> Result<(String, Uuid), AuthServerError> {
         let auth_path =
             if query_str.is_empty() { path } else { &format!("{}?{}", path, query_str) };
 

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -16,7 +16,6 @@ use uuid::Uuid;
 
 use crate::{
     error::AuthServerError, server::Server, telemetry::helpers::record_relayer_request_500,
-    ApiError,
 };
 pub(crate) use assemble_malleable_quote::SponsoredAssembleMalleableQuoteResponseCtx;
 
@@ -204,7 +203,7 @@ impl Server {
         headers: warp::hyper::HeaderMap,
         body: Bytes,
         query_str: String,
-    ) -> Result<RequestContext<Req>, ApiError>
+    ) -> Result<RequestContext<Req>, AuthServerError>
     where
         Req: ExternalMatchRequestType,
     {
@@ -214,7 +213,7 @@ impl Server {
         let sdk_version = get_sdk_version(&headers);
 
         // Deserialize the request body, then build the context
-        let body: Req = serde_json::from_slice(&body).map_err(AuthServerError::serde)?;
+        let body: Req = serde_json::from_slice(&body).map_err(AuthServerError::bad_request)?;
         self.validate_request_body(&body)?;
 
         Ok(RequestContext {


### PR DESCRIPTION
### Purpose
This PR changes the auth server to return http 400 in cases when decoding a request body fails, and extends the mapping of `AuthServerError -> ApiError` to more completely capture all API codes.

### Testing
- [x] Tested locally