### PR TITLE
price-reporter: exchanges: coinbase: Do not recompute book each message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7434,6 +7444,7 @@ dependencies = [
  "atomic_float 0.1.0",
  "common",
  "config",
+ "crossbeam-skiplist",
  "derivative",
  "external-api",
  "futures",
@@ -7445,6 +7456,7 @@ dependencies = [
  "jsonwebtoken 9.3.1",
  "lazy_static",
  "matchit 0.7.3",
+ "ordered-float",
  "reqwest 0.12.22",
  "serde",
  "serde_json",

--- a/price-reporter/Cargo.toml
+++ b/price-reporter/Cargo.toml
@@ -16,8 +16,9 @@ tokio-tungstenite = { version = "0.18", features = ["native-tls"] }
 tungstenite = "0.18"
 url = "2.4"
 
-# === Runtime === #
+# === Runtime + Concurrency === #
 async-trait = "0.1"
+crossbeam-skiplist = "0.1"
 futures = "0.3"
 futures-util = "0.3"
 tokio = "1"
@@ -36,6 +37,7 @@ atomic_float = "0.1"
 derivative = "2.2.0"
 itertools = "0.10"
 lazy_static = "1.4"
+ordered-float = "4.0"
 
 # === Renegade === #
 renegade-api = { package = "external-api", workspace = true }


### PR DESCRIPTION
### Purpose
This PR updates the Coinbase connection handler to persist order book data across messages. Previously a buggy implementation meant that we recomputed the book anew from each message. However, each message only contains book updates, so we were recomputing the book based on only new placements/cancellations. 

This is likely the cause of the price flickering as new price levels entirely determine the new book.

I also refactored the order book data implementation to use non-blocking crossbeam atomic primitives under the hood, so that it is more efficient with potentially concurrent updates.

### Testing
- [x] Tested locally
- [x] Testing in testnet 