### PR TITLE
price_reporter_client: optional exit-on-stale

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4591,6 +4591,7 @@ dependencies = [
  "futures",
  "hex 0.4.3",
  "http 0.2.12",
+ "http 1.3.1",
  "http-body-util",
  "itertools 0.13.0",
  "metrics",

--- a/auth/auth-server/src/server/setup.rs
+++ b/auth/auth-server/src/server/setup.rs
@@ -72,8 +72,10 @@ impl Server {
         )
         .await?;
 
-        let price_reporter_client =
-            Arc::new(PriceReporterClient::new(args.price_reporter_url.clone())?);
+        let price_reporter_client = Arc::new(PriceReporterClient::new(
+            args.price_reporter_url.clone(),
+            false, // exit_on_stale
+        )?);
 
         // Setup quote metrics
         let quote_metrics = maybe_setup_quote_metrics(

--- a/funds-manager/Dockerfile
+++ b/funds-manager/Dockerfile
@@ -55,5 +55,5 @@ RUN apt-get update && \
 COPY --from=builder /build/target/release/funds-manager /bin/funds-manager
 
 # Set log filtering
-ENV RUST_LOG="funds_manager=info,fireblocks_sdk=off,warp=warn"
+ENV RUST_LOG="funds_manager=info,fireblocks_sdk=off,warp=warn,price_reporter_client=info"
 ENTRYPOINT ["/bin/funds-manager"]

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -59,6 +59,7 @@ bigdecimal = { version = "0.4", features = ["serde"] }
 bytes = "1.5.0"
 futures = "0.3"
 http = "0.2"
+http1 = { package = "http", version = "1.3.1" }
 itertools = "0.13"
 metrics = "=0.22.3"
 num-bigint = "0.4"

--- a/funds-manager/funds-manager-server/src/middleware.rs
+++ b/funds-manager/funds-manager-server/src/middleware.rs
@@ -1,6 +1,7 @@
 //! Middleware for the funds manager server
 
 use crate::error::ApiError;
+use crate::helpers::convert_headers;
 use crate::{with_server, Server};
 use bytes::Bytes;
 use funds_manager_api::auth::{get_request_bytes, X_SIGNATURE_HEADER};
@@ -67,8 +68,9 @@ async fn verify_hmac(
         None => return Ok((body,)), // Auth is disabled, allow the request
     };
 
+    let auth_headers = convert_headers(&headers);
     // Try v2 auth first
-    if validate_expiring_auth(&path, &headers, &body, hmac_key).is_ok() {
+    if validate_expiring_auth(&path, &auth_headers, &body, hmac_key).is_ok() {
         return Ok((body,));
     }
 

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -58,7 +58,10 @@ impl Server {
             .unwrap()?;
         }
 
-        let price_reporter = Arc::new(PriceReporterClient::new(args.price_reporter_url.clone())?);
+        let price_reporter = Arc::new(PriceReporterClient::new(
+            args.price_reporter_url.clone(),
+            true, // exit_on_stale
+        )?);
 
         let hmac_key = args.get_hmac_key();
 

--- a/price-reporter-client/src/lib.rs
+++ b/price-reporter-client/src/lib.rs
@@ -66,8 +66,10 @@ pub struct PriceReporterClient {
 }
 
 impl PriceReporterClient {
-    /// Create a new PriceReporterClient with the given base URL
-    pub fn new(base_url: String) -> Result<Self, PriceReporterClientError> {
+    /// Create a new PriceReporterClient with the given base URL.
+    /// If `exit_on_stale` is true, the process will exit if the price stream
+    /// becomes stale.
+    pub fn new(base_url: String, exit_on_stale: bool) -> Result<Self, PriceReporterClientError> {
         let mut ws_url: Url = base_url.parse().map_err(PriceReporterClientError::parsing)?;
         ws_url
             .set_scheme("wss")
@@ -83,7 +85,10 @@ impl PriceReporterClient {
             .map(|t| t.get_addr())
             .collect();
 
-        Ok(Self { base_url, multi_price_stream: MultiPriceStream::new(ws_url.to_string(), mints) })
+        Ok(Self {
+            base_url,
+            multi_price_stream: MultiPriceStream::new(ws_url.to_string(), mints, exit_on_stale),
+        })
     }
 
     /// A convenience method for fetching the current price of ETH in USDC.


### PR DESCRIPTION
This PR adds an `exit_on_stale` option to the `PriceReporterClient` which, when set, has the client maintain a 1-minute timer that exits the current process. This timer gets re-created every time a price is updated, so as long as we're receiving prices within each minute, the self-destruct won't be invoked.

### Testing
- [x] Run local price reporter client w/ sleeps in between price updates, asserting that the process exits when the staleness timeout is hit
- [x] Run unmodified local price reporter client, asserting that prices are updated and the process runs w/o exiting