### PR TITLE
solver: fix native eth mapping, add logs

### DIFF
--- a/renegade-solver/src/uniswapx/abis/priority_order.rs
+++ b/renegade-solver/src/uniswapx/abis/priority_order.rs
@@ -14,6 +14,7 @@ use crate::{
             error::{FixedPointMathError, FixedPointResult},
             mul_div_down, mul_div_up,
         },
+        NATIVE_ETH_ADDRESS, WETH_TICKER,
     },
 };
 
@@ -50,11 +51,16 @@ impl PriorityOrder {
     }
 
     /// Returns the base token address (non-USDC token)
+    ///
+    /// Maps Native ETH to WETH since this returns a Renegade Token where native
+    /// ETH address is not valid
     pub fn base_token(&self) -> Token {
         if self.is_sell() {
-            Token::from_addr(&self.input.token.to_string())
+            let base = self.map_native_eth_to_weth(self.input.token.to_string());
+            Token::from_addr(&base)
         } else {
-            self.output_token()
+            let base = self.map_native_eth_to_weth(self.output_token().get_addr().to_string());
+            Token::from_addr(&base)
         }
     }
 
@@ -101,6 +107,14 @@ impl PriorityOrder {
     /// Assumes all outputs have the same token
     pub fn output_token(&self) -> Token {
         Token::from_addr(&self.outputs[0].token.to_string())
+    }
+
+    /// Map Native ETH to WETH
+    fn map_native_eth_to_weth(&self, token: String) -> String {
+        match token.as_str() {
+            NATIVE_ETH_ADDRESS => Token::from_ticker(WETH_TICKER).get_addr(),
+            _ => token,
+        }
     }
 }
 

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -34,6 +34,12 @@ const ORDER_CACHE_SIZE: usize = 100;
 const NATIVE_ETH_SYMBOL: &str = "ETH";
 /// The symbol for USDC
 const USDC_SYMBOL: &str = "USDC";
+/// Native ETH address as per UniswapX
+const NATIVE_ETH_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+/// Native ETH address as per Renegade
+const NATIVE_ETH_ADDRESS_RENEGADE: &str = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+/// WETH ticker
+const WETH_TICKER: &str = "WETH";
 
 /// A shared read-only bimap of supported tokens
 ///

--- a/renegade-solver/src/uniswapx/priority_fee.rs
+++ b/renegade-solver/src/uniswapx/priority_fee.rs
@@ -9,13 +9,7 @@
 /// for more details.
 use alloy_primitives::U256;
 
-use crate::{
-    error::SolverResult,
-    uniswapx::{
-        abis::{priority_order::MPS, uniswapx::PriorityOrderReactor::PriorityOrder},
-        UniswapXSolver,
-    },
-};
+use crate::uniswapx::abis::priority_order::MPS;
 
 /// Compute the priority fee in wei
 pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_sell: bool) -> U256 {
@@ -27,6 +21,11 @@ pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_s
     };
 
     if !improvement {
+        tracing::info!(
+            "Renegade price: {} | UniswapX price: {} | Improvement: 0 bps",
+            renegade_price,
+            priority_order_price,
+        );
         return U256::ZERO;
     }
 
@@ -47,17 +46,6 @@ pub fn compute_priority_fee(priority_order_price: f64, renegade_price: f64, is_s
     );
 
     priority_fee_wei
-}
-
-impl UniswapXSolver {
-    /// Get the price of a token from the price reporter client
-    ///
-    /// Assumes one side of the order is USDC and there is only one output token
-    pub(crate) async fn get_renegade_price(&self, order: &PriorityOrder) -> SolverResult<f64> {
-        let mint = order.base_token().get_addr();
-        let price = self.price_reporter_client.get_price(&mint, self.chain_id).await?;
-        Ok(price)
-    }
 }
 
 #[cfg(test)]

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -66,11 +66,18 @@ impl UniswapXSolver {
         let external_order = self.build_scaled_order(&order, priority_fee_wei)?;
         let renegade_bundle = self.solve_renegade_leg(external_order).await?;
         if let Some(bundle) = renegade_bundle {
-            info!("Found renegade solution with output amount: {}", bundle.receive.amount);
+            info!(
+                "Found renegade solution with input amount: {}, output amount: {}",
+                bundle.send.amount, bundle.receive.amount
+            );
+            let input_delta = bundle.send.amount as i128 - u256_to_u128(scaled_input)? as i128;
+            if input_delta > 0 {
+                info!("Renegade bundle is larger than the order by {}", input_delta);
+            }
             // Negative delta means the renegade bundle is smaller than the order
-            let signed_delta = bundle.receive.amount as i128 - u256_to_u128(scaled_output)? as i128;
-            if signed_delta < 0 {
-                info!("Renegade bundle is smaller than the order by {}", signed_delta);
+            let output_delta = bundle.receive.amount as i128 - u256_to_u128(scaled_output)? as i128;
+            if output_delta < 0 {
+                info!("Renegade bundle is smaller than the order by {}", output_delta);
             }
         } else {
             info!("No renegade solution found");


### PR DESCRIPTION
### Purpose
This PR ensures we map native ETH to the expected address, specifically: 
- to WETH when getting decimals
- to `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` when requesting a bundle from the relayer