### PR TITLE
auth-server: metrics: add side metric to settled quote vol

### DIFF
--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -8,6 +8,7 @@ use renegade_circuit_types::order::OrderSide;
 use renegade_common::types::token::Token;
 
 use crate::chain_events::utils::GPv2Settlement;
+use crate::telemetry::helpers::extend_labels_with_side;
 use crate::{bundle_store::BundleContext, chain_events::listener::OnChainEventListenerExecutor};
 use crate::{
     error::AuthServerError,
@@ -56,7 +57,8 @@ impl OnChainEventListenerExecutor {
             &labels,
         );
 
-        let labels = extend_labels_with_base_asset(&match_result.base_mint, labels);
+        labels = extend_labels_with_base_asset(&match_result.base_mint, labels);
+        labels = extend_labels_with_side(&match_result.direction, labels);
         record_volume_with_tags(
             &match_result.quote_mint,
             match_result.quote_amount,

--- a/auth/auth-server/src/telemetry/helpers.rs
+++ b/auth/auth-server/src/telemetry/helpers.rs
@@ -111,6 +111,16 @@ pub(crate) fn extend_labels_with_base_asset(
     labels
 }
 
+/// Extends the given labels with a side tag
+pub(crate) fn extend_labels_with_side(
+    side: &OrderSide,
+    mut labels: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    let side_label = if side == &OrderSide::Sell { "sell" } else { "buy" };
+    labels.insert(0, (SIDE_TAG.to_string(), side_label.to_string()));
+    labels
+}
+
 /// Record a volume metric with the given extra tags
 pub(crate) fn record_volume_with_tags(
     mint: &str,


### PR DESCRIPTION
### Purpose
This PR ensures `external_match_settled_quote_volume` metrics is tagged with `side:{buy,sell}`.

### Testing
- [ ] Tested locally
- [x] Test in testnet