### PR TITLE
solver: add settlement helpers

### DIFF
--- a/renegade-solver/src/uniswapx/abis/conversion.rs
+++ b/renegade-solver/src/uniswapx/abis/conversion.rs
@@ -2,13 +2,15 @@
 
 use alloy::primitives::U256;
 
-use crate::error::{SolverError, SolverResult};
-
 // ----------------------
 // | Conversion Helpers |
 // ----------------------
 
 /// Parse a u128 from a U256
-pub(crate) fn u256_to_u128(u256: U256) -> SolverResult<u128> {
-    u256.try_into().map_err(|_| SolverError::InvalidU256(u256))
+///
+/// The function returns `Result<u128, U256>` where the `Err(U256)` variant
+/// contains the original value that did not fit into 128 bits, to be handled
+/// by the caller.
+pub(crate) fn u256_to_u128(u256: U256) -> Result<u128, U256> {
+    u256.try_into().map_err(|_| u256)
 }

--- a/renegade-solver/src/uniswapx/executor_client/contract_interaction.rs
+++ b/renegade-solver/src/uniswapx/executor_client/contract_interaction.rs
@@ -1,14 +1,43 @@
 //! Defines `ExecutorClient` helpers that allow for interacting with the
 //! executor contract
 use alloy::rpc::types::TransactionReceipt;
+use alloy_sol_types::SolCall;
 use renegade_solidity_abi::IDarkpool::{
-    MatchAtomicLinkingProofs, MatchAtomicProofs, PartyMatchPayload, SignedOrder,
-    ValidMatchSettleAtomicStatement,
+    processAtomicMatchSettleCall, MatchAtomicLinkingProofs, MatchAtomicProofs, PartyMatchPayload,
+    SignedOrder, ValidMatchSettleAtomicStatement,
 };
+
+use alloy_primitives::U256;
 
 use crate::uniswapx::executor_client::{errors::ExecutorError, ExecutorClient};
 
 impl ExecutorClient {
+    // -----------
+    // | GETTERS |
+    // -----------
+
+    /// Parse calldata for Darkpool's processAtomicMatchSettle
+    fn parse_calldata_for_execute_atomic_match_settle(
+        &self,
+        calldata: &[u8],
+    ) -> Result<
+        (
+            PartyMatchPayload,
+            ValidMatchSettleAtomicStatement,
+            MatchAtomicProofs,
+            MatchAtomicLinkingProofs,
+        ),
+        ExecutorError,
+    > {
+        let calldata = processAtomicMatchSettleCall::abi_decode(calldata)?;
+        let internal_party_payload = calldata.internalPartyPayload;
+        let match_settle_statement = calldata.matchSettleStatement;
+        let proofs = calldata.proofs;
+        let linking_proofs = calldata.linkingProofs;
+
+        Ok((internal_party_payload, match_settle_statement, proofs, linking_proofs))
+    }
+
     // -----------
     // | SETTERS |
     // -----------
@@ -16,21 +45,25 @@ impl ExecutorClient {
     /// Executes a UniswapX order with atomic match settlement
     pub async fn execute_atomic_match_settle(
         &self,
-        order: SignedOrder,
-        internal_party_payload: PartyMatchPayload,
-        match_settle_statement: ValidMatchSettleAtomicStatement,
-        proofs: MatchAtomicProofs,
-        linking_proofs: MatchAtomicLinkingProofs,
+        calldata: &[u8],
+        signed_order: SignedOrder,
+        priority_fee_wei: U256,
     ) -> Result<TransactionReceipt, ExecutorError> {
+        // Parse the calldata for the executeAtomicMatchSettle call
+        let (internal_party_payload, match_settle_statement, proofs, linking_proofs) =
+            self.parse_calldata_for_execute_atomic_match_settle(calldata)?;
+
+        // Build the call to the executeAtomicMatchSettle function
         let call = self.contract.executeAtomicMatchSettle(
-            order,
+            signed_order,
             internal_party_payload,
             match_settle_statement,
             proofs,
             linking_proofs,
         );
 
-        let receipt = self.send_tx(call).await?;
+        // Submit on-chain
+        let receipt = self.send_tx(call, priority_fee_wei).await?;
 
         Ok(receipt)
     }

--- a/renegade-solver/src/uniswapx/executor_client/mod.rs
+++ b/renegade-solver/src/uniswapx/executor_client/mod.rs
@@ -161,7 +161,7 @@ impl ExecutorClient {
             .ok_or_else(|| ExecutorError::contract_interaction("base fee overflow"))?;
 
         // Final gas price for a legacy tx: baseFee + buffer + priority fee.
-        let gas_price_u256 = base_fee_per_gas + base_fee_buffer + priority_fee_wei;
+        let gas_price_u256 = base_fee_buffer + priority_fee_wei;
 
         Ok(u256_to_u128(gas_price_u256)?)
     }

--- a/renegade-solver/src/uniswapx/uniswap_api/types.rs
+++ b/renegade-solver/src/uniswapx/uniswap_api/types.rs
@@ -4,6 +4,7 @@
 //! [here](https://github.com/Uniswap/uniswapx-service/blob/main/swagger.json)
 
 use alloy::{hex, sol_types::SolValue};
+use renegade_solidity_abi::IDarkpool::SignedOrder;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -69,6 +70,17 @@ impl OrderEntity {
             hex::decode(self.encoded_order.clone()).map_err(SolverError::abi_encoding)?;
         let order = PriorityOrder::abi_decode(&order_bytes).unwrap();
         Ok(order)
+    }
+
+    /// Decode a SignedOrder
+    ///
+    /// We decode into the SignedOrder type found in renegade_abi for
+    /// compatibility with the Executor contract
+    pub fn decode_signed_order(&self) -> SolverResult<SignedOrder> {
+        let order_bytes =
+            hex::decode(self.encoded_order.clone()).map_err(SolverError::abi_encoding)?;
+        let sig_bytes = hex::decode(self.signature.clone()).map_err(SolverError::abi_encoding)?;
+        Ok(SignedOrder { order: order_bytes.into(), sig: sig_bytes.into() })
     }
 }
 


### PR DESCRIPTION
### Purpose
This PR adds helpers to submit a solution to the executor contract, including computing the total `gasPrice` net of `priorityFee` and `basePriorityFee`.

In the next PR I will add tx simulation for testing.

### Testing
- [x] Tested locally that calldata is correctly parsed