### PR TITLE
auth-server: api-handlers: Allow stringified numbers in request

### DIFF
--- a/auth/auth-server/Cargo.toml
+++ b/auth/auth-server/Cargo.toml
@@ -70,7 +70,7 @@ num-bigint = "0.4"
 atomic_float = "1"
 rustls = "0.23"
 serde = { version = "1.0.218", features = ["derive"] }
-serde_json = "1.0.139"
+serde_json = { version = "1.0.139", features = ["arbitrary_precision"] }
 serde_urlencoded = "0.7"
 thiserror = "1.0"
 tracing = "0.1"

--- a/auth/auth-server/src/http_utils/request_response.rs
+++ b/auth/auth-server/src/http_utils/request_response.rs
@@ -3,7 +3,8 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use http::header::CONTENT_LENGTH;
+use http::header::{ACCEPT, CONTENT_LENGTH};
+use http::HeaderMap;
 use reqwest::{Client, Response};
 use serde::Serialize;
 use serde_json::json;
@@ -67,6 +68,11 @@ pub fn convert_headers(headers: &warp::hyper::HeaderMap) -> http1::HeaderMap {
 // ------------
 // | Requests |
 // ------------
+
+/// Whether or not to stringify numbers in the request/response body
+pub fn should_stringify_numbers(headers: &HeaderMap) -> bool {
+    headers.get(ACCEPT).and_then(|v| v.to_str().ok()).is_some_and(|v| v.contains("number=string"))
+}
 
 /// Sends a basic POST request
 pub async fn send_post_request<T: Serialize>(

--- a/auth/auth-server/src/http_utils/stringify_formatter.rs
+++ b/auth/auth-server/src/http_utils/stringify_formatter.rs
@@ -1,11 +1,22 @@
 //! A formatter which stringifies all numbers in a response
 
-use std::{fmt::Display, io};
+use std::{
+    fmt::Display,
+    io::{self},
+    str::FromStr,
+};
 
-use serde::Serialize;
-use serde_json::ser::{CompactFormatter, Formatter, Serializer};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{
+    ser::{CompactFormatter, Formatter, Serializer},
+    Number, Value,
+};
 
 use crate::error::AuthServerError;
+
+// --------------
+// | Serializer |
+// --------------
 
 /// Serialize a value to json, possibly stringifying all numbers
 pub(crate) fn json_serialize<T: Serialize>(
@@ -155,6 +166,63 @@ impl Default for StringifyNumbersFormatter {
     }
 }
 
+// ----------------
+// | Deserializer |
+// ----------------
+
+/// Deserialize a value from json, possibly parsing stringified numbers
+fn json_deserialize<'de, T: DeserializeOwned>(
+    buf: &'de [u8],
+    stringify: bool,
+) -> Result<T, AuthServerError> {
+    if stringify {
+        let mut val: Value = serde_json::from_slice(buf).map_err(AuthServerError::serde)?;
+        convert_stringified_numbers(&mut val)?;
+        serde_json::from_value(val).map_err(AuthServerError::serde)
+    } else {
+        serde_json::from_slice(buf).map_err(AuthServerError::serde)
+    }
+}
+
+/// Convert all the stringified numbers in a struct into numbers
+fn convert_stringified_numbers(val: &mut Value) -> Result<(), AuthServerError> {
+    match val {
+        // If we see a string, check if that string represents a number.
+        // If it does, we convert it to a number. Under the hood, `serde_json` uses
+        // a string type to represent arbitrary precision numbers, so we don't actually need
+        // the parsed value, we just need to annotate it as a number, and the deserializer will
+        // handle it correctly.
+        Value::String(s) => {
+            // Try parsing a number
+            if is_numeric(s) {
+                let num = Number::from_str(s).map_err(AuthServerError::serde)?;
+                *val = Value::Number(num);
+            }
+        },
+
+        // Recurse into objects and arrays
+        Value::Object(map) => {
+            for (_, value) in map.iter_mut() {
+                convert_stringified_numbers(value)?;
+            }
+        },
+        Value::Array(arr) => {
+            for value in arr.iter_mut() {
+                convert_stringified_numbers(value)?;
+            }
+        },
+        _ => {},
+    }
+    Ok(())
+}
+
+/// Returns whether the given string represents a number
+///
+/// This can be an integer or floating point value
+fn is_numeric(s: &str) -> bool {
+    s.parse::<f64>().is_ok()
+}
+
 #[cfg(test)]
 mod test {
     use eyre::Result;
@@ -286,6 +354,26 @@ mod test {
         let gd_parsed_array: [u128; 10] = gd_parsed.try_into().unwrap();
         assert_eq!(test_struct.g.d, gd_parsed_array);
 
+        Ok(())
+    }
+
+    /// Tests deserializing a struct without stringifying the numbers
+    #[test]
+    fn test_json_deserialize() -> Result<()> {
+        let test_struct = TestStruct::new();
+        let json_buf = json_serialize(&test_struct, false /* stringify */)?;
+        let deser: TestStruct = json_deserialize(&json_buf, false /* stringify */)?;
+        assert_eq!(test_struct, deser);
+        Ok(())
+    }
+
+    /// Tests deserializing a struct with stringified numbers
+    #[test]
+    fn test_json_deserialize_stringify() -> Result<()> {
+        let test_struct = TestStruct::new();
+        let json_buf = json_serialize(&test_struct, true /* stringify */)?;
+        let deser: TestStruct = json_deserialize(&json_buf, true /* stringify */)?;
+        assert_eq!(test_struct, deser);
         Ok(())
     }
 }


### PR DESCRIPTION
### Purpose
This PR adds a `json_deserialize` method which can optionally convert all stringified numbers into number types ahead of deserialization. This allows clients to send numbers as string values.

### Testing
- [x] Tested on a locally running auth server
- [x] Testing in testnet