### PR TITLE
auth-server: db: schema: Generate DB schema updates

### DIFF
--- a/auth/auth-server/migrations/2025-07-22-222752_add_user_fees_table/down.sql
+++ b/auth/auth-server/migrations/2025-07-22-222752_add_user_fees_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the user_fees table
+DROP TABLE user_fees;

--- a/auth/auth-server/migrations/2025-07-22-222752_add_user_fees_table/up.sql
+++ b/auth/auth-server/migrations/2025-07-22-222752_add_user_fees_table/up.sql
@@ -1,0 +1,8 @@
+-- Create the user_fees table with compound primary key and foreign key constraint
+CREATE TABLE user_fees (
+    id UUID NOT NULL,
+    asset VARCHAR NOT NULL,
+    fee REAL NOT NULL,
+    PRIMARY KEY (id, asset),
+    FOREIGN KEY (id) REFERENCES api_keys(id) ON DELETE CASCADE
+);

--- a/auth/auth-server/migrations/2025-07-22-223537_add_default_fees_table/down.sql
+++ b/auth/auth-server/migrations/2025-07-22-223537_add_default_fees_table/down.sql
@@ -1,0 +1,2 @@
+-- Drop the asset_default_fees table
+DROP TABLE asset_default_fees;

--- a/auth/auth-server/migrations/2025-07-22-223537_add_default_fees_table/up.sql
+++ b/auth/auth-server/migrations/2025-07-22-223537_add_default_fees_table/up.sql
@@ -1,0 +1,5 @@
+-- Create the asset_default_fees table with asset as primary key
+CREATE TABLE asset_default_fees (
+    asset VARCHAR PRIMARY KEY,
+    fee REAL NOT NULL
+);

--- a/auth/auth-server/src/server/db/schema.rs
+++ b/auth/auth-server/src/server/db/schema.rs
@@ -28,8 +28,4 @@ diesel::table! {
 
 diesel::joinable!(user_fees -> api_keys (id));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    api_keys,
-    asset_default_fees,
-    user_fees,
-);
+diesel::allow_tables_to_appear_in_same_query!(api_keys, asset_default_fees, user_fees,);

--- a/auth/auth-server/src/server/db/schema.rs
+++ b/auth/auth-server/src/server/db/schema.rs
@@ -10,3 +10,26 @@ diesel::table! {
         rate_limit_whitelisted -> Bool,
     }
 }
+
+diesel::table! {
+    asset_default_fees (asset) {
+        asset -> Varchar,
+        fee -> Float4,
+    }
+}
+
+diesel::table! {
+    user_fees (id, asset) {
+        id -> Uuid,
+        asset -> Varchar,
+        fee -> Float4,
+    }
+}
+
+diesel::joinable!(user_fees -> api_keys (id));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    api_keys,
+    asset_default_fees,
+    user_fees,
+);


### PR DESCRIPTION
### Purpose
This PR adds two tables to the auth server's database:
- `asset_default_fees`: Stores the default external match fee for an asset as a floating point value.
- `user_fees`: Stores per-user, per-asset overrides for the external match fee as a floating point value.

These tables will be queried and cached by the auth server.

### Testing
- [x] Applied to the testnet auth server DB