### PR TITLE
solver: add priority fee calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7490,6 +7490,7 @@ dependencies = [
  "bimap",
  "clap",
  "common",
+ "config",
  "constants",
  "lru 0.12.5",
  "price-reporter-client",

--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -26,6 +26,7 @@ alloy-contract = { workspace = true }
 
 # === Renegade Dependencies === #
 renegade-common = { workspace = true }
+renegade-config = { workspace = true }
 renegade-constants = { workspace = true }
 renegade-solidity-abi = { workspace = true }
 renegade-sdk = "0.1.15"

--- a/renegade-solver/src/cli.rs
+++ b/renegade-solver/src/cli.rs
@@ -1,6 +1,7 @@
 //! The CLI for the renegade solver
 
 use clap::Parser;
+use renegade_common::types::chain::Chain;
 use renegade_util::telemetry::{configure_telemetry_with_metrics_config, metrics::MetricsConfig};
 
 /// The default metrics prefix
@@ -29,6 +30,9 @@ pub struct Cli {
     /// The API secret for the Renegade external match API
     #[arg(long, env = "RENEGADE_API_SECRET")]
     pub renegade_api_secret: String,
+    /// The chain the solver is running on
+    #[arg(long, env = "CHAIN_ID", default_value = "base-mainnet")]
+    pub chain_id: Chain,
 
     // --- Executor Config --- //
     /// The address of the executor contract

--- a/renegade-solver/src/error.rs
+++ b/renegade-solver/src/error.rs
@@ -1,6 +1,7 @@
 //! Error types for the solver
 
 use alloy::primitives::U256;
+use price_reporter_client::error::PriceReporterClientError;
 use renegade_sdk::ExternalMatchClientError;
 use serde_json::json;
 use thiserror::Error;
@@ -32,6 +33,9 @@ pub enum SolverError {
     /// Error from the renegade client
     #[error("Renegade client error: {0}")]
     Renegade(#[from] ExternalMatchClientError),
+    /// Error from the price reporter client
+    #[error("Price reporter client error: {0}")]
+    PriceReporter(#[from] PriceReporterClientError),
 }
 
 impl SolverError {

--- a/renegade-solver/src/error.rs
+++ b/renegade-solver/src/error.rs
@@ -12,6 +12,8 @@ use warp::{
     Rejection,
 };
 
+use crate::uniswapx::fixed_point::error::FixedPointMathError;
+
 /// Type alias for Results using SolverError
 pub type SolverResult<T> = Result<T, SolverError>;
 
@@ -36,6 +38,12 @@ pub enum SolverError {
     /// Error from the price reporter client
     #[error("Price reporter client error: {0}")]
     PriceReporter(#[from] PriceReporterClientError),
+    /// Fixed point math error
+    #[error("Fixed point math error: {0}")]
+    FixedPoint(#[from] FixedPointMathError),
+    /// An order's input and outputs both scale with priority fee
+    #[error("Input and outputs both scale with priority fee")]
+    InputOutputScaling,
 }
 
 impl SolverError {

--- a/renegade-solver/src/uniswapx/abis/mod.rs
+++ b/renegade-solver/src/uniswapx/abis/mod.rs
@@ -1,4 +1,5 @@
 //! ABI types for UniswapX and our filler contract
 
-pub(crate) mod conversion;
+pub mod conversion;
+pub mod priority_order;
 pub mod uniswapx;

--- a/renegade-solver/src/uniswapx/abis/priority_order.rs
+++ b/renegade-solver/src/uniswapx/abis/priority_order.rs
@@ -1,10 +1,21 @@
-//! Extensions for PriorityOrder
+//! Extensions for PriorityOrder, PriorityInput, and PriorityOutput
+//!
+//! Scaling logic is copied from UniswapX's [`PriorityFeeLib.sol` library](https://github.com/Uniswap/UniswapX/blob/4c01ff07cb16df7ad7f5c2b8e9253005c1259275/src/lib/PriorityFeeLib.sol).
 use alloy_primitives::U256;
 use renegade_common::types::token::Token;
 
 use super::{conversion::u256_to_u128, uniswapx::PriorityOrderReactor::PriorityOrder};
 
-use crate::error::SolverResult;
+use crate::{
+    error::SolverResult,
+    uniswapx::{
+        abis::uniswapx::PriorityOrderReactor::{PriorityInput, PriorityOutput},
+        fixed_point::{
+            error::{FixedPointMathError, FixedPointResult},
+            mul_div_down, mul_div_up,
+        },
+    },
+};
 
 impl PriorityOrder {
     /// Determines if this is a buy order (input token is USDC)
@@ -71,5 +82,72 @@ impl PriorityOrder {
         let base_decimal_corrected_amt = self.base_amt_decimal_corrected()?;
         let price = quote_decimal_corrected_amt / base_decimal_corrected_amt;
         Ok(price)
+    }
+}
+
+/// Milli-basis-point conversion value (10^7 = 100% in milli-bps)
+pub(crate) const MPS: u64 = 10_000_000;
+
+/// Milli-basis-point basis represented as a U256 constant
+const MPS_U256: U256 = U256::from_limbs([MPS, 0, 0, 0]);
+
+impl PriorityInput {
+    /// Returns the input scaled by 1 - (priority_fee ×
+    /// priority_fee_scaling_rate)
+    ///
+    /// This implements scaling favoring the swapper where higher priority fees
+    /// result in lower required input amounts. The scaling is bounded by 0
+    /// and the original input amount.
+    pub fn scale(&self, priority_fee_wei: U256) -> FixedPointResult {
+        let priority_fee_scaling_rate = self.mpsPerPriorityFeeWei;
+
+        // Discount scaling factor = priority fee * priority fee scaling rate
+        let discount_scaling_factor = priority_fee_wei
+            .checked_mul(priority_fee_scaling_rate)
+            .ok_or(FixedPointMathError::Overflow)?;
+
+        if discount_scaling_factor >= MPS_U256 {
+            return Ok(U256::ZERO);
+        }
+
+        if discount_scaling_factor == U256::ZERO {
+            return Ok(self.amount);
+        }
+
+        // Scaling numerator = MPS - discount scaling factor
+        let scaling_numerator = MPS_U256 - discount_scaling_factor; // Safe due to early return above
+
+        let amount = mul_div_down(self.amount, scaling_numerator, MPS_U256)?;
+
+        Ok(amount)
+    }
+}
+
+impl PriorityOutput {
+    /// Returns the output scaled by 1 + (priority_fee ×
+    /// priority_fee_scaling_rate)
+    ///
+    /// This implements scaling favoring the swapper where higher priority fees
+    /// result in higher output amounts. The scaling is bounded by the
+    /// original output amount and above.
+    pub fn scale(&self, priority_fee_wei: U256) -> FixedPointResult {
+        let priority_fee_scaling_rate = self.mpsPerPriorityFeeWei;
+
+        if priority_fee_scaling_rate == U256::ZERO {
+            return Ok(self.amount);
+        }
+
+        // Scaling factor = priority fee * priority fee scaling rate
+        let scaling_factor = priority_fee_wei
+            .checked_mul(priority_fee_scaling_rate)
+            .ok_or(FixedPointMathError::Overflow)?;
+
+        // Scaling numerator = MPS + scaling factor
+        let scaling_numerator =
+            MPS_U256.checked_add(scaling_factor).ok_or(FixedPointMathError::Overflow)?;
+
+        let amount = mul_div_up(self.amount, scaling_numerator, MPS_U256)?;
+
+        Ok(amount)
     }
 }

--- a/renegade-solver/src/uniswapx/abis/priority_order.rs
+++ b/renegade-solver/src/uniswapx/abis/priority_order.rs
@@ -1,0 +1,75 @@
+//! Extensions for PriorityOrder
+use alloy_primitives::U256;
+use renegade_common::types::token::Token;
+
+use super::{conversion::u256_to_u128, uniswapx::PriorityOrderReactor::PriorityOrder};
+
+use crate::error::SolverResult;
+
+impl PriorityOrder {
+    /// Determines if this is a buy order (input token is USDC)
+    pub fn is_sell(&self) -> bool {
+        let usdc_address = Token::usdc().get_alloy_address();
+        self.input.token == usdc_address
+    }
+
+    /// Returns the quote token address (always USDC)
+    pub fn quote_token(&self) -> Token {
+        if self.is_sell() {
+            Token::from_addr(&self.outputs[0].token.to_string())
+        } else {
+            Token::from_addr(&self.input.token.to_string())
+        }
+    }
+
+    /// Returns the quote amount (USDC amount)
+    pub fn quote_amount(&self) -> U256 {
+        if self.is_sell() {
+            self.outputs[0].amount
+        } else {
+            self.input.amount
+        }
+    }
+
+    /// Returns the decimal corrected quote amount
+    pub fn quote_amt_decimal_corrected(&self) -> SolverResult<f64> {
+        let amount = u256_to_u128(self.quote_amount())?;
+        let decimal_corrected_amt = self.quote_token().convert_to_decimal(amount);
+        Ok(decimal_corrected_amt)
+    }
+
+    /// Returns the base token address (non-USDC token)
+    pub fn base_token(&self) -> Token {
+        if self.is_sell() {
+            Token::from_addr(&self.input.token.to_string())
+        } else {
+            Token::from_addr(&self.outputs[0].token.to_string())
+        }
+    }
+
+    /// Returns the base amount (non-USDC token amount)
+    pub fn base_amount(&self) -> U256 {
+        if self.is_sell() {
+            self.input.amount
+        } else {
+            self.outputs[0].amount
+        }
+    }
+
+    /// Returns the decimal corrected base amount
+    pub fn base_amt_decimal_corrected(&self) -> SolverResult<f64> {
+        let amount = u256_to_u128(self.base_amount())?;
+        let decimal_corrected_amt = self.base_token().convert_to_decimal(amount);
+        Ok(decimal_corrected_amt)
+    }
+
+    /// Calculate the order price from this PriorityOrder
+    ///
+    /// Assumes one side of the order is USDC and there is only one output token
+    pub fn get_price(&self) -> SolverResult<f64> {
+        let quote_decimal_corrected_amt = self.quote_amt_decimal_corrected()?;
+        let base_decimal_corrected_amt = self.base_amt_decimal_corrected()?;
+        let price = quote_decimal_corrected_amt / base_decimal_corrected_amt;
+        Ok(price)
+    }
+}

--- a/renegade-solver/src/uniswapx/fixed_point/error.rs
+++ b/renegade-solver/src/uniswapx/fixed_point/error.rs
@@ -1,0 +1,17 @@
+//! Error types for fixed point math
+use alloy_primitives::U256;
+use thiserror::Error;
+
+/// Type alias for Results using FixedPointMathError
+pub type FixedPointResult = Result<U256, FixedPointMathError>;
+
+/// The error type for fixed point math
+#[derive(Error, Debug)]
+pub enum FixedPointMathError {
+    /// Division by zero
+    #[error("Division by zero")]
+    DivisionByZero,
+    /// Overflow
+    #[error("Overflow")]
+    Overflow,
+}

--- a/renegade-solver/src/uniswapx/fixed_point/mod.rs
+++ b/renegade-solver/src/uniswapx/fixed_point/mod.rs
@@ -1,0 +1,180 @@
+//! Emulates Solidity's fixed point math functions found in
+//! [FixedPointMathLib](https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol)
+use crate::uniswapx::fixed_point::error::{FixedPointMathError, FixedPointResult};
+use alloy_primitives::U256;
+
+pub mod error;
+
+/// Validates division parameters and checks for early return conditions.
+/// Returns Ok(Some(result)) for early return cases (like y=0),
+/// Ok(None) if validation passes and calculation should proceed,
+/// or Err for validation failures.
+fn validate_division(
+    x: U256,
+    y: U256,
+    denominator: U256,
+) -> Result<Option<U256>, FixedPointMathError> {
+    if denominator.is_zero() {
+        return Err(FixedPointMathError::DivisionByZero);
+    }
+
+    if y.is_zero() {
+        return Ok(Some(U256::ZERO));
+    }
+
+    // Check for overflow: x <= U256::MAX / y
+    let max_x = U256::MAX / y;
+    if x > max_x {
+        return Err(FixedPointMathError::Overflow);
+    }
+
+    // Validation passed, calculation can proceed
+    Ok(None)
+}
+
+/// Returns x * y / denominator, rounded down.
+/// Equivalent to Solidity's mulDivDown with overflow protection
+pub fn mul_div_down(x: U256, y: U256, denominator: U256) -> FixedPointResult {
+    // Validate division parameters
+    match validate_division(x, y, denominator)? {
+        Some(early_result) => return Ok(early_result),
+        None => {}, // Continue with calculation
+    }
+
+    // Safe to multiply and divide
+    Ok((x * y) / denominator)
+}
+
+/// Returns x * y / denominator, rounded up.
+/// Equivalent to Solidity's mulDivUp with overflow protection
+pub fn mul_div_up(x: U256, y: U256, denominator: U256) -> FixedPointResult {
+    // Validate division parameters
+    match validate_division(x, y, denominator)? {
+        Some(early_result) => return Ok(early_result),
+        None => {}, // Continue with calculation
+    }
+
+    let product = x * y;
+    let quotient = product / denominator;
+    let remainder = product % denominator;
+
+    // Add 1 if there's a remainder (round up)
+    if remainder > U256::ZERO {
+        quotient.checked_add(U256::from(1)).ok_or(FixedPointMathError::Overflow)
+    } else {
+        Ok(quotient)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mul_div_down_basic_functionality() {
+        // Basic test: 10 * 3 / 2 = 15
+        let result = mul_div_down(U256::from(10), U256::from(3), U256::from(2));
+        assert_eq!(result.unwrap(), U256::from(15));
+
+        // Test with remainder (rounds down): 10 * 3 / 4 = 7.5 -> 7
+        let result = mul_div_down(U256::from(10), U256::from(3), U256::from(4));
+        assert_eq!(result.unwrap(), U256::from(7));
+
+        // Test with large numbers
+        let result = mul_div_down(U256::from(1000000), U256::from(500000), U256::from(250000));
+        assert_eq!(result.unwrap(), U256::from(2000000));
+    }
+
+    #[test]
+    fn test_mul_div_up_basic_functionality() {
+        // Basic test: 10 * 3 / 2 = 15
+        let result = mul_div_up(U256::from(10), U256::from(3), U256::from(2));
+        assert_eq!(result.unwrap(), U256::from(15));
+
+        // Test with remainder (rounds up): 10 * 3 / 4 = 7.5 -> 8
+        let result = mul_div_up(U256::from(10), U256::from(3), U256::from(4));
+        assert_eq!(result.unwrap(), U256::from(8));
+
+        // Test with large numbers
+        let result = mul_div_up(U256::from(1000000), U256::from(500000), U256::from(250000));
+        assert_eq!(result.unwrap(), U256::from(2000000));
+    }
+
+    #[test]
+    fn test_rounding_behavior_difference() {
+        // Case where down and up should differ
+        let x = U256::from(7);
+        let y = U256::from(3);
+        let denominator = U256::from(2);
+        // 7 * 3 / 2 = 21 / 2 = 10.5
+
+        let down_result = mul_div_down(x, y, denominator).unwrap();
+        let up_result = mul_div_up(x, y, denominator).unwrap();
+
+        assert_eq!(down_result, U256::from(10)); // rounds down
+        assert_eq!(up_result, U256::from(11)); // rounds up
+        assert!(up_result > down_result);
+
+        // Case where both should be equal (no remainder)
+        let result_down = mul_div_down(U256::from(6), U256::from(4), U256::from(3)).unwrap();
+        let result_up = mul_div_up(U256::from(6), U256::from(4), U256::from(3)).unwrap();
+        assert_eq!(result_down, U256::from(8));
+        assert_eq!(result_up, U256::from(8));
+    }
+
+    #[test]
+    fn test_division_by_zero_error() {
+        let result = mul_div_down(U256::from(10), U256::from(5), U256::ZERO);
+        assert!(matches!(result, Err(FixedPointMathError::DivisionByZero)));
+
+        let result = mul_div_up(U256::from(10), U256::from(5), U256::ZERO);
+        assert!(matches!(result, Err(FixedPointMathError::DivisionByZero)));
+    }
+
+    #[test]
+    fn test_zero_input_handling() {
+        // x = 0 should return 0
+        let result = mul_div_down(U256::ZERO, U256::from(5), U256::from(3));
+        assert_eq!(result.unwrap(), U256::ZERO);
+
+        let result = mul_div_up(U256::ZERO, U256::from(5), U256::from(3));
+        assert_eq!(result.unwrap(), U256::ZERO);
+
+        // y = 0 should return 0
+        let result = mul_div_down(U256::from(5), U256::ZERO, U256::from(3));
+        assert_eq!(result.unwrap(), U256::ZERO);
+
+        let result = mul_div_up(U256::from(5), U256::ZERO, U256::from(3));
+        assert_eq!(result.unwrap(), U256::ZERO);
+    }
+
+    #[test]
+    fn test_overflow_protection() {
+        // Test case that would overflow: U256::MAX * 2
+        let result = mul_div_down(U256::MAX, U256::from(2), U256::from(1));
+        assert!(matches!(result, Err(FixedPointMathError::Overflow)));
+
+        let result = mul_div_up(U256::MAX, U256::from(2), U256::from(1));
+        assert!(matches!(result, Err(FixedPointMathError::Overflow)));
+
+        // Test edge case: max_x calculation
+        let large_y = U256::from(1000);
+        let max_x = U256::MAX / large_y;
+        let result = mul_div_down(max_x + U256::from(1), large_y, U256::from(1));
+        assert!(matches!(result, Err(FixedPointMathError::Overflow)));
+    }
+
+    #[test]
+    fn test_boundary_values() {
+        // Test with U256::MAX as denominator (should work)
+        let result = mul_div_down(U256::from(100), U256::from(200), U256::MAX);
+        assert_eq!(result.unwrap(), U256::ZERO); // Very small result rounds down to 0
+
+        // Test near-maximum safe values
+        let result = mul_div_down(U256::MAX, U256::from(1), U256::MAX);
+        assert_eq!(result.unwrap(), U256::from(1));
+
+        let result = mul_div_up(U256::MAX, U256::from(1), U256::MAX);
+        assert_eq!(result.unwrap(), U256::from(1));
+    }
+}

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -8,6 +8,7 @@ use bimap::BiMap;
 use executor_client::ExecutorClient;
 use lru::LruCache;
 use price_reporter_client::PriceReporterClient;
+use renegade_common::types::chain::Chain;
 use renegade_sdk::ExternalMatchClient;
 use reqwest::Client as ReqwestClient;
 use tokio::sync::RwLock;
@@ -15,6 +16,7 @@ use tracing::error;
 
 mod abis;
 pub mod executor_client;
+mod priority_fee;
 mod renegade_api;
 mod solve;
 mod uniswap_api;
@@ -75,6 +77,8 @@ pub struct UniswapXSolver {
     /// An order is placed in the cache even if processing the order fails, this
     /// cache is for deduplicating requests rather than tracking order status.
     order_cache: OrderCache,
+    /// The chain the solver is running on
+    chain_id: Chain,
 }
 
 impl UniswapXSolver {
@@ -88,7 +92,8 @@ impl UniswapXSolver {
         executor_client: ExecutorClient,
         price_reporter_client: PriceReporterClient,
     ) -> SolverResult<Self> {
-        let Cli { uniswapx_url: base_url, renegade_api_key, renegade_api_secret, .. } = cli;
+        let Cli { uniswapx_url: base_url, renegade_api_key, renegade_api_secret, chain_id, .. } =
+            cli;
 
         // TODO: Add support for other chains
         let renegade_client =
@@ -103,6 +108,7 @@ impl UniswapXSolver {
             price_reporter_client,
             supported_tokens,
             order_cache: new_order_cache(),
+            chain_id,
         })
     }
 

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -16,6 +16,7 @@ use tracing::error;
 
 mod abis;
 pub mod executor_client;
+pub mod fixed_point;
 mod priority_fee;
 mod renegade_api;
 mod solve;

--- a/renegade-solver/src/uniswapx/priority_fee.rs
+++ b/renegade-solver/src/uniswapx/priority_fee.rs
@@ -11,15 +11,11 @@ use alloy_primitives::U256;
 
 use crate::{
     error::SolverResult,
-    uniswapx::{abis::uniswapx::PriorityOrderReactor::PriorityOrder, UniswapXSolver},
+    uniswapx::{
+        abis::{priority_order::MPS, uniswapx::PriorityOrderReactor::PriorityOrder},
+        UniswapXSolver,
+    },
 };
-
-/// Multiplier to convert units to basis points (1 basis point = 0.01%)
-const BPS_PER_UNIT: f64 = 10_000.0;
-/// Multiplier to convert basis points to milli-bps (1 milli-bps = 0.00001%)
-const MPS_PER_BPS: f64 = 1000.0;
-/// Multiplier to convert units to milli-bps (1 milli-bps = 0.00001%)
-const MPS_PER_UNIT: f64 = BPS_PER_UNIT * MPS_PER_BPS;
 
 /// Compute the priority fee in wei
 pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_sell: bool) -> U256 {
@@ -39,7 +35,7 @@ pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_s
     let improvement_percent = abs_diff / priority_order_price;
 
     // Convert to milli-bps
-    let priority_fee_mps = improvement_percent * MPS_PER_UNIT;
+    let priority_fee_mps = improvement_percent * (MPS as f64);
 
     U256::from(priority_fee_mps as u128)
 }
@@ -71,12 +67,12 @@ mod tests {
         let renegade_price = 1090.0; // filler's offered price
         let is_sell = true; // selling ETH for USDC
 
-        let priority_fee = compute_priority_fee(priority_order_price, renegade_price, is_sell);
+        let priority_fee_wei = compute_priority_fee(priority_order_price, renegade_price, is_sell);
 
         // Expected calculation:
         // improvement = (1090 - 1000) / 1000 = 0.09 = 9%
         // bps = 0.09 * 10,000 = 900 bps
         // mps = 900 * 1000 = 900,000 mps
-        assert_eq!(priority_fee, U256::from(900_000u128));
+        assert_eq!(priority_fee_wei, U256::from(900_000u128));
     }
 }

--- a/renegade-solver/src/uniswapx/priority_fee.rs
+++ b/renegade-solver/src/uniswapx/priority_fee.rs
@@ -82,3 +82,29 @@ impl UniswapXSolver {
         Ok(price)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_priority_fee_calculation_docs_example() {
+        // Example from UniswapX docs:
+        // Alice sells 1 ETH for minimum 1000 USDC
+        // Fair market rate: 1100 USDC per ETH
+        // Filler offers 1090 USDC (10% margin from 100 USDC profit)
+        // Expected: 900 bps improvement = 900,000 mps = 900,000 wei
+
+        let priority_order_price = 1000.0; // minimum 1000 USDC
+        let renegade_price = 1090.0; // filler's offered price
+        let is_sell = true; // selling ETH for USDC
+
+        let priority_fee = compute_priority_fee(priority_order_price, renegade_price, is_sell);
+
+        // Expected calculation:
+        // improvement = (1090 - 1000) / 1000 = 0.09 = 9%
+        // bps = 0.09 * 10,000 = 900 bps
+        // mps = 900 * 1000 = 900,000 mps
+        assert_eq!(priority_fee, U256::from(900_000u128));
+    }
+}

--- a/renegade-solver/src/uniswapx/priority_fee.rs
+++ b/renegade-solver/src/uniswapx/priority_fee.rs
@@ -8,41 +8,38 @@
 /// See [UniswapX's documentation](https://docs.uniswapx.org/docs/priority-fee)
 /// for more details.
 use alloy_primitives::U256;
-use renegade_common::types::token::Token;
 
 use crate::{
     error::SolverResult,
-    uniswapx::{
-        abis::{conversion::u256_to_u128, uniswapx::PriorityOrderReactor::PriorityOrder},
-        UniswapXSolver,
-    },
+    uniswapx::{abis::uniswapx::PriorityOrderReactor::PriorityOrder, UniswapXSolver},
 };
 
-/// Multiplier to convert decimal to basis points (1 basis point = 0.01%)
-const DECIMAL_TO_BPS: f64 = 10_000.0;
-/// Multiplier to convert basis points to milli-bps (1 milli-bps = 0.001%)
-const BPS_TO_MPB: f64 = 1000.0;
+/// Multiplier to convert units to basis points (1 basis point = 0.01%)
+const BPS_PER_UNIT: f64 = 10_000.0;
+/// Multiplier to convert basis points to milli-bps (1 milli-bps = 0.00001%)
+const MPS_PER_BPS: f64 = 1000.0;
+/// Multiplier to convert units to milli-bps (1 milli-bps = 0.00001%)
+const MPS_PER_UNIT: f64 = BPS_PER_UNIT * MPS_PER_BPS;
 
 /// Compute the priority fee in wei
 pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_sell: bool) -> U256 {
     // Check if we can provide improvement over the order minimum
-    let no_improvement = (is_sell && renegade_price < priority_order_price)
-        || (!is_sell && renegade_price > priority_order_price);
+    let improvement = if is_sell {
+        renegade_price >= priority_order_price
+    } else {
+        renegade_price <= priority_order_price
+    };
 
-    if no_improvement {
+    if !improvement {
         return U256::ZERO;
     }
 
     // Calculate improvement as a percentage of the order minimum price
-    // Sell: (renegade_price - priority_order_price) / priority_order_price (+1.0)
-    // Buy:  (priority_order_price - renegade_price) / priority_order_price (-1.0)
-    let improvement_direction = if is_sell { 1.0 } else { -1.0 };
-    let improvement_percentage =
-        improvement_direction * (renegade_price - priority_order_price) / priority_order_price;
+    let abs_diff = (renegade_price - priority_order_price).abs();
+    let improvement_percent = abs_diff / priority_order_price;
 
-    // Convert to basis points then to milli-bps
-    let improvement_bps = improvement_percentage * DECIMAL_TO_BPS;
-    let priority_fee_mps = improvement_bps * BPS_TO_MPB;
+    // Convert to milli-bps
+    let priority_fee_mps = improvement_percent * MPS_PER_UNIT;
 
     U256::from(priority_fee_mps as u128)
 }
@@ -50,35 +47,10 @@ pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_s
 impl UniswapXSolver {
     /// Get the price of a token from the price reporter client
     ///
-    /// Assumes one side of the order is USDC
+    /// Assumes one side of the order is USDC and there is only one output token
     pub(crate) async fn get_renegade_price(&self, order: &PriorityOrder) -> SolverResult<f64> {
-        let is_buy = self.is_usdc(order.input.token);
-        let mint = if is_buy { order.outputs[0].token } else { order.input.token };
-        let price = self.price_reporter_client.get_price(&mint.to_string(), self.chain_id).await?;
-        Ok(price)
-    }
-
-    /// Get the price of a token from a PriorityOrder
-    ///
-    /// Assumes one side of the order is USDC
-    pub(crate) async fn get_priority_order_price(
-        &self,
-        order: &PriorityOrder,
-    ) -> SolverResult<f64> {
-        let is_buy = self.is_usdc(order.input.token);
-
-        let quote_amount = if is_buy { order.input.amount } else { order.outputs[0].amount };
-        let quote_amount_u128 = u256_to_u128(quote_amount)?;
-        let quote_token = Token::new(&self.get_usdc_address().to_string(), self.chain_id);
-        let quote_decimal_corrected_amt = quote_token.convert_to_decimal(quote_amount_u128);
-
-        let base_mint = if is_buy { order.outputs[0].token } else { order.input.token };
-        let base_amount = if is_buy { order.outputs[0].amount } else { order.input.amount };
-        let base_amount_u128 = u256_to_u128(base_amount)?;
-        let base_token = Token::new(&base_mint.to_string(), self.chain_id);
-        let base_decimal_corrected_amt = base_token.convert_to_decimal(base_amount_u128);
-
-        let price = quote_decimal_corrected_amt / base_decimal_corrected_amt;
+        let mint = order.base_token().get_addr();
+        let price = self.price_reporter_client.get_price(&mint, self.chain_id).await?;
         Ok(price)
     }
 }

--- a/renegade-solver/src/uniswapx/priority_fee.rs
+++ b/renegade-solver/src/uniswapx/priority_fee.rs
@@ -1,0 +1,84 @@
+//! Helper methods for computing priority fees
+//!
+//! We maintain the following invariant from the UniswapX specification:
+/// For every wei of priority fee above a certain threshold (an optional value
+/// specified in the order), the user is owed 1 milli-bps more of their output
+/// token (or less of their input token).
+///
+/// See [UniswapX's documentation](https://docs.uniswapx.org/docs/priority-fee)
+/// for more details.
+use alloy_primitives::U256;
+use renegade_common::types::token::Token;
+
+use crate::{
+    error::SolverResult,
+    uniswapx::{
+        abis::{conversion::u256_to_u128, uniswapx::PriorityOrderReactor::PriorityOrder},
+        UniswapXSolver,
+    },
+};
+
+/// Multiplier to convert decimal to basis points (1 basis point = 0.01%)
+const DECIMAL_TO_BPS: f64 = 10_000.0;
+/// Multiplier to convert basis points to milli-bps (1 milli-bps = 0.001%)
+const BPS_TO_MPB: f64 = 1000.0;
+
+/// Compute the priority fee in wei
+pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_sell: bool) -> U256 {
+    // Check if we can provide improvement over the order minimum
+    let no_improvement = (is_sell && renegade_price < priority_order_price)
+        || (!is_sell && renegade_price > priority_order_price);
+
+    if no_improvement {
+        return U256::ZERO;
+    }
+
+    // Calculate improvement as a percentage of the order minimum price
+    // Sell: (renegade_price - priority_order_price) / priority_order_price (+1.0)
+    // Buy:  (priority_order_price - renegade_price) / priority_order_price (-1.0)
+    let improvement_direction = if is_sell { 1.0 } else { -1.0 };
+    let improvement_percentage =
+        improvement_direction * (renegade_price - priority_order_price) / priority_order_price;
+
+    // Convert to basis points then to milli-bps
+    let improvement_bps = improvement_percentage * DECIMAL_TO_BPS;
+    let priority_fee_mps = improvement_bps * BPS_TO_MPB;
+
+    U256::from(priority_fee_mps as u128)
+}
+
+impl UniswapXSolver {
+    /// Get the price of a token from the price reporter client
+    ///
+    /// Assumes one side of the order is USDC
+    pub(crate) async fn get_renegade_price(&self, order: &PriorityOrder) -> SolverResult<f64> {
+        let is_buy = self.is_usdc(order.input.token);
+        let mint = if is_buy { order.outputs[0].token } else { order.input.token };
+        let price = self.price_reporter_client.get_price(&mint.to_string(), self.chain_id).await?;
+        Ok(price)
+    }
+
+    /// Get the price of a token from a PriorityOrder
+    ///
+    /// Assumes one side of the order is USDC
+    pub(crate) async fn get_priority_order_price(
+        &self,
+        order: &PriorityOrder,
+    ) -> SolverResult<f64> {
+        let is_buy = self.is_usdc(order.input.token);
+
+        let quote_amount = if is_buy { order.input.amount } else { order.outputs[0].amount };
+        let quote_amount_u128 = u256_to_u128(quote_amount)?;
+        let quote_token = Token::new(&self.get_usdc_address().to_string(), self.chain_id);
+        let quote_decimal_corrected_amt = quote_token.convert_to_decimal(quote_amount_u128);
+
+        let base_mint = if is_buy { order.outputs[0].token } else { order.input.token };
+        let base_amount = if is_buy { order.outputs[0].amount } else { order.input.amount };
+        let base_amount_u128 = u256_to_u128(base_amount)?;
+        let base_token = Token::new(&base_mint.to_string(), self.chain_id);
+        let base_decimal_corrected_amt = base_token.convert_to_decimal(base_amount_u128);
+
+        let price = quote_decimal_corrected_amt / base_decimal_corrected_amt;
+        Ok(price)
+    }
+}

--- a/renegade-solver/src/uniswapx/renegade_api.rs
+++ b/renegade-solver/src/uniswapx/renegade_api.rs
@@ -16,12 +16,9 @@ impl UniswapXSolver {
     /// Renegade API. Validation for this should be done in the caller.
     pub(crate) async fn solve_renegade_leg(
         &self,
-        input_token: Address,
-        output_token: Address,
-        input_amount: u128,
+        order: ExternalOrder,
     ) -> SolverResult<Option<AtomicMatchApiBundle>> {
         let opt = Self::get_external_match_options();
-        let order = self.build_order(input_token, output_token, input_amount)?;
         let maybe_bundle =
             self.renegade_client.request_external_match_with_options(order, opt).await?;
 
@@ -41,7 +38,7 @@ impl UniswapXSolver {
     }
 
     /// Build an order for the given token pair
-    fn build_order(
+    pub(crate) fn build_order(
         &self,
         input_token: Address,
         output_token: Address,

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -35,9 +35,9 @@ impl UniswapXSolver {
         );
 
         // Compute priority fee
-        let priority_order_price = self.get_priority_order_price(&order).await?;
+        let priority_order_price = order.get_price()?;
         let renegade_price = self.get_renegade_price(&order).await?;
-        let is_sell = self.is_usdc(order.outputs[0].token);
+        let is_sell = order.is_sell();
         let priority_fee = compute_priority_fee(priority_order_price, renegade_price, is_sell);
         info!("Priority fee (wei): {}", priority_fee);
 

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -1,10 +1,12 @@
 //! Code for solving order routes
 
 use alloy::primitives::Address;
+use alloy_primitives::U256;
+use renegade_sdk::types::ExternalOrder;
 use tracing::info;
 
 use crate::{
-    error::SolverResult,
+    error::{SolverError, SolverResult},
     uniswapx::{
         abis::{conversion::u256_to_u128, uniswapx::PriorityOrderReactor::PriorityOrder},
         priority_fee::compute_priority_fee,
@@ -38,14 +40,18 @@ impl UniswapXSolver {
         let priority_order_price = order.get_price()?;
         let renegade_price = self.get_renegade_price(&order).await?;
         let is_sell = order.is_sell();
-        let priority_fee = compute_priority_fee(priority_order_price, renegade_price, is_sell);
-        info!("Priority fee (wei): {}", priority_fee);
+        let priority_fee_wei = compute_priority_fee(priority_order_price, renegade_price, is_sell);
+        info!("Priority fee (wei): {}", priority_fee_wei);
+
+        // Scale the order
+        let scaled_input = order.input.scale(priority_fee_wei)?;
+        let scaled_output = order.outputs[0].scale(priority_fee_wei)?;
+        info!("Input scaled from {} to {}", input.amount, scaled_input);
+        info!("Output scaled from {} to {}", first_output.amount, scaled_output);
 
         // Find a solution for the order
-        let in_token = order.input.token;
-        let out_token = order.outputs[0].token;
-        let amount = u256_to_u128(order.input.amount)?;
-        let renegade_bundle = self.solve_renegade_leg(in_token, out_token, amount).await?;
+        let external_order = self.build_scaled_order(&order, priority_fee)?;
+        let renegade_bundle = self.solve_renegade_leg(external_order).await?;
         if let Some(bundle) = renegade_bundle {
             info!("Found renegade solution with receive amount: {}", bundle.receive.amount);
         } else {
@@ -53,6 +59,27 @@ impl UniswapXSolver {
         }
 
         Ok(())
+    }
+
+    /// Build an ExternalOrder from a PriorityOrder with scaled input and output
+    /// amounts
+    fn build_scaled_order(
+        &self,
+        order: &PriorityOrder,
+        priority_fee: U256,
+    ) -> SolverResult<ExternalOrder> {
+        let scaled_input = order.input.scale(priority_fee)?;
+        let scaled_output = order.outputs[0].scale(priority_fee)?;
+
+        // Assert only one of {scaled_input, scaled_output} was scaled
+        if scaled_input != order.input.amount && scaled_output != order.outputs[0].amount {
+            return Err(SolverError::InputOutputScaling);
+        }
+
+        let input_u128 = u256_to_u128(scaled_input)?;
+        let order = self.build_order(order.input.token, order.outputs[0].token, input_u128)?;
+
+        Ok(order)
     }
 
     /// A temporary (more restrictive) set of order filters while we keep the


### PR DESCRIPTION
### Purpose
This PR adds priority fee calculation given a PriorityOrder and the canonical Renegade price. 

In the next PR we will scale the requested amounts using the priority fee before requesting an external match from the relayer.

### Testing
- [x] Test example from [docs](https://docs.uniswap.org/contracts/uniswapx/guides/priority/priorityorderreactor#example-implementation)