### PR TITLE
auth-server: chain_events: include internal fee take in match spread cost

### DIFF
--- a/auth/auth-server/src/chain_events/abis/arbitrum.rs
+++ b/auth/auth-server/src/chain_events/abis/arbitrum.rs
@@ -2,6 +2,8 @@
 
 use alloy_primitives::U256;
 use alloy_sol_types::SolCall;
+use renegade_circuit_types::fees::FeeTake;
+use renegade_constants::Scalar;
 use renegade_darkpool_client::{
     arbitrum::{
         abi::{
@@ -16,7 +18,10 @@ use renegade_darkpool_client::{
             PROCESS_MALLEABLE_ATOMIC_MATCH_SETTLE_WITH_RECEIVER_SELECTOR,
         },
         contract_types::{
-            conversion::{to_circuit_bounded_match_result, to_circuit_external_match_result},
+            conversion::{
+                to_circuit_bounded_match_result, to_circuit_external_match_result,
+                to_circuit_fee_rates,
+            },
             types::{ValidMalleableMatchSettleAtomicStatement, ValidMatchSettleAtomicStatement},
         },
         helpers::deserialize_calldata,
@@ -25,14 +30,21 @@ use renegade_darkpool_client::{
 };
 
 use crate::{
-    chain_events::{abis::ExternalMatch, error::OnChainEventListenerError},
+    chain_events::{
+        abis::{
+            compute_malleable_match_internal_fee_take, compute_standard_match_internal_fee_take,
+            ExternalMatch,
+        },
+        error::OnChainEventListenerError,
+    },
     server::helpers::get_selector,
 };
 
-/// Parse an external match from darkpool calldata
+/// Parse an external match from darkpool calldata,
+/// returning it alongside the internal party's fee take
 pub(crate) fn parse_external_match(
     calldata: &[u8],
-) -> Result<Option<ExternalMatch>, OnChainEventListenerError> {
+) -> Result<Option<(ExternalMatch, FeeTake)>, OnChainEventListenerError> {
     let selector = get_selector(calldata)?;
     // Parse the `VALID MATCH SETTLE ATOMIC` statement from the calldata
     let match_res = match selector {
@@ -58,27 +70,38 @@ pub(crate) fn parse_external_match(
     Ok(Some(match_res))
 }
 
-/// Parse an external match from a regular atomic match settle call
+/// Parse an external match from a regular atomic match settle call,
+/// returning it alongside the internal party's fee take
 fn parse_standard_match(
     statement_bytes: &[u8],
-) -> Result<ExternalMatch, OnChainEventListenerError> {
+) -> Result<(ExternalMatch, FeeTake), OnChainEventListenerError> {
     let statement: ValidMatchSettleAtomicStatement = deserialize_calldata(statement_bytes)?;
     let match_res = to_circuit_external_match_result(&statement.match_result)
         .map_err(OnChainEventListenerError::darkpool)?;
 
-    Ok(ExternalMatch::Standard(match_res))
+    let protocol_fee_scalar = Scalar::new(statement.protocol_fee);
+    let internal_fee_take =
+        compute_standard_match_internal_fee_take(protocol_fee_scalar, &match_res);
+
+    Ok((ExternalMatch::Standard(match_res), internal_fee_take))
 }
 
 /// Parse an external match from a malleable atomic match settle call
 fn parse_malleable_match(
     base_amount: U256,
     statement_bytes: &[u8],
-) -> Result<ExternalMatch, OnChainEventListenerError> {
+) -> Result<(ExternalMatch, FeeTake), OnChainEventListenerError> {
     let base_amt = u256_to_amount(base_amount).map_err(OnChainEventListenerError::darkpool)?;
     let statement: ValidMalleableMatchSettleAtomicStatement =
         deserialize_calldata(statement_bytes)?;
     let match_res = to_circuit_bounded_match_result(&statement.match_result)
         .map_err(OnChainEventListenerError::darkpool)?;
 
-    Ok(ExternalMatch::Malleable(match_res, base_amt))
+    let internal_fee_rate = to_circuit_fee_rates(&statement.internal_fee_rates)
+        .map_err(OnChainEventListenerError::darkpool)?;
+
+    let internal_fee_take =
+        compute_malleable_match_internal_fee_take(internal_fee_rate, &match_res, base_amt)?;
+
+    Ok((ExternalMatch::Malleable(match_res, base_amt), internal_fee_take))
 }

--- a/auth/auth-server/src/chain_events/abis/base.rs
+++ b/auth/auth-server/src/chain_events/abis/base.rs
@@ -1,26 +1,42 @@
 //! Base ABI helpers
 
 use alloy_sol_types::SolCall;
-use renegade_darkpool_client::{base::conversion::ToCircuitType, conversion::u256_to_amount};
+use renegade_circuit_types::fees::FeeTake;
+use renegade_darkpool_client::{
+    base::conversion::ToCircuitType,
+    conversion::{u256_to_amount, u256_to_scalar},
+};
 use renegade_solidity_abi::IDarkpool::{
     processAtomicMatchSettleCall, processMalleableAtomicMatchSettleCall,
 };
 
 use crate::{
-    chain_events::{abis::ExternalMatch, error::OnChainEventListenerError},
+    chain_events::{
+        abis::{
+            compute_malleable_match_internal_fee_take, compute_standard_match_internal_fee_take,
+            ExternalMatch,
+        },
+        error::OnChainEventListenerError,
+    },
     server::helpers::get_selector,
 };
 
-/// Parse an external match from darkpool calldata
+/// Parse an external match from darkpool calldata,
+/// returning it alongside the internal party's fee take
 pub(crate) fn parse_external_match(
     calldata: &[u8],
-) -> Result<Option<ExternalMatch>, OnChainEventListenerError> {
+) -> Result<Option<(ExternalMatch, FeeTake)>, OnChainEventListenerError> {
     let selector = get_selector(calldata)?;
-    let match_res = match selector {
+    let (match_res, internal_fee_take) = match selector {
         processAtomicMatchSettleCall::SELECTOR => {
             let call = processAtomicMatchSettleCall::abi_decode(calldata)?;
             let match_res = call.matchSettleStatement.matchResult.to_circuit_type()?;
-            ExternalMatch::Standard(match_res)
+
+            let protocol_fee_scalar = u256_to_scalar(call.matchSettleStatement.protocolFeeRate);
+            let internal_fee_take =
+                compute_standard_match_internal_fee_take(protocol_fee_scalar, &match_res);
+
+            (ExternalMatch::Standard(match_res), internal_fee_take)
         },
         processMalleableAtomicMatchSettleCall::SELECTOR => {
             let call = processMalleableAtomicMatchSettleCall::abi_decode(calldata)?;
@@ -28,10 +44,16 @@ pub(crate) fn parse_external_match(
             let base_amt =
                 u256_to_amount(call.baseAmount).map_err(OnChainEventListenerError::darkpool)?;
 
-            ExternalMatch::Malleable(match_res, base_amt)
+            let internal_fee_take = compute_malleable_match_internal_fee_take(
+                call.matchSettleStatement.internalFeeRates.to_circuit_type()?,
+                &match_res,
+                base_amt,
+            )?;
+
+            (ExternalMatch::Malleable(match_res, base_amt), internal_fee_take)
         },
         _ => return Ok(None),
     };
 
-    Ok(Some(match_res))
+    Ok(Some((match_res, internal_fee_take)))
 }

--- a/auth/auth-server/src/chain_events/abis/mod.rs
+++ b/auth/auth-server/src/chain_events/abis/mod.rs
@@ -1,13 +1,17 @@
 //! ABI helpers for the chain events listener
 use renegade_api::http::external_match::{ApiBoundedMatchResult, ApiExternalMatchResult};
 use renegade_circuit_types::{
+    fees::{FeeTake, FeeTakeRate},
+    fixed_point::FixedPoint,
     r#match::{BoundedMatchResult, ExternalMatchResult},
     wallet::Nullifier,
     Amount,
 };
+use renegade_constants::Scalar;
 
 use crate::{
     bundle_store::helpers::{generate_bundle_id, generate_malleable_bundle_id},
+    chain_events::error::OnChainEventListenerError,
     error::AuthServerError,
 };
 
@@ -53,4 +57,40 @@ impl ExternalMatch {
             },
         }
     }
+}
+
+/// Compute the internal fee take for a standard external match.
+///
+/// Currently, the internal party is only charged the protocol fee.
+pub(crate) fn compute_standard_match_internal_fee_take(
+    protocol_fee_scalar: Scalar,
+    match_res: &ExternalMatchResult,
+) -> FeeTake {
+    let protocol_fee_rate = FixedPoint::from_repr(protocol_fee_scalar);
+    let internal_fee_rate = FeeTakeRate::new(
+        FixedPoint::zero(), // relayer_fee_rate
+        protocol_fee_rate,
+    );
+
+    compute_internal_fee_take(match_res, internal_fee_rate)
+}
+
+/// Compute the internal fee take for a malleable match.
+pub(crate) fn compute_malleable_match_internal_fee_take(
+    internal_fee_rate: FeeTakeRate,
+    bounded_match_res: &BoundedMatchResult,
+    base_amt: Amount,
+) -> Result<FeeTake, OnChainEventListenerError> {
+    let external_match_res = bounded_match_res.to_external_match_result(base_amt);
+    Ok(compute_internal_fee_take(&external_match_res, internal_fee_rate))
+}
+
+/// Compute the internal fee take for any external match,
+/// given the match result and fee take rate.
+fn compute_internal_fee_take(
+    match_res: &ExternalMatchResult,
+    internal_fee_rate: FeeTakeRate,
+) -> FeeTake {
+    let (_, internal_party_recv) = match_res.external_party_send();
+    internal_fee_rate.compute_fee_take(internal_party_recv)
 }


### PR DESCRIPTION
This PR ensures that the adverse selection ("external match spread") cost metric uses a match price that is inclusive of fees. This is a more accurate view of the costs incurred by the internal party.

This required computing the internal party's fee take from the settled TX's calldata, which relies on the simplifying assumption that the internal party's relayer fee obligation is 0 for external matches. Otherwise, in the case of standard external matches, we currently have no way of inferring the internal party's relayer fee take.

### Testing
- [ ] Run local auth server, invoke external match, sanity-check spread cost & fee impact