### PR TITLE
funds-manager: execution_client: swap: add swaps to cover tgt amt

### DIFF
--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -251,9 +251,11 @@ impl ChainConfig {
 
         // Build an execution client
         let execution_client = ExecutionClient::new(
+            chain,
             self.execution_venue_api_key.clone(),
             self.execution_venue_base_url.clone(),
             &self.rpc_url,
+            price_reporter.clone(),
         )
         .map_err(FundsManagerError::custom)?;
 

--- a/funds-manager/funds-manager-server/src/execution_client/error.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/error.rs
@@ -2,26 +2,29 @@
 
 use std::{error::Error, fmt::Display};
 
+use price_reporter_client::error::PriceReporterClientError;
 use warp::reject::Reject;
 
 /// An error returned by the execution client
 #[derive(Debug, Clone)]
 pub enum ExecutionClientError {
-    /// An error interacting with Arbitrum
-    Arbitrum(String),
+    /// An error interacting with the chain
+    OnChain(String),
     /// An error returned by the execution client
     Http(String),
     /// An error parsing a value
     Parse(String),
+    /// An error returned by the price reporter
+    PriceReporter(PriceReporterClientError),
     /// A custom error
     Custom(String),
 }
 
 impl ExecutionClientError {
-    /// Create a new arbitrum error
+    /// Create a new onchain error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn arbitrum<T: ToString>(e: T) -> Self {
-        ExecutionClientError::Arbitrum(e.to_string())
+    pub fn onchain<T: ToString>(e: T) -> Self {
+        ExecutionClientError::OnChain(e.to_string())
     }
 
     /// Create a new http error
@@ -46,9 +49,10 @@ impl ExecutionClientError {
 impl Display for ExecutionClientError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let msg = match self {
-            ExecutionClientError::Arbitrum(e) => format!("Arbitrum error: {e}"),
+            ExecutionClientError::OnChain(e) => format!("Onchain error: {e}"),
             ExecutionClientError::Http(e) => format!("HTTP error: {e}"),
             ExecutionClientError::Parse(e) => format!("Parse error: {e}"),
+            ExecutionClientError::PriceReporter(e) => format!("Price reporter error: {e}"),
             ExecutionClientError::Custom(e) => format!("Custom error: {e}"),
         };
 
@@ -61,5 +65,11 @@ impl Reject for ExecutionClientError {}
 impl From<reqwest::Error> for ExecutionClientError {
     fn from(e: reqwest::Error) -> Self {
         ExecutionClientError::http(e)
+    }
+}
+
+impl From<PriceReporterClientError> for ExecutionClientError {
+    fn from(e: PriceReporterClientError) -> Self {
+        ExecutionClientError::PriceReporter(e)
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -12,11 +12,13 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use http::StatusCode;
+use price_reporter_client::PriceReporterClient;
+use renegade_common::types::chain::Chain;
 use reqwest::{Client, Url};
 use serde::Deserialize;
 use tracing::{error, instrument};
 
-use crate::helpers::{build_provider, send_tx_with_retry, ONE_CONFIRMATION};
+use crate::helpers::{build_provider, get_erc20_balance, send_tx_with_retry, ONE_CONFIRMATION};
 
 use self::error::ExecutionClientError;
 
@@ -26,6 +28,8 @@ const API_KEY_HEADER: &str = "x-lifi-api-key";
 /// The client for interacting with the execution venue
 #[derive(Clone)]
 pub struct ExecutionClient {
+    /// The chain on which the execution client settles transactions
+    chain: Chain,
     /// The API key to use for requests
     api_key: Option<String>,
     /// The base URL for the execution client
@@ -34,18 +38,29 @@ pub struct ExecutionClient {
     http_client: Arc<Client>,
     /// The RPC provider
     rpc_provider: DynProvider,
+    /// The price reporter client
+    price_reporter: Arc<PriceReporterClient>,
 }
 
 impl ExecutionClient {
     /// Create a new client
     pub fn new(
+        chain: Chain,
         api_key: Option<String>,
         base_url: String,
         rpc_url: &str,
+        price_reporter: Arc<PriceReporterClient>,
     ) -> Result<Self, ExecutionClientError> {
         let rpc_provider = build_provider(rpc_url).map_err(ExecutionClientError::parse)?;
 
-        Ok(Self { api_key, base_url, http_client: Arc::new(Client::new()), rpc_provider })
+        Ok(Self {
+            chain,
+            api_key,
+            base_url,
+            http_client: Arc::new(Client::new()),
+            rpc_provider,
+            price_reporter,
+        })
     }
 
     /// Get a full URL for a given endpoint
@@ -100,6 +115,17 @@ impl ExecutionClient {
     ) -> Result<TransactionReceipt, ExecutionClientError> {
         send_tx_with_retry(tx, client, ONE_CONFIRMATION)
             .await
-            .map_err(ExecutionClientError::arbitrum)
+            .map_err(ExecutionClientError::onchain)
+    }
+
+    /// Get the erc20 balance of an address
+    pub(crate) async fn get_erc20_balance(
+        &self,
+        token_address: &str,
+        address: &str,
+    ) -> Result<f64, ExecutionClientError> {
+        get_erc20_balance(token_address, address, self.rpc_provider.clone())
+            .await
+            .map_err(ExecutionClientError::onchain)
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -1,5 +1,7 @@
 //! Handlers for executing swaps
 
+use std::cmp::Ordering;
+
 use alloy::{
     eips::BlockId,
     hex,
@@ -13,12 +15,19 @@ use funds_manager_api::{
     quoters::{AugmentedExecutionQuote, ExecutionQuote, LiFiQuoteParams},
     u256_try_into_u64,
 };
-use renegade_common::types::chain::Chain;
+use renegade_common::types::{
+    chain::Chain,
+    token::{get_all_tokens, Token, STABLECOIN_TICKERS},
+};
 use tracing::{info, instrument, warn};
 
 use crate::helpers::IERC20;
 
 use super::{error::ExecutionClientError, ExecutionClient};
+
+// -------------
+// | Constants |
+// -------------
 
 /// The factor by which the swap size will be divided when retrying
 const SWAP_DECAY_FACTOR: U256 = U256::from_limbs([2, 0, 0, 0]);
@@ -30,8 +39,35 @@ const MIN_SWAP_QUOTE_AMOUNT: f64 = 10.0; // 10 USDC
 const APPROVAL_AMPLIFIER: U256 = U256::from_limbs([4, 0, 0, 0]);
 /// The address of the LiFi diamond (same address on Arbitrum One and Base
 /// Mainnet), constantized here to simplify approvals
-pub const LIFI_DIAMOND_ADDRESS: Address =
+const LIFI_DIAMOND_ADDRESS: Address =
     Address::new(hex!("0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae"));
+/// The buffer to scale the target amount by when executing swaps to cover it,
+/// to account for price drift
+const SWAP_TO_COVER_BUFFER: f64 = 1.1;
+
+// ---------
+// | Types |
+// ---------
+
+/// The outcome of an executed swap
+pub struct SwapOutcome {
+    /// The quote that was executed
+    pub augmented_quote: AugmentedExecutionQuote,
+    /// The transaction receipt of the swap
+    pub receipt: TransactionReceipt,
+    /// The cumulative gas cost of the swap, across all attempts.
+    pub cumulative_gas_cost: U256,
+}
+
+/// A candidate token to swap out of to cover a target amount of another token
+struct SwapCandidate {
+    /// The candidate token
+    pub token: Token,
+    /// The balance of the token
+    pub balance: f64,
+    /// The price of the token
+    pub price: f64,
+}
 
 // -----------
 // | Helpers |
@@ -56,17 +92,17 @@ impl ExecutionClient {
         let latest_block = client
             .get_block(BlockId::latest())
             .await
-            .map_err(ExecutionClientError::arbitrum)?
-            .ok_or(ExecutionClientError::arbitrum("No latest block found"))?;
+            .map_err(ExecutionClientError::onchain)?
+            .ok_or(ExecutionClientError::onchain("No latest block found"))?;
 
         let latest_basefee = latest_block
             .header
             .base_fee_per_gas
-            .ok_or(ExecutionClientError::arbitrum("No basefee found"))?
+            .ok_or(ExecutionClientError::onchain("No basefee found"))?
             as u128;
 
         let gas_limit =
-            u256_try_into_u64(quote.gas_limit).map_err(ExecutionClientError::arbitrum)?;
+            u256_try_into_u64(quote.gas_limit).map_err(ExecutionClientError::onchain)?;
 
         let tx = TransactionRequest::default()
             .with_to(quote.to)
@@ -87,13 +123,25 @@ impl ExecutionClient {
     /// attempted swaps
     pub async fn swap_immediate_decaying(
         &self,
-        chain: Chain,
         mut params: LiFiQuoteParams,
         wallet: PrivateKeySigner,
-    ) -> Result<(AugmentedExecutionQuote, TransactionReceipt, U256), ExecutionClientError> {
+    ) -> Result<SwapOutcome, ExecutionClientError> {
+        // Approve the top-level sell amount
+        let sell_token_amount = params.from_amount;
+        let sell_token_address: Address =
+            params.from_token.parse().map_err(ExecutionClientError::parse)?;
+
+        self.approve_erc20_allowance(
+            sell_token_address,
+            LIFI_DIAMOND_ADDRESS,
+            sell_token_amount,
+            &wallet,
+        )
+        .await?;
+
         let mut cumulative_gas_cost = U256::ZERO;
         loop {
-            let augmented_quote = self.get_augmented_quote(params.clone(), chain).await?;
+            let augmented_quote = self.get_augmented_quote(params.clone(), self.chain).await?;
 
             // Submit the swap
             let client = self.get_signing_provider(wallet.clone());
@@ -103,7 +151,7 @@ impl ExecutionClient {
 
             // If the swap succeeds, return
             if receipt.status() {
-                return Ok((augmented_quote, receipt, cumulative_gas_cost));
+                return Ok(SwapOutcome { augmented_quote, receipt, cumulative_gas_cost });
             }
 
             // Otherwise, decrease the swap size and try again
@@ -111,6 +159,177 @@ impl ExecutionClient {
             params =
                 LiFiQuoteParams { from_amount: params.from_amount / SWAP_DECAY_FACTOR, ..params };
         }
+    }
+
+    /// Try to execute swaps to cover a target amount of a token,
+    /// first checking if any swaps are necessary.
+    ///
+    /// Returns a vector of outcomes for the executed swaps.
+    pub async fn try_swap_to_cover(
+        &self,
+        target_amount: f64,
+        params: LiFiQuoteParams,
+        wallet: PrivateKeySigner,
+    ) -> Result<Vec<SwapOutcome>, ExecutionClientError> {
+        let target_token = Token::from_addr_on_chain(&params.to_token, self.chain);
+        let ticker = target_token.get_ticker().unwrap_or(target_token.get_addr());
+
+        // Check that the current token balances doesn't already cover the target amount
+        let current_balance =
+            self.get_erc20_balance(&target_token.addr, &wallet.address().to_string()).await?;
+
+        if current_balance >= target_amount {
+            info!("Current {ticker} balance ({current_balance}) is greater than target amount ({target_amount}), skipping swaps");
+            return Ok(vec![]);
+        }
+
+        let amount_to_cover = target_amount - current_balance;
+
+        // Check that the amount to cover is greater than the minimum swap amount
+        if amount_to_cover < MIN_SWAP_QUOTE_AMOUNT {
+            info!("Amount to cover ({amount_to_cover}) is less than minimum swap amount ({MIN_SWAP_QUOTE_AMOUNT}), skipping swaps");
+            return Ok(vec![]);
+        }
+
+        self.execute_swaps_to_cover(target_token, amount_to_cover, params, wallet).await
+    }
+
+    /// Execute swaps to cover a target amount of a token.
+    ///
+    /// Returns a vector of outcomes for the executed swaps.
+    async fn execute_swaps_to_cover(
+        &self,
+        target_token: Token,
+        amount_to_cover: f64,
+        params: LiFiQuoteParams,
+        wallet: PrivateKeySigner,
+    ) -> Result<Vec<SwapOutcome>, ExecutionClientError> {
+        let target_ticker = target_token.get_ticker().unwrap_or(target_token.get_addr());
+
+        // Get the balances of the candidate tokens to swap out of,
+        // sorted by descending value
+        let swap_candidates =
+            self.get_swap_candidates(&target_token, &wallet.address().to_string()).await?;
+
+        // We increase the amount to cover by a fixed buffer to account for drift
+        // in the prices sampled when getting swap candidates
+        let mut remaining_amount = amount_to_cover * SWAP_TO_COVER_BUFFER;
+        info!("Need to cover {amount_to_cover} {target_ticker}, purchasing {remaining_amount}");
+
+        let mut outcomes = vec![];
+        for candidate in swap_candidates {
+            let token = &candidate.token;
+            let ticker = token.get_ticker().unwrap_or(token.get_addr());
+
+            let maybe_outcome = self
+                .try_swap_candidate(
+                    target_token.get_addr(),
+                    candidate,
+                    remaining_amount,
+                    params.clone(),
+                    wallet.clone(),
+                )
+                .await?;
+
+            if maybe_outcome.is_none() {
+                break;
+            }
+
+            let swap_outcome = maybe_outcome.unwrap();
+
+            let sell_amount = swap_outcome
+                .augmented_quote
+                .get_decimal_corrected_sell_amount()
+                .map_err(ExecutionClientError::custom)?;
+
+            let quoted_buy_amount = swap_outcome
+                .augmented_quote
+                .get_decimal_corrected_buy_amount()
+                .map_err(ExecutionClientError::custom)?;
+
+            outcomes.push(swap_outcome);
+
+            info!("Swapped {sell_amount} {ticker} for {quoted_buy_amount} {target_ticker}");
+
+            remaining_amount -= quoted_buy_amount;
+        }
+
+        Ok(outcomes)
+    }
+
+    /// Get the candidate token balances to swap out of to cover some amount of
+    /// the target token. Returns a vector of (token, balance, price)
+    /// tuples, sorted by descending value.
+    async fn get_swap_candidates(
+        &self,
+        target_token: &Token,
+        wallet_address: &str,
+    ) -> Result<Vec<SwapCandidate>, ExecutionClientError> {
+        let candidate_tokens: Vec<Token> = get_all_tokens()
+            .into_iter()
+            .filter(|token| {
+                token.get_chain() == self.chain
+                    && !STABLECOIN_TICKERS
+                        .contains(&token.get_ticker().unwrap_or_default().as_str())
+                    && token.get_addr() != target_token.get_addr()
+            })
+            .collect();
+
+        let mut swap_candidates = vec![];
+        for token in candidate_tokens {
+            let balance = self.get_erc20_balance(&token.addr, wallet_address).await?;
+            let price = self.price_reporter.get_price(&token.addr, self.chain).await?;
+            swap_candidates.push(SwapCandidate { token, balance, price });
+        }
+
+        // Sort the tokens by their value, descending
+        swap_candidates.sort_by(|a, b| {
+            let value_a = a.balance * a.price;
+            let value_b = b.balance * b.price;
+
+            value_b.partial_cmp(&value_a).unwrap_or(Ordering::Equal)
+        });
+
+        Ok(swap_candidates)
+    }
+
+    /// Try to swap out of a candidate token to cover a target amount of a
+    /// token.
+    ///
+    /// Returns an outcome for the swap if it was successful,
+    /// or `None` if no swap occurred.
+    async fn try_swap_candidate(
+        &self,
+        target_token_addr: String,
+        candidate: SwapCandidate,
+        amount_to_cover: f64,
+        params: LiFiQuoteParams,
+        wallet: PrivateKeySigner,
+    ) -> Result<Option<SwapOutcome>, ExecutionClientError> {
+        let SwapCandidate { token, balance, price } = candidate;
+        let balance_value = balance * price;
+
+        // If the token balance is less than the remaining amount, we swap out of the
+        // entire balance. Otherwise, we calculate the necessary amount to
+        // swap out of.
+        let swap_amount_decimal =
+            if balance_value <= amount_to_cover { balance } else { amount_to_cover / price };
+
+        let swap_value = swap_amount_decimal * price;
+        if swap_value < MIN_SWAP_QUOTE_AMOUNT {
+            return Ok(None);
+        }
+
+        let swap_amount = token.convert_from_decimal(swap_amount_decimal);
+        let swap_params = LiFiQuoteParams {
+            to_token: target_token_addr,
+            from_token: token.get_addr(),
+            from_amount: U256::from(swap_amount),
+            ..params
+        };
+
+        let swap_outcome = self.swap_immediate_decaying(swap_params, wallet).await?;
+        Ok(Some(swap_outcome))
     }
 
     /// Get an execution quote for a swap
@@ -151,7 +370,7 @@ impl ExecutionClient {
             .allowance(wallet.address(), spender)
             .call()
             .await
-            .map_err(ExecutionClientError::arbitrum)?;
+            .map_err(ExecutionClientError::onchain)?;
 
         if allowance >= amount {
             info!("Already approved erc20 allowance for {spender:#x}");
@@ -161,9 +380,9 @@ impl ExecutionClient {
         // Otherwise, approve the allowance
         let approval_amount = amount * APPROVAL_AMPLIFIER;
         let tx = erc20.approve(spender, approval_amount);
-        let pending_tx = tx.send().await.map_err(ExecutionClientError::arbitrum)?;
+        let pending_tx = tx.send().await.map_err(ExecutionClientError::onchain)?;
 
-        let receipt = pending_tx.get_receipt().await.map_err(ExecutionClientError::arbitrum)?;
+        let receipt = pending_tx.get_receipt().await.map_err(ExecutionClientError::onchain)?;
 
         info!("Approved erc20 allowance at: {:#x}", receipt.transaction_hash);
         Ok(())


### PR DESCRIPTION
This PR adds a `try_swap_to_cover` method to the `ExecutionClient`, which will swap out of other token balances in order to cover the target amount of the target token. It does so by greedily swapping out of the highest-valued balances of the wallet provided to the method.

### TODO:
- Set up handler which invokes `try_swap_to_cover`, records swap cost metrics, and returns the total purchased amount of the target token
- Test the new endpoint