### PR TITLE
funds-manager: execution-client: Use decimal corrected price

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -207,6 +207,21 @@ impl AugmentedExecutionQuote {
         Ok(self.get_sell_token().convert_to_decimal(sell_amount))
     }
 
+    /// Get the decimal corrected price
+    pub fn get_decimal_corrected_price(&self) -> Result<f64, String> {
+        // Fetch the decimal corrected amounts
+        let buy_amount = self.get_decimal_corrected_buy_amount()?;
+        let sell_amount = self.get_decimal_corrected_sell_amount()?;
+        let (base_amt, quote_amt) = if self.quote.is_sell() {
+            (sell_amount, buy_amount)
+        } else {
+            (buy_amount, sell_amount)
+        };
+
+        let price = quote_amt / base_amt;
+        Ok(price)
+    }
+
     /// Get the buy amount min as a decimal-corrected string
     pub fn get_decimal_corrected_buy_amount_min(&self) -> Result<f64, String> {
         let buy_amount_min = u256_try_into_u128(self.quote.buy_amount_min)?;

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -404,11 +404,9 @@ impl ExecutionClient {
         let base_addr = augmented_quote.quote.base_addr();
         let renegade_price =
             self.price_reporter.get_price(&base_addr.to_string(), augmented_quote.chain).await?;
-
-        // Get the price of the quote
-        let quote_amount = augmented_quote.quote.quote_amount() as f64;
-        let base_amount = augmented_quote.quote.base_amount() as f64;
-        let quote_price = quote_amount / base_amount;
+        let quote_price = augmented_quote
+            .get_decimal_corrected_price()
+            .map_err(ExecutionClientError::quote_validation)?;
 
         // Check that the price is within the max price impact
         let deviation = if augmented_quote.quote.is_sell() {


### PR DESCRIPTION
### Purpose
This PR fixes an issue with the price deviation check in which the funds manager was not using the decimal corrected price from the quote.

### Testing
- [x] Tested in mainnet