### PR TITLE
auth-server: api-handlers: Allow native asset in token validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,50 +1530,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-sdk-ecr"
-version = "1.87.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "787c8e5d3888da32c320a108f499dbbbe785c1898112707a65984a57da98c512"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-ecs"
-version = "1.91.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34163a23ad87d125d80aadfc87bf95259034423355ca5eaa6f2b99fef1b537c5"
-dependencies = [
- "aws-credential-types",
- "aws-runtime",
- "aws-smithy-async",
- "aws-smithy-http",
- "aws-smithy-json",
- "aws-smithy-runtime",
- "aws-smithy-runtime-api",
- "aws-smithy-types",
- "aws-types",
- "bytes",
- "fastrand",
- "http 0.2.12",
- "regex-lite",
- "tracing",
-]
-
-[[package]]
 name = "aws-sdk-s3"
 version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,19 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,23 +3232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deploy"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aws-config",
- "aws-sdk-ecr",
- "aws-sdk-ecs",
- "base64 0.22.1",
- "clap",
- "dialoguer",
- "serde",
- "serde_json",
- "tokio",
- "toml 0.8.23",
-]
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3386,20 +3312,6 @@ dependencies = [
  "quote",
  "syn 2.0.104",
  "unicode-xid",
-]
-
-[[package]]
-name = "dialoguer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
-dependencies = [
- "console",
- "fuzzy-matcher",
- "shell-words",
- "tempfile",
- "thiserror 1.0.69",
- "zeroize",
 ]
 
 [[package]]
@@ -3702,12 +3614,6 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -4477,15 +4383,6 @@ name = "futures-utils-wasm"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
-
-[[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
 
 [[package]]
 name = "fxhash"
@@ -8457,12 +8354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9674,12 +9565,6 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ members = [
     "auth/auth-server-api",
     "compliance/compliance-server",
     "compliance/compliance-api",
-    "deploy",
     "renegade-solver",
     "dealer/renegade-dealer",
     "dealer/renegade-dealer-api",

--- a/auth/auth-server/src/server/api_handlers/external_match/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/mod.rs
@@ -286,7 +286,9 @@ impl Server {
         // Check that the base and quote tokens are valid
         let base = Token::from_addr_biguint(body.base_mint());
         let quote = Token::from_addr_biguint(body.quote_mint());
-        if !base.is_named() {
+
+        let base_valid = base.is_named() || base.is_native_asset();
+        if !base_valid {
             let base_addr = base.get_addr();
             return Err(AuthServerError::bad_request(format!("Invalid base token: {base_addr}")));
         }

--- a/auth/auth-server/src/server/api_handlers/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/mod.rs
@@ -18,7 +18,7 @@ use rand::Rng;
 use renegade_api::http::external_match::ExternalOrder;
 use renegade_circuit_types::fixed_point::FixedPoint;
 use renegade_common::types::token::Token;
-use renegade_constants::DEFAULT_EXTERNAL_MATCH_RELAYER_FEE;
+use renegade_constants::{DEFAULT_EXTERNAL_MATCH_RELAYER_FEE, NATIVE_ASSET_WRAPPER_TICKER};
 use renegade_util::hex::biguint_to_hex_addr;
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
@@ -65,6 +65,10 @@ pub fn get_sdk_version(headers: &HeaderMap) -> String {
 /// Get a ticker from a `BigUint` encoded mint
 pub fn ticker_from_biguint(mint: &BigUint) -> Result<String, AuthServerError> {
     let token = Token::from_addr_biguint(mint);
+    if token.is_native_asset() {
+        return Ok(NATIVE_ASSET_WRAPPER_TICKER.to_string());
+    }
+
     token.get_ticker().ok_or_else(|| {
         let token_addr = biguint_to_hex_addr(mint);
         AuthServerError::bad_request(format!("Invalid token: {token_addr}"))


### PR DESCRIPTION
### Purpose
This PR checks for the native asset `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` in token validation in the auth server. This fixes a bug wherein native ETH was disallowed at the API layer.

### Testing
- [x] Tested locally