### PR TITLE
auth-sever: api-handlers: Set relayer fee in request processing

### DIFF
--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -49,6 +49,10 @@ impl ExternalMatchRequestType for AssembleExternalMatchRequest {
     fn quote_mint(&self) -> &BigUint {
         &self.signed_quote.quote.order.quote_mint
     }
+
+    fn set_fee(&mut self, fee: f64) {
+        self.relayer_fee_rate = fee;
+    }
 }
 
 /// The response context for an assemble quote request

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -44,6 +44,10 @@ impl ExternalMatchRequestType for ExternalMatchRequest {
     fn quote_mint(&self) -> &BigUint {
         &self.external_order.quote_mint
     }
+
+    fn set_fee(&mut self, fee: f64) {
+        self.relayer_fee_rate = fee;
+    }
 }
 
 /// The response context for a direct match request

--- a/auth/auth-server/src/server/db/models.rs
+++ b/auth/auth-server/src/server/db/models.rs
@@ -137,3 +137,10 @@ impl From<UserAssetFeeQueryResult> for UserAssetFeeEntry {
         }
     }
 }
+
+/// Result of a fee query with fallback logic
+#[derive(diesel::QueryableByName)]
+pub struct FeeResult {
+    #[diesel(sql_type = diesel::sql_types::Float)]
+    pub fee: f32,
+}


### PR DESCRIPTION
### Purpose
This PR sets the `relayer_fee` field on each request during preprocessing according to the fee override stored in the DB.

### Testing
- [x] Testing locally
- [ ] Testing in testnet