### PR TITLE
auth-server: api-handlers: Implement fee override managment interface

### DIFF
--- a/auth/auth-server-api/src/fee_management.rs
+++ b/auth/auth-server-api/src/fee_management.rs
@@ -1,0 +1,77 @@
+//! Fee management API endpoints
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// --------------------------
+// | Request/Response Types |
+// --------------------------
+
+/// A request to set the default fee for an asset
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SetAssetDefaultFeeRequest {
+    /// The asset identifier
+    pub asset: String,
+    /// The fee rate as a floating point value
+    pub fee: f32,
+}
+
+/// A request to set a user-specific fee override
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SetUserFeeRequest {
+    /// The user's API key ID
+    pub user_id: Uuid,
+    /// The asset identifier
+    pub asset: String,
+    /// The fee rate as a floating point value
+    pub fee: f32,
+}
+
+/// Response containing all fee configurations
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetAllFeesResponse {
+    /// All user-asset fee pairs (cartesian product with defaults applied)
+    pub user_asset_fees: Vec<UserAssetFeeEntry>,
+    /// All asset default fees for reference
+    pub default_fees: Vec<AssetDefaultFeeEntry>,
+}
+
+// -------------
+// | API Types |
+// -------------
+
+/// A user-specific fee override entry
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserFeeEntry {
+    /// The user's API key ID
+    pub id: Uuid,
+    /// The asset ticker
+    pub asset: String,
+    /// The fee rate as a floating point value
+    pub fee: f32,
+}
+
+/// A default fee entry for an asset
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AssetDefaultFeeEntry {
+    /// The asset ticker
+    pub asset: String,
+    /// The fee rate as a floating point value
+    pub fee: f32,
+}
+
+/// A fee entry for a specific user-asset pair
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserAssetFeeEntry {
+    /// The user's API key ID
+    pub user_id: Uuid,
+    /// The user's API key description
+    pub user_description: String,
+    /// The asset ticker
+    pub asset: String,
+    /// The fee rate as a floating point value
+    pub fee: f32,
+    /// Whether this fee is a user-specific override (true) or inherited from
+    /// default (false)
+    pub is_override: bool,
+}

--- a/auth/auth-server-api/src/lib.rs
+++ b/auth/auth-server-api/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::needless_pass_by_ref_mut)]
 #![feature(trivial_bounds)]
 
+pub mod fee_management;
 pub mod key_management;
 
 use alloy_primitives::{ruint::FromUintError, Address, U256};

--- a/auth/auth-server/src/server/api_handlers/external_match_fees.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match_fees.rs
@@ -1,0 +1,54 @@
+//! Handles admin external match fee requests
+
+use bytes::Bytes;
+use http::HeaderMap;
+use tracing::instrument;
+use warp::{filters::path::FullPath, reject::Rejection, reply::Reply};
+
+use crate::{http_utils::request_response::empty_json_reply, server::Server};
+
+impl Server {
+    // --- Getters --- //
+
+    /// Get the per-asset, per-user fee for all users and assets
+    #[instrument(skip_all)]
+    pub async fn get_all_user_fees(
+        &self,
+        path: FullPath,
+        headers: HeaderMap,
+    ) -> Result<impl Reply, Rejection> {
+        self.authorize_management_request(&path, &headers, &Bytes::new() /* body */)?;
+
+        Ok(empty_json_reply())
+    }
+
+    // --- Setters --- //
+
+    /// Set the default fee for a given asset
+    #[instrument(skip_all)]
+    pub async fn set_asset_default_fee(
+        &self,
+        path: FullPath,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<impl Reply, Rejection> {
+        // Check management auth on the request
+        self.authorize_management_request(&path, &headers, &body)?;
+
+        Ok(empty_json_reply())
+    }
+
+    /// Set the per-user fee override for a given asset
+    #[instrument(skip_all)]
+    pub async fn set_user_fee_override(
+        &self,
+        path: FullPath,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<impl Reply, Rejection> {
+        // Check management auth on the request
+        self.authorize_management_request(&path, &headers, &body)?;
+
+        Ok(empty_json_reply())
+    }
+}

--- a/auth/auth-server/src/server/api_handlers/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/mod.rs
@@ -4,6 +4,7 @@
 //! it to the relayer with admin authentication
 
 mod external_match;
+mod external_match_fees;
 mod key_management;
 mod order_book;
 mod settlement;

--- a/auth/auth-server/src/server/db/models.rs
+++ b/auth/auth-server/src/server/db/models.rs
@@ -4,11 +4,14 @@
 
 use std::time::SystemTime;
 
-use auth_server_api::key_management::ApiKey as UserFacingApiKey;
+use auth_server_api::{
+    fee_management::{AssetDefaultFeeEntry, UserAssetFeeEntry},
+    key_management::ApiKey as UserFacingApiKey,
+};
 use diesel::prelude::*;
 use uuid::Uuid;
 
-use crate::server::db::schema::api_keys;
+use crate::server::db::schema::{api_keys, asset_default_fees, user_fees};
 
 #[derive(Queryable, Selectable, Clone)]
 #[diesel(table_name = api_keys)]
@@ -60,6 +63,77 @@ impl From<NewApiKey> for ApiKey {
             created_at: SystemTime::now(),
             is_active: true,
             rate_limit_whitelisted: false,
+        }
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = user_fees)]
+pub struct NewUserFee {
+    pub id: Uuid,
+    pub asset: String,
+    pub fee: f32,
+}
+
+impl NewUserFee {
+    /// Create a new user fee entry
+    pub fn new(id: Uuid, asset: String, fee: f32) -> Self {
+        Self { id, asset, fee }
+    }
+}
+
+#[derive(Queryable, Selectable, Clone)]
+#[diesel(table_name = asset_default_fees)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct AssetDefaultFee {
+    pub asset: String,
+    pub fee: f32,
+}
+
+// Conversion functions between DB models and API types
+impl From<AssetDefaultFee> for AssetDefaultFeeEntry {
+    fn from(db_fee: AssetDefaultFee) -> Self {
+        Self { asset: db_fee.asset, fee: db_fee.fee }
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = asset_default_fees)]
+pub struct NewAssetDefaultFee {
+    pub asset: String,
+    pub fee: f32,
+}
+
+impl NewAssetDefaultFee {
+    /// Create a new asset default fee entry
+    pub fn new(asset: String, fee: f32) -> Self {
+        Self { asset, fee }
+    }
+}
+
+/// Result of the joined query for user-asset fees with defaults
+#[derive(QueryableByName, Clone)]
+pub struct UserAssetFeeQueryResult {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    pub user_id: Uuid,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub user_description: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    pub asset: String,
+    #[diesel(sql_type = diesel::sql_types::Float)]
+    pub fee: f32,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    pub is_override: bool,
+}
+
+impl From<UserAssetFeeQueryResult> for UserAssetFeeEntry {
+    fn from(query_result: UserAssetFeeQueryResult) -> Self {
+        Self {
+            user_id: query_result.user_id,
+            user_description: query_result.user_description,
+            asset: query_result.asset,
+            fee: query_result.fee,
+            is_override: query_result.is_override,
         }
     }
 }


### PR DESCRIPTION
### Purpose
This PR sets up API handlers for:
- Getting the current external match fees on a per-user, per-asset basis.
- Setting a default fee for an asset
- Setting a per-user fee override

### Testing
- [x] Tested all endpoints locally against the testnet DB