### PR TITLE
auth-server: api-handlers: Add methods for removing fee overrides

### DIFF
--- a/auth/auth-server-api/src/fee_management.rs
+++ b/auth/auth-server-api/src/fee_management.rs
@@ -27,6 +27,22 @@ pub struct SetUserFeeRequest {
     pub fee: f32,
 }
 
+/// A request to remove a user-specific fee override
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoveUserFeeRequest {
+    /// The user's API key ID
+    pub user_id: Uuid,
+    /// The asset identifier
+    pub asset: String,
+}
+
+/// A request to remove the default fee for an asset
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RemoveAssetDefaultFeeRequest {
+    /// The asset identifier
+    pub asset: String,
+}
+
 /// Response containing all fee configurations
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetAllFeesResponse {

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -318,6 +318,28 @@ async fn main() {
             server.set_user_fee_override(path, headers, body).await
         });
 
+    // Remove the default external match fee for an asset
+    let remove_asset_default_fee = warp::path!("v0" / "fees" / "remove-asset-default-fee")
+        .and(warp::post())
+        .and(warp::path::full())
+        .and(warp::header::headers_cloned())
+        .and(warp::body::bytes())
+        .and(with_server(server.clone()))
+        .and_then(|path, headers, body, server: Arc<Server>| async move {
+            server.remove_asset_default_fee(path, headers, body).await
+        });
+
+    // Remove the per-user fee override for an asset
+    let remove_user_fee_override = warp::path!("v0" / "fees" / "remove-user-fee-override")
+        .and(warp::post())
+        .and(warp::path::full())
+        .and(warp::header::headers_cloned())
+        .and(warp::body::bytes())
+        .and(with_server(server.clone()))
+        .and_then(|path, headers, body, server: Arc<Server>| async move {
+            server.remove_user_fee_override(path, headers, body).await
+        });
+
     // --- Proxied Routes --- //
 
     let external_quote_path = warp::path("v0")
@@ -409,6 +431,8 @@ async fn main() {
         .or(get_all_user_fees)
         .or(set_asset_default_fee)
         .or(set_user_fee_override)
+        .or(remove_asset_default_fee)
+        .or(remove_user_fee_override)
         .or(order_book_depth_with_mint)
         .or(order_book_depth)
         .boxed()


### PR DESCRIPTION
### Purpose
This PR adds two endpoints for removing fee overrides: one for per-user and one for per-asset.

### Testing
- [x] Tested locally