### PR TITLE
price-reporter: migrate off of `renegade-price-reporter` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -68,17 +68,6 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -161,7 +150,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -407,7 +396,7 @@ dependencies = [
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "tiny-keccak",
 ]
 
@@ -904,28 +893,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyerror"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71add24cc141a1e8326f249b74c41cfd217aeb2a67c9c6cf9134d175469afd49"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "arc-swap"
@@ -1161,7 +1132,7 @@ dependencies = [
  "rustls 0.20.9",
  "serde",
  "serde_json",
- "sha3 0.10.8",
+ "sha3",
  "tokio",
  "tracing",
  "zeroize",
@@ -1470,7 +1441,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex 0.4.3",
+ "hex",
  "http 1.3.1",
  "ring 0.17.14",
  "time",
@@ -1605,7 +1576,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "hex 0.4.3",
+ "hex",
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
@@ -1721,7 +1692,7 @@ dependencies = [
  "bytes",
  "crypto-bigint 0.5.5",
  "form_urlencoded",
- "hex 0.4.3",
+ "hex",
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
@@ -1756,7 +1727,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "crc-fast",
- "hex 0.4.3",
+ "hex",
  "http 0.2.12",
  "http-body 0.4.6",
  "md-5",
@@ -1918,7 +1889,7 @@ dependencies = [
  "serde",
  "time",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2115,15 +2086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,26 +2168,14 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -2239,24 +2189,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2265,23 +2202,8 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blst"
@@ -2321,29 +2243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
-dependencies = [
- "borsh-derive",
- "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
-dependencies = [
- "once_cell",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,66 +2265,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "bus"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7118d0221d84fada881b657c2ddb7cd55108db79c8764c9ee212c0c259b783"
-dependencies = [
- "crossbeam-channel",
- "num_cpus",
- "parking_lot_core 0.9.11",
-]
-
-[[package]]
 name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
-name = "byte-unit"
-version = "5.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
-dependencies = [
- "rust_decimal",
- "serde",
- "utf8-width",
-]
-
-[[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "bytemuck"
-version = "1.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -2481,7 +2324,7 @@ dependencies = [
  "blst",
  "cc",
  "glob",
- "hex 0.4.3",
+ "hex",
  "libc",
  "once_cell",
  "serde",
@@ -2493,7 +2336,7 @@ version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d73155ae6b28cf5de4cfc29aeb02b8a1c6dab883cb015d15cd514e42766846"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.14.5",
@@ -2588,12 +2431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,7 +2518,7 @@ dependencies = [
  "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
  "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
  "futures",
- "hex 0.4.3",
+ "hex",
  "itertools 0.10.5",
  "jf-primitives",
  "k256",
@@ -2713,7 +2550,7 @@ dependencies = [
  "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade)",
  "constants 0.1.0 (git+https://github.com/renegade-fi/renegade)",
  "futures",
- "hex 0.4.3",
+ "hex",
  "itertools 0.10.5",
  "jf-primitives",
  "k256",
@@ -2738,7 +2575,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal 0.3.1",
- "bitvec 1.0.1",
+ "bitvec",
  "circuit-macros 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
  "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
  "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
@@ -2856,7 +2693,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8fba409ce3dc04f7d804074039eb68b960b0829161f8e06c95fea3f122528"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "coins-bip32",
  "hmac",
  "once_cell",
@@ -2876,13 +2713,13 @@ dependencies = [
  "bech32",
  "bs58 0.5.1",
  "digest 0.10.7",
- "generic-array 0.14.7",
- "hex 0.4.3",
+ "generic-array",
+ "hex",
  "ripemd",
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "sha3 0.10.8",
+ "sha3",
  "thiserror 1.0.69",
 ]
 
@@ -2913,7 +2750,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3028,7 +2865,7 @@ checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "hex 0.4.3",
+ "hex",
  "proptest",
  "serde",
 ]
@@ -3101,12 +2938,6 @@ dependencies = [
  "serde",
  "serde_with",
 ]
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -3197,16 +3028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "create2"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77400797683577a98863496c945600573f30a738651ee5cc047234f9a4cc821"
-dependencies = [
- "hex 0.4.3",
- "sha3 0.8.2",
-]
-
-[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,7 +3112,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -3303,7 +3124,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -3315,7 +3136,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -3547,19 +3368,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -3672,20 +3480,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -3874,7 +3673,7 @@ dependencies = [
  "der 0.6.1",
  "digest 0.10.7",
  "ff 0.12.1",
- "generic-array 0.14.7",
+ "generic-array",
  "group 0.12.1",
  "pkcs8 0.9.0",
  "rand_core 0.6.4",
@@ -3893,7 +3692,7 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
- "generic-array 0.14.7",
+ "generic-array",
  "group 0.13.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -3953,13 +3752,13 @@ checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "hex 0.4.3",
+ "hex",
  "k256",
  "log",
  "rand 0.8.5",
  "rlp",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "zeroize",
 ]
 
@@ -3993,7 +3792,7 @@ dependencies = [
  "aes",
  "ctr",
  "digest 0.10.7",
- "hex 0.4.3",
+ "hex",
  "hmac",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
@@ -4001,24 +3800,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sha3 0.10.8",
+ "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
-]
-
-[[package]]
-name = "ethabi"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
-dependencies = [
- "ethereum-types 0.12.1",
- "hex 0.4.3",
- "serde",
- "serde_json",
- "sha3 0.9.1",
- "thiserror 1.0.69",
- "uint",
 ]
 
 [[package]]
@@ -4027,28 +3811,15 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
 dependencies = [
- "ethereum-types 0.14.1",
- "hex 0.4.3",
+ "ethereum-types",
+ "hex",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
- "sha3 0.10.8",
+ "sha3",
  "thiserror 1.0.69",
  "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
-dependencies = [
- "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -4058,26 +3829,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "fixed-hash",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
-dependencies = [
- "ethbloom 0.11.1",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "primitive-types 0.10.1",
- "uint",
 ]
 
 [[package]]
@@ -4086,12 +3843,12 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "ethbloom",
+ "fixed-hash",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
+ "impl-serde",
+ "primitive-types",
  "scale-info",
  "uint",
 ]
@@ -4195,8 +3952,8 @@ dependencies = [
  "chrono",
  "const-hex",
  "elliptic-curve 0.13.8",
- "ethabi 18.0.0",
- "generic-array 0.14.7",
+ "ethabi",
+ "generic-array",
  "k256",
  "num_enum",
  "once_cell",
@@ -4354,7 +4111,7 @@ dependencies = [
  "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
  "common",
  "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "hex 0.4.3",
+ "hex",
  "http 1.3.1",
  "itertools 0.10.5",
  "num-bigint",
@@ -4462,22 +4219,10 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
  "tracing",
  "url",
  "uuid 1.17.0",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -4590,7 +4335,7 @@ dependencies = [
  "fireblocks-sdk",
  "funds-manager-api",
  "futures",
- "hex 0.4.3",
+ "hex",
  "http 0.2.12",
  "http 1.3.1",
  "http-body-util",
@@ -4629,12 +4374,6 @@ dependencies = [
  "sha2 0.10.9",
  "uuid 1.17.0",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "funty"
@@ -4778,15 +4517,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
@@ -4838,7 +4568,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
- "opaque-debug 0.3.1",
+ "opaque-debug",
  "polyval",
 ]
 
@@ -4864,25 +4594,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gossip-api"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c8938f1#c8938f119b8c53e74d33bb5b36a5ce4852708294"
-dependencies = [
- "bincode",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "common",
- "hmac",
- "libp2p",
- "openraft",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "uuid 1.17.0",
 ]
 
 [[package]]
@@ -4922,7 +4633,7 @@ dependencies = [
  "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4941,7 +4652,7 @@ dependencies = [
  "indexmap 2.9.0",
  "slab",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
  "tracing",
 ]
 
@@ -4959,9 +4670,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4969,7 +4677,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -4978,7 +4686,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -5058,12 +4766,6 @@ name = "hermit-abi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
@@ -5432,17 +5134,6 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -5464,20 +5155,11 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
-dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
 dependencies = [
- "parity-scale-codec 3.7.5",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -5487,15 +5169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5552,7 +5225,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -5678,7 +5351,7 @@ dependencies = [
  "rayon",
  "serde",
  "sha2 0.10.9",
- "sha3 0.10.8",
+ "sha3",
  "tagged-base64",
  "typenum",
  "zeroize",
@@ -5698,29 +5371,6 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "tagged-base64",
-]
-
-[[package]]
-name = "job-types"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c8938f1#c8938f119b8c53e74d33bb5b36a5ce4852708294"
-dependencies = [
- "ark-mpc",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "circuits",
- "common",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "crossbeam",
- "external-api",
- "gossip-api",
- "libp2p",
- "libp2p-core",
- "metrics",
- "renegade-metrics",
- "serde",
- "tokio",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "uuid 1.17.0",
 ]
 
 [[package]]
@@ -5748,21 +5398,6 @@ name = "json"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
-dependencies = [
- "futures",
- "futures-executor",
- "futures-util",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
 
 [[package]]
 name = "jsonwebtoken"
@@ -5916,7 +5551,6 @@ dependencies = [
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-identity",
- "libp2p-request-response",
  "libp2p-swarm",
  "multiaddr",
  "pin-project",
@@ -5990,22 +5624,6 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "zeroize",
-]
-
-[[package]]
-name = "libp2p-request-response"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffdb374267d42dc5ed5bc53f6e601d4a64ac5964779c6e40bb9e4f14c1e30d5"
-dependencies = [
- "async-trait",
- "futures",
- "instant",
- "libp2p-core",
- "libp2p-identity",
- "libp2p-swarm",
- "rand 0.8.5",
- "smallvec",
 ]
 
 [[package]]
@@ -6107,12 +5725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6120,12 +5732,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -6138,16 +5744,6 @@ name = "matchit"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
 
 [[package]]
 name = "md-5"
@@ -6183,7 +5779,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "portable-atomic",
 ]
 
@@ -6304,7 +5900,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rayon",
  "serde",
- "sha3 0.10.8",
+ "sha3",
  "tagged-base64",
 ]
 
@@ -6423,35 +6019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nalgebra"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d506eb7e08d6329505faa8a3a00a5dcc6de9f76e0c77e4b75763ae3c770831ff"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "rand 0.8.5",
- "rand_distr",
- "simba",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6516,15 +6083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6547,16 +6105,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-integer",
  "num-traits",
 ]
 
@@ -6637,12 +6185,6 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
@@ -6656,7 +6198,7 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "open-fastrlp-derive",
 ]
 
@@ -6670,41 +6212,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "openraft"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbaeb68eb89f273a47b845f1654ed70be799577a990639136f32decbb1782c26"
-dependencies = [
- "anyerror",
- "byte-unit",
- "chrono",
- "clap",
- "derive_more 1.0.0",
- "futures",
- "maplit",
- "openraft-macros",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
- "validit",
-]
-
-[[package]]
-name = "openraft-macros"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0976e3223aacad0eb3d192505297a36a57b3940cbd9d50f9b64cdf18055c7c"
-dependencies = [
- "chrono",
- "proc-macro2",
- "quote",
- "semver 1.0.26",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -6901,44 +6408,18 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
-dependencies = [
- "arrayvec",
- "bitvec 0.20.4",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 2.3.1",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
- "bitvec 1.0.1",
+ "bitvec",
  "byte-slice-cast",
  "const_format",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.7.5",
+ "parity-scale-codec-derive",
  "rustversion",
  "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
-dependencies = [
- "proc-macro-crate 1.1.3",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -7209,7 +6690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.1",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -7221,7 +6702,7 @@ checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "opaque-debug 0.3.1",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -7335,40 +6816,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "price-reporter"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c8938f1#c8938f119b8c53e74d33bb5b36a5ce4852708294"
-dependencies = [
- "async-trait",
- "atomic_float 0.1.0",
- "common",
- "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "create2",
- "external-api",
- "futures",
- "futures-util",
- "hex 0.3.2",
- "itertools 0.11.0",
- "job-types",
- "jsonwebtoken 9.3.1",
- "lazy_static",
- "reqwest 0.12.22",
- "serde",
- "serde_json",
- "statrs",
- "system-bus",
- "thiserror 2.0.12",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite 0.18.0",
- "tracing",
- "tungstenite 0.18.0",
- "url",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "web3",
-]
-
-[[package]]
 name = "price-reporter-client"
 version = "0.1.0"
 dependencies = [
@@ -7388,27 +6835,14 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-rlp",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
+ "fixed-hash",
+ "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "uint",
 ]
@@ -7531,26 +6965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7655,12 +7069,6 @@ dependencies = [
  "parking_lot 0.12.4",
  "scheduled-thread-pool",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -7773,16 +7181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7819,12 +7217,6 @@ checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -7882,7 +7274,7 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.15",
+ "tokio-util",
  "url",
  "uuid 1.17.0",
 ]
@@ -7967,15 +7359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
-]
-
-[[package]]
 name = "renegade-crypto"
 version = "0.1.0"
 source = "git+https://github.com/renegade-fi/renegade.git?rev=c8938f1#c8938f119b8c53e74d33bb5b36a5ce4852708294"
@@ -8044,21 +7427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "renegade-metrics"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c8938f1#c8938f119b8c53e74d33bb5b36a5ce4852708294"
-dependencies = [
- "atomic_float 1.1.0",
- "circuit-types 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
- "common",
- "lazy_static",
- "metrics",
- "num-bigint",
- "tracing",
- "util 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c8938f1)",
-]
-
-[[package]]
 name = "renegade-price-reporter"
 version = "0.1.0"
 dependencies = [
@@ -8077,7 +7445,6 @@ dependencies = [
  "jsonwebtoken 9.3.1",
  "lazy_static",
  "matchit 0.7.3",
- "price-reporter",
  "reqwest 0.12.22",
  "serde",
  "serde_json",
@@ -8170,7 +7537,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util 0.7.15",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -8346,35 +7713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec 1.0.1",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid 1.17.0",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8422,8 +7760,8 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "parity-scale-codec 3.7.5",
- "primitive-types 0.12.2",
+ "parity-scale-codec",
+ "primitive-types",
  "proptest",
  "rand 0.8.5",
  "rand 0.9.1",
@@ -8439,22 +7777,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust_decimal"
-version = "1.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa7de2ba56ac291bd90c6b9bece784a52ae1411f9506544b3eae36dd2356d50"
-dependencies = [
- "arrayvec",
- "borsh",
- "bytes",
- "num-traits",
- "rand 0.8.5",
- "rkyv",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "rustc-demangle"
@@ -8667,15 +7989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "safe_arch"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8701,7 +8014,7 @@ checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
 dependencies = [
  "cfg-if",
  "derive_more 1.0.0",
- "parity-scale-codec 3.7.5",
+ "parity-scale-codec",
  "scale-info-derive",
 ]
 
@@ -8779,12 +8092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8792,7 +8099,7 @@ checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct 0.1.1",
  "der 0.6.1",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8 0.9.0",
  "subtle",
  "zeroize",
@@ -8806,20 +8113,11 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
-dependencies = [
- "secp256k1-sys 0.4.2",
 ]
 
 [[package]]
@@ -8830,17 +8128,8 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -9024,7 +8313,7 @@ checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
- "hex 0.4.3",
+ "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
  "serde",
@@ -9057,19 +8346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug 0.3.1",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9096,7 +8372,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.1",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -9118,31 +8394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "sha3"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
-dependencies = [
- "block-buffer 0.7.3",
- "byte-tools",
- "digest 0.8.1",
- "keccak",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.1",
 ]
 
 [[package]]
@@ -9214,25 +8465,6 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "simba"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7840f121a46d63066ee7a99fc81dcabbc6105e437cae43528cea199b5a05f"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -9320,21 +8552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "soketto"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
-dependencies = [
- "base64 0.13.1",
- "bytes",
- "futures",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha-1",
-]
-
-[[package]]
 name = "solang-parser"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9394,19 +8611,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "statrs"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35a062dbadac17a42e0fc64c27f419b25d6fae98572eb43c8814c9e873d7721"
-dependencies = [
- "approx",
- "lazy_static",
- "nalgebra",
- "num-traits",
- "rand 0.8.5",
-]
 
 [[package]]
 name = "string_cache"
@@ -9495,7 +8699,7 @@ checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
 dependencies = [
  "dirs",
  "fs2",
- "hex 0.4.3",
+ "hex",
  "once_cell",
  "reqwest 0.11.27",
  "semver 1.0.26",
@@ -9589,18 +8793,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
-]
-
-[[package]]
-name = "system-bus"
-version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=c8938f1#c8938f119b8c53e74d33bb5b36a5ce4852708294"
-dependencies = [
- "bus",
- "common",
- "futures",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -9922,7 +9114,7 @@ dependencies = [
  "rand 0.9.1",
  "socket2 0.5.10",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
  "whoami",
 ]
 
@@ -9955,7 +9147,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
 ]
 
 [[package]]
@@ -10015,21 +9207,6 @@ dependencies = [
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-io",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -10139,7 +9316,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.15",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10419,7 +9596,7 @@ checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex 0.4.3",
+ "hex",
  "static_assertions",
 ]
 
@@ -10509,7 +9686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.0.3",
+ "idna",
  "percent-encoding",
 ]
 
@@ -10524,12 +9701,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-width"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"
@@ -10557,7 +9728,7 @@ dependencies = [
  "crossbeam",
  "eyre",
  "futures",
- "hex 0.4.3",
+ "hex",
  "json",
  "libp2p",
  "metrics",
@@ -10596,7 +9767,7 @@ dependencies = [
  "crossbeam",
  "eyre",
  "futures",
- "hex 0.4.3",
+ "hex",
  "json",
  "libp2p",
  "metrics",
@@ -10641,15 +9812,6 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "validit"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fad49f3eae9c160c06b4d49700a99e75817f127cf856e494b56d5e23170020"
-dependencies = [
- "anyerror",
 ]
 
 [[package]]
@@ -10734,7 +9896,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "tokio-util 0.7.15",
+ "tokio-util",
  "tower-service",
  "tracing",
 ]
@@ -10912,54 +10074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web3"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f258e254752d210b84fe117b31f1e3cc9cbf04c0d747eb7f8cf7cf5e370f6d"
-dependencies = [
- "arrayvec",
- "base64 0.13.1",
- "bytes",
- "derive_more 0.99.20",
- "ethabi 16.0.0",
- "ethereum-types 0.12.1",
- "futures",
- "futures-timer",
- "headers",
- "hex 0.4.3",
- "idna 0.2.3",
- "jsonrpc-core",
- "log",
- "once_cell",
- "parking_lot 0.12.4",
- "pin-project",
- "reqwest 0.11.27",
- "rlp",
- "secp256k1 0.21.3",
- "serde",
- "serde_json",
- "soketto",
- "tiny-keccak",
- "tokio",
- "tokio-stream",
- "tokio-util 0.6.10",
- "url",
- "web3-async-native-tls",
-]
-
-[[package]]
-name = "web3-async-native-tls"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
-dependencies = [
- "native-tls",
- "thiserror 1.0.69",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "webpki"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11014,16 +10128,6 @@ dependencies = [
  "redox_syscall 0.5.12",
  "wasite",
  "web-sys",
-]
-
-[[package]]
-name = "wide"
-version = "0.7.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]
@@ -11457,12 +10561,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"

--- a/price-reporter/Cargo.toml
+++ b/price-reporter/Cargo.toml
@@ -38,7 +38,6 @@ itertools = "0.10"
 lazy_static = "1.4"
 
 # === Renegade === #
-renegade-price-reporter = { package = "price-reporter", workspace = true }
 renegade-api = { package = "external-api", workspace = true }
 renegade-config = { package = "config", workspace = true }
 renegade-common = { package = "common", workspace = true }

--- a/price-reporter/src/errors.rs
+++ b/price-reporter/src/errors.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use renegade_price_reporter::errors::ExchangeConnectionError;
+use crate::exchanges::error::ExchangeConnectionError;
 
 /// An error that can occur in the price reporter server.
 #[derive(Debug, thiserror::Error)]

--- a/price-reporter/src/exchanges/error.rs
+++ b/price-reporter/src/exchanges/error.rs
@@ -8,6 +8,9 @@ use thiserror::Error;
 /// consecutive errors.
 #[derive(Clone, Debug, Error)]
 pub enum ExchangeConnectionError {
+    /// Tried to initialize an ExchangeConnection that was already initialized
+    #[error("tried to initialize an ExchangeConnection that was already initialized: {0}")]
+    AlreadyInitialized(Exchange, Token, Token),
     /// A websocket remote connection hangup.
     #[error("remote connection hangup: {0}")]
     ConnectionHangup(String),
@@ -26,16 +29,23 @@ pub enum ExchangeConnectionError {
         "maximum retry count exceeded while trying to re-establish an exchange connection to {0}"
     )]
     MaxRetries(Exchange),
-    /// The given pair is not supported by the exchange
-    #[error("the given pair ({0}, {1}) is not supported by the exchange ({2})")]
-    UnsupportedPair(Token, Token, Exchange),
     /// Error sending on the `write` end of the websocket
     #[error("error sending on the `write` end of the websocket: {0}")]
     SendError(String),
     /// Error saving the state of a price stream
     #[error("error saving the state of a price stream: {0}")]
     SaveState(String),
-    /// Tried to initialize an ExchangeConnection that was already initialized
-    #[error("tried to initialize an ExchangeConnection that was already initialized: {0}")]
-    AlreadyInitialized(Exchange, Token, Token),
+    /// An unsupported exchange was requested
+    #[error("an unsupported exchange was requested: {0}")]
+    UnsupportedExchange(Exchange),
+    /// The given pair is not supported by the exchange
+    #[error("the given pair ({0}, {1}) is not supported by the exchange ({2})")]
+    UnsupportedPair(Token, Token, Exchange),
+}
+
+impl ExchangeConnectionError {
+    /// Create an error indicating that the given exchange is not supported
+    pub fn unsupported_exchange(exchange: Exchange) -> Self {
+        Self::UnsupportedExchange(exchange)
+    }
 }

--- a/price-reporter/src/exchanges/mod.rs
+++ b/price-reporter/src/exchanges/mod.rs
@@ -1,12 +1,19 @@
 //! Exchange connection shims
 
-mod binance;
-mod coinbase;
-mod connection;
-mod error;
-mod kraken;
-mod okx;
-mod util;
+use renegade_common::types::{exchange::Exchange, token::Token};
+
+use crate::exchanges::{
+    binance::BinanceConnection, coinbase::CoinbaseConnection, connection::ExchangeConnection,
+    error::ExchangeConnectionError, kraken::KrakenConnection, okx::OkxConnection,
+};
+
+pub(crate) mod binance;
+pub(crate) mod coinbase;
+pub(crate) mod connection;
+pub(crate) mod error;
+pub(crate) mod kraken;
+pub(crate) mod okx;
+pub(crate) mod util;
 
 /// The configuration options that may be used by exchange connections
 #[derive(Clone, Debug, Default)]
@@ -29,4 +36,29 @@ impl ExchangeConnectionsConfig {
     pub fn uniswap_v3_configured(&self) -> bool {
         self.eth_websocket_addr.is_some()
     }
+}
+
+/// Construct a new websocket connection for the given exchange
+pub async fn connect_exchange(
+    base_token: &Token,
+    quote_token: &Token,
+    config: &ExchangeConnectionsConfig,
+    exchange: Exchange,
+) -> Result<Box<dyn ExchangeConnection>, ExchangeConnectionError> {
+    let base_token = base_token.clone();
+    let quote_token = quote_token.clone();
+
+    Ok(match exchange {
+        Exchange::Binance => {
+            Box::new(BinanceConnection::connect(base_token, quote_token, config).await?)
+        },
+        Exchange::Coinbase => {
+            Box::new(CoinbaseConnection::connect(base_token, quote_token, config).await?)
+        },
+        Exchange::Kraken => {
+            Box::new(KrakenConnection::connect(base_token, quote_token, config).await?)
+        },
+        Exchange::Okx => Box::new(OkxConnection::connect(base_token, quote_token, config).await?),
+        _ => return Err(ExchangeConnectionError::unsupported_exchange(exchange)),
+    })
 }

--- a/price-reporter/src/exchanges/util.rs
+++ b/price-reporter/src/exchanges/util.rs
@@ -3,7 +3,26 @@
 use itertools::Itertools;
 use renegade_common::types::{exchange::Exchange, token::Token};
 
-use crate::exchanges::error::ExchangeConnectionError;
+use crate::exchanges::{
+    binance::BinanceConnection, coinbase::CoinbaseConnection, connection::ExchangeConnection,
+    error::ExchangeConnectionError, kraken::KrakenConnection, okx::OkxConnection,
+};
+
+/// Check if the given exchange supports the given pair
+pub async fn supports_pair(
+    exchange: &Exchange,
+    base_token: &Token,
+    quote_token: &Token,
+) -> Result<bool, ExchangeConnectionError> {
+    Ok(match exchange {
+        Exchange::Binance => BinanceConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Coinbase => CoinbaseConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Kraken => KrakenConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Okx => OkxConnection::supports_pair(base_token, quote_token).await?,
+        Exchange::Renegade => BinanceConnection::supports_pair(base_token, quote_token).await?,
+        _ => return Err(ExchangeConnectionError::unsupported_exchange(*exchange)),
+    })
+}
 
 /// Returns whether or not the given exchange lists both the tokens in the pair
 /// separately

--- a/price-reporter/src/http_server.rs
+++ b/price-reporter/src/http_server.rs
@@ -14,6 +14,7 @@ use matchit::Router;
 use renegade_util::err_str;
 use routes::{RefreshTokenMappingHandler, REFRESH_TOKEN_MAPPING_ROUTE};
 use tokio::net::{TcpListener, TcpStream};
+use tracing::error;
 
 use crate::{
     errors::ServerError,
@@ -103,7 +104,11 @@ impl HttpServer {
         loop {
             let (stream, _) = listener.accept().await.map_err(err_str!(ServerError::HttpServer))?;
             let self_clone = self.clone();
-            tokio::spawn(async move { self_clone.handle_stream(stream).await });
+            tokio::spawn(async move {
+                if let Err(e) = self_clone.handle_stream(stream).await {
+                    error!("Error handling stream: {e}");
+                }
+            });
         }
     }
 

--- a/price-reporter/src/http_server/routes.rs
+++ b/price-reporter/src/http_server/routes.rs
@@ -9,11 +9,11 @@ use hyper::{
 };
 use renegade_api::auth::validate_expiring_auth;
 use renegade_common::types::{chain::Chain, exchange::Exchange, hmac::HmacKey, price::Price};
-use renegade_price_reporter::worker::ExchangeConnectionsConfig;
 use renegade_util::err_str;
 
 use crate::{
     errors::ServerError,
+    exchanges::ExchangeConnectionsConfig,
     http_server::{resp_body, ResponseBody},
     init_default_price_streams,
     utils::{setup_all_token_remaps, PairInfo, UrlParams},

--- a/price-reporter/src/main.rs
+++ b/price-reporter/src/main.rs
@@ -16,7 +16,6 @@ use renegade_common::types::{
     exchange::Exchange,
     token::{get_all_tokens, Token, USDC_TICKER, USDT_TICKER, USD_TICKER},
 };
-use renegade_price_reporter::worker::ExchangeConnectionsConfig;
 use renegade_util::err_str;
 use tokio::{net::TcpListener, sync::mpsc::unbounded_channel};
 use tracing::{error, info};
@@ -24,6 +23,8 @@ use utils::{
     get_canonical_exchanges, parse_config_env_vars, setup_all_token_remaps, setup_logging, PairInfo,
 };
 use ws_server::{handle_connection, GlobalPriceStreams};
+
+use crate::exchanges::ExchangeConnectionsConfig;
 
 mod errors;
 mod exchanges;

--- a/price-reporter/src/utils/mod.rs
+++ b/price-reporter/src/utils/mod.rs
@@ -17,7 +17,6 @@ use renegade_common::types::{
     token::{default_exchange_stable as _default_exchange_stable, read_token_remaps, Token},
 };
 use renegade_config::setup_token_remaps;
-use renegade_price_reporter::worker::ExchangeConnectionsConfig;
 use renegade_util::err_str;
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -35,6 +34,7 @@ use tracing_subscriber::{
 };
 use tungstenite::Message;
 
+use crate::exchanges::ExchangeConnectionsConfig;
 use crate::{errors::ServerError, http_server::routes::Handler};
 
 mod canonical_exchange;

--- a/price-reporter/src/utils/pair_info.rs
+++ b/price-reporter/src/utils/pair_info.rs
@@ -12,11 +12,11 @@ use renegade_common::types::{
     exchange::Exchange,
     token::{default_chain, Token, USDC_TICKER},
 };
-use renegade_price_reporter::exchange::supports_pair;
 use renegade_util::err_str;
 
 use crate::{
     errors::ServerError,
+    exchanges::util::supports_pair,
     utils::{
         canonical_exchange::get_canonical_exchange, default_exchange_stable, get_token_and_chain,
         resolve_tokens_and_chain, PriceTopic,

--- a/price-reporter/src/ws_server.rs
+++ b/price-reporter/src/ws_server.rs
@@ -6,11 +6,6 @@ use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use futures_util::{SinkExt, StreamExt};
 use renegade_api::websocket::{SubscriptionResponse, WebsocketMessage};
 use renegade_common::types::{exchange::Exchange, price::Price};
-use renegade_price_reporter::{
-    errors::ExchangeConnectionError,
-    exchange::{connect_exchange, ExchangeConnection},
-    worker::ExchangeConnectionsConfig,
-};
 use renegade_util::err_str;
 use tokio::{net::TcpStream, sync::watch::channel, sync::RwLock, time::Instant};
 use tokio_stream::StreamMap;
@@ -20,6 +15,10 @@ use tungstenite::Message;
 
 use crate::{
     errors::ServerError,
+    exchanges::{
+        connect_exchange, connection::ExchangeConnection, error::ExchangeConnectionError,
+        ExchangeConnectionsConfig,
+    },
     utils::{
         get_price_topic_str, get_subscribed_topics, ClosureSender, PairInfo, PriceMessage,
         PriceReceiver, PriceSender, PriceStream, PriceStreamMap, SharedPriceStreams, WsWriteStream,


### PR DESCRIPTION
### Purpose
This PR completes the migration off of the `renegade-price-reporter` dependency and gets the price reporter building and streaming on its own internalized logic.

### Testing
- [x] Tested locally
- [ ] Testing in testnet