### PR TITLE
funds-manager: fee_indexer: route for getting unredeemed fee totals

### DIFF
--- a/funds-manager/funds-manager-api/src/types/fees.rs
+++ b/funds-manager/funds-manager-api/src/types/fees.rs
@@ -1,7 +1,5 @@
 //! API types for managing and redeeming fees
 
-use std::collections::HashMap;
-
 use renegade_api::types::ApiWallet;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -43,9 +41,18 @@ pub struct WithdrawFeeBalanceRequest {
     pub mint: String,
 }
 
+/// A single unredeemed fee total
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UnredeemedFeeTotal {
+    /// The mint of the fee asset
+    pub mint: String,
+    /// The nominal amount of the fee
+    pub amount: u128,
+}
+
 /// The response containing the unredeemed fee totals
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UnredeemedFeeTotalsResponse {
-    /// The unredeemed fee totals, mapping from mint to nominal amount
-    pub totals: HashMap<String, u128>,
+    /// The unredeemed fee totals
+    pub totals: Vec<UnredeemedFeeTotal>,
 }

--- a/funds-manager/funds-manager-api/src/types/fees.rs
+++ b/funds-manager/funds-manager-api/src/types/fees.rs
@@ -1,5 +1,7 @@
 //! API types for managing and redeeming fees
 
+use std::collections::HashMap;
+
 use renegade_api::types::ApiWallet;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -18,6 +20,8 @@ pub const GET_FEE_WALLETS_ROUTE: &str = "get-fee-wallets";
 pub const WITHDRAW_FEE_BALANCE_ROUTE: &str = "withdraw-fee-balance";
 /// The route to get the hot wallet address for fee redemption
 pub const GET_FEE_HOT_WALLET_ADDRESS_ROUTE: &str = "get-hot-wallet-address";
+/// The route to get the unredeemed fee totals
+pub const GET_UNREDEEMED_FEE_TOTALS_ROUTE: &str = "get-unredeemed-fee-totals";
 
 // -------------
 // | Api Types |
@@ -37,4 +41,11 @@ pub struct WithdrawFeeBalanceRequest {
     pub wallet_id: Uuid,
     /// The mint of the asset to withdraw
     pub mint: String,
+}
+
+/// The response containing the unredeemed fee totals
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UnredeemedFeeTotalsResponse {
+    /// The unredeemed fee totals, mapping from mint to nominal amount
+    pub totals: HashMap<String, u128>,
 }

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -7,7 +7,9 @@ use crate::error::ApiError;
 use crate::execution_client::error::ExecutionClientError;
 use crate::Server;
 use bytes::Bytes;
-use funds_manager_api::fees::{FeeWalletsResponse, WithdrawFeeBalanceRequest};
+use funds_manager_api::fees::{
+    FeeWalletsResponse, UnredeemedFeeTotalsResponse, WithdrawFeeBalanceRequest,
+};
 use funds_manager_api::gas::{
     CreateGasWalletResponse, GasWalletsResponse, RefillGasRequest, RegisterGasWalletRequest,
     RegisterGasWalletResponse, ReportActivePeersRequest, WithdrawGasRequest,
@@ -119,6 +121,18 @@ pub(crate) async fn get_fee_hot_wallet_address_handler(
 
     let resp = DepositAddressResponse { address };
     Ok(warp::reply::json(&resp))
+}
+
+/// Handler for querying the total amount of unredeemed fees for each mint
+pub(crate) async fn get_unredeemed_fee_totals_handler(
+    chain: Chain,
+    server: Arc<Server>,
+) -> Result<Json, warp::Rejection> {
+    let indexer = server.get_fee_indexer(&chain)?;
+    let totals_vec = indexer.get_unredeemed_fee_totals().await?;
+    let totals = HashMap::from_iter(totals_vec.into_iter());
+
+    Ok(warp::reply::json(&UnredeemedFeeTotalsResponse { totals }))
 }
 
 /// Handler for retrieving the hot wallet address for gas operations

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -8,7 +8,7 @@ use crate::execution_client::error::ExecutionClientError;
 use crate::Server;
 use bytes::Bytes;
 use funds_manager_api::fees::{
-    FeeWalletsResponse, UnredeemedFeeTotalsResponse, WithdrawFeeBalanceRequest,
+    FeeWalletsResponse, UnredeemedFeeTotal, UnredeemedFeeTotalsResponse, WithdrawFeeBalanceRequest,
 };
 use funds_manager_api::gas::{
     CreateGasWalletResponse, GasWalletsResponse, RefillGasRequest, RegisterGasWalletRequest,
@@ -130,7 +130,8 @@ pub(crate) async fn get_unredeemed_fee_totals_handler(
 ) -> Result<Json, warp::Rejection> {
     let indexer = server.get_fee_indexer(&chain)?;
     let totals_vec = indexer.get_unredeemed_fee_totals().await?;
-    let totals = HashMap::from_iter(totals_vec.into_iter());
+    let totals =
+        totals_vec.into_iter().map(|(mint, amount)| UnredeemedFeeTotal { mint, amount }).collect();
 
     Ok(warp::reply::json(&UnredeemedFeeTotalsResponse { totals }))
 }

--- a/funds-manager/migrations/2025-07-24-192651_fee_redemption_index/down.sql
+++ b/funds-manager/migrations/2025-07-24-192651_fee_redemption_index/down.sql
@@ -1,0 +1,2 @@
+-- Drop the index on fee redemption/mint/chain
+DROP INDEX IF EXISTS idx_redeemed_by_mint_chain;

--- a/funds-manager/migrations/2025-07-24-192651_fee_redemption_index/up.sql
+++ b/funds-manager/migrations/2025-07-24-192651_fee_redemption_index/up.sql
@@ -1,0 +1,2 @@
+-- Create an index for faster retrieval of unredeemed fee totals
+CREATE INDEX idx_redeemed_by_mint_chain ON fees (chain, redeemed, mint) INCLUDE (amount);


### PR DESCRIPTION
This PR adds a `/get-unredeemed-fee-totals` route to the funds manager, used to get the total amount of unredeemed fees for each mint. These holdings will be added to our view of NAV.

### Testing
- [x] Ran local funds manager, asserted that endpoint result matches what is computed by running simpler queries directly against the DB
- [x] Asserted that resultant query makes use of the new index