### PR TITLE
auth-server: chain_events: record quoter match spread cost

### DIFF
--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -227,8 +227,12 @@ impl OnChainEventListenerExecutor {
                 )
                 .await;
 
-                // Record settlement metrics
                 let api_match: ApiExternalMatchResult = external_match.match_result().into();
+
+                // Record quoter match spread cost
+                self.record_quoter_match_spread_cost(&bundle_ctx, &api_match).await?;
+
+                // Record settlement metrics
                 self.record_settlement_metrics(tx, &bundle_ctx, &api_match).await?;
 
                 // Record sponsorship metrics

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -61,6 +61,10 @@ pub const UNSUCCESSFUL_RELAYER_REQUEST_COUNT: &str = "num_unsuccessful_relayer_r
 /// Metric describing the number of times a quote was not found
 pub const QUOTE_NOT_FOUND_COUNT: &str = "num_quotes_not_found";
 
+/// Metric describing the cost due to spread on a quoter match against the
+/// reference price
+pub const QUOTER_MATCH_SPREAD_COST: &str = "quoter_match_spread_cost";
+
 // ---------------
 // | METRIC TAGS |
 // ---------------


### PR DESCRIPTION
This PR introduces the recording of a new metric: the "quoter match spread cost." This is the cost due to the spread between the match price and the reference price at the time of settlement.

This materializes as a cost in our accounting of the NAV since we use the reference price to compute the NAV of a quoter's holdings, but matches occur at the match price, so we may realize a loss of NAV at the time of a match.

### Testing
- [x] Test against testnet, sanity-check metric values w/ different settlement delays