### PR TITLE
auth-server: chain_events: record quoter match spread costs from quoter POV

### DIFF
--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -229,8 +229,8 @@ impl OnChainEventListenerExecutor {
 
                 let api_match: ApiExternalMatchResult = external_match.match_result().into();
 
-                // Record quoter match spread cost
-                self.record_quoter_match_spread_cost(&bundle_ctx, &api_match).await?;
+                // Record external match spread cost
+                self.record_external_match_spread_cost(&bundle_ctx, &api_match).await?;
 
                 // Record settlement metrics
                 self.record_settlement_metrics(tx, &bundle_ctx, &api_match).await?;

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -61,9 +61,10 @@ pub const UNSUCCESSFUL_RELAYER_REQUEST_COUNT: &str = "num_unsuccessful_relayer_r
 /// Metric describing the number of times a quote was not found
 pub const QUOTE_NOT_FOUND_COUNT: &str = "num_quotes_not_found";
 
-/// Metric describing the cost due to spread on a quoter match against the
-/// reference price
-pub const QUOTER_MATCH_SPREAD_COST: &str = "quoter_match_spread_cost";
+/// Metric describing the cost experienced by the internal party
+/// in an external match due to the spread between the match price
+/// and the reference price at the time of settlement
+pub const EXTERNAL_MATCH_SPREAD_COST: &str = "external_match_spread_cost";
 
 // ---------------
 // | METRIC TAGS |


### PR DESCRIPTION
This PR ensures that we record the quoter match spread cost from the perspective of the quoter. The quoter takes the _opposite_ side of the external party's order, and this informs the sign on the spread cost metric.

We also call out an assumption made in the recording of this metric: that the external match for which we record this cost was executed against a quoter. Currently, the overwhelming majority (~all) of our external match volume is against the quoters, and this assumption greatly simplifies the implementation of this metric.