### PR TITLE
funds-manager: execution_client: use ExecutableQuote for Lifi execution

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -1,15 +1,8 @@
 //! API types for quoter management
-use alloy_primitives::{hex, Address, Bytes, U256};
-use renegade_common::types::{
-    chain::Chain,
-    token::{Token, USDC_TICKER},
-};
+use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    serialization::{f64_string_serialization, u256_string_serialization},
-    u256_try_into_u128,
-};
+use crate::serialization::{f64_string_serialization, u256_string_serialization};
 
 // --------------
 // | Api Routes |
@@ -66,218 +59,23 @@ pub struct WithdrawFundsRequest {
 
 // --- Execution --- //
 
-/// The subset of the quote response forwarded to consumers of this client
-// TODO: Remove in favor of `funds_manager_server::execution_client::venues::ExecutionQuote`
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// A simplified representation of an execution quote, suitable for API
+/// responses
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ExecutionQuote {
-    /// The token address we're buying
-    pub buy_token_address: Address,
-    /// The token address we're selling
-    pub sell_token_address: Address,
-    /// The amount of tokens to sell
+pub struct ApiExecutionQuote {
+    /// The address of the token being sold
+    pub sell_token_address: String,
+    /// The address of the token being bought
+    pub buy_token_address: String,
+    /// The amount of the token being sold
     #[serde(with = "u256_string_serialization")]
     pub sell_amount: U256,
-    /// The amount of tokens expected to be received
+    /// The amount of the token being bought
     #[serde(with = "u256_string_serialization")]
     pub buy_amount: U256,
-    /// The minimum amount of tokens expected to be received
-    #[serde(with = "u256_string_serialization")]
-    pub buy_amount_min: U256,
-    /// The submitting address
-    pub from: Address,
-    /// The swap contract address
-    pub to: Address,
-    /// The calldata for the swap
-    pub data: Bytes,
-    /// The value of the tx; should be zero
-    #[serde(with = "u256_string_serialization")]
-    pub value: U256,
-    /// The gas price used in the swap
-    #[serde(with = "u256_string_serialization")]
-    pub gas_price: U256,
-    /// The estimated gas for the swap
-    #[serde(with = "u256_string_serialization")]
-    pub estimated_gas: U256,
-    /// The gas limit for the swap
-    #[serde(with = "u256_string_serialization")]
-    pub gas_limit: U256,
-}
-
-impl ExecutionQuote {
-    /// Whether the quote is a sell order in Renegade terms
-    pub fn is_sell(&self) -> bool {
-        let usdc = Token::usdc();
-        self.buy_token_address == usdc.get_alloy_address()
-    }
-
-    /// Get the base token address
-    pub fn base_addr(&self) -> Address {
-        if self.is_sell() {
-            self.sell_token_address
-        } else {
-            self.buy_token_address
-        }
-    }
-
-    /// Get the base amount
-    pub fn base_amount(&self) -> u128 {
-        let amt_u256 = if self.is_sell() { self.sell_amount } else { self.buy_amount };
-        u256_try_into_u128(amt_u256).expect("Quote amount overflows u128")
-    }
-
-    /// Get the quote token address
-    pub fn quote_addr(&self) -> Address {
-        if self.is_sell() {
-            self.buy_token_address
-        } else {
-            self.sell_token_address
-        }
-    }
-
-    /// Get the quote amount
-    pub fn quote_amount(&self) -> u128 {
-        let amt_u256 = if self.is_sell() { self.buy_amount } else { self.sell_amount };
-        u256_try_into_u128(amt_u256).expect("Quote amount overflows u128")
-    }
-}
-
-/// An execution quote, augmented with additional contextual data
-#[derive(Clone, Debug)]
-pub struct AugmentedExecutionQuote {
-    /// The quote
-    pub quote: ExecutionQuote,
-    /// The chain the quote is for
-    pub chain: Chain,
-}
-
-impl AugmentedExecutionQuote {
-    /// Create a new augmented execution quote
-    pub fn new(quote: ExecutionQuote, chain: Chain) -> Self {
-        Self { quote, chain }
-    }
-
-    /// Convert the quote to a canonical string representation for HMAC signing
-    pub fn to_canonical_string(&self) -> String {
-        format!(
-            "{}{}{}{}{}{}{}{}{}{}{}{}",
-            self.quote.buy_token_address,
-            self.quote.sell_token_address,
-            self.quote.sell_amount,
-            self.quote.buy_amount,
-            self.quote.from,
-            self.quote.to,
-            hex::encode(&self.quote.data),
-            self.quote.value,
-            self.quote.gas_price,
-            self.quote.estimated_gas,
-            self.quote.gas_limit,
-            self.chain,
-        )
-    }
-
-    /// Get the buy token address as a formatted string
-    pub fn get_buy_token_address(&self) -> String {
-        format!("{:#x}", self.quote.buy_token_address)
-    }
-
-    /// Get the sell token address as a formatted string
-    pub fn get_sell_token_address(&self) -> String {
-        format!("{:#x}", self.quote.sell_token_address)
-    }
-
-    /// Get the from address as a formatted string
-    pub fn get_from_address(&self) -> String {
-        format!("{:#x}", self.quote.from)
-    }
-
-    /// Get the to address as a formatted string
-    pub fn get_to_address(&self) -> String {
-        format!("{:#x}", self.quote.to)
-    }
-
-    /// Get the buy amount as a decimal-corrected string
-    pub fn get_decimal_corrected_buy_amount(&self) -> Result<f64, String> {
-        let buy_amount = u256_try_into_u128(self.quote.buy_amount)?;
-        Ok(self.get_buy_token().convert_to_decimal(buy_amount))
-    }
-
-    /// Get the sell amount as a decimal-corrected string
-    pub fn get_decimal_corrected_sell_amount(&self) -> Result<f64, String> {
-        let sell_amount = u256_try_into_u128(self.quote.sell_amount)?;
-        Ok(self.get_sell_token().convert_to_decimal(sell_amount))
-    }
-
-    /// Get the buy amount min as a decimal-corrected string
-    pub fn get_decimal_corrected_buy_amount_min(&self) -> Result<f64, String> {
-        let buy_amount_min = u256_try_into_u128(self.quote.buy_amount_min)?;
-        Ok(self.get_buy_token().convert_to_decimal(buy_amount_min))
-    }
-}
-
-impl AugmentedExecutionQuote {
-    /// Get the price in units of USDC per base token.
-    /// If a custom buy amount is provided, it is used in place of the standard
-    /// buy amount.
-    pub fn get_price(&self, buy_amount: Option<U256>) -> Result<f64, String> {
-        let buy_amount = u256_try_into_u128(buy_amount.unwrap_or(self.quote.buy_amount))?;
-        let decimal_buy_amount = self.get_buy_token().convert_to_decimal(buy_amount);
-
-        let decimal_sell_amount = self.get_decimal_corrected_sell_amount()?;
-
-        let buy_per_sell = decimal_buy_amount / decimal_sell_amount;
-        if self.is_buy() {
-            Ok(1.0 / buy_per_sell)
-        } else {
-            Ok(buy_per_sell)
-        }
-    }
-
-    /// Returns the non-USDC token
-    pub fn get_base_token(&self) -> Token {
-        if self.is_buy() {
-            self.get_buy_token()
-        } else {
-            self.get_sell_token()
-        }
-    }
-
-    /// Return true if the sell token is USDC
-    pub fn is_buy(&self) -> bool {
-        let usdc_mint = &Token::from_ticker_on_chain(USDC_TICKER, self.chain).get_alloy_address();
-        &self.quote.sell_token_address == usdc_mint
-    }
-
-    /// Returns the token being bought
-    pub fn get_buy_token(&self) -> Token {
-        Token::from_addr_on_chain(&self.get_buy_token_address(), self.chain)
-    }
-
-    /// Returns the token being sold
-    pub fn get_sell_token(&self) -> Token {
-        Token::from_addr_on_chain(&self.get_sell_token_address(), self.chain)
-    }
-
-    /// Returns the volume in USDC
-    pub fn get_quote_amount(&self) -> Result<f64, String> {
-        if self.is_buy() {
-            self.get_decimal_corrected_sell_amount()
-        } else {
-            self.get_decimal_corrected_buy_amount()
-        }
-    }
-
-    /// Returns the notional volume in USDC, taking into account the actual
-    /// buy amount for sell orders
-    pub fn notional_volume_usdc(&self, buy_amount_actual: U256) -> Result<f64, String> {
-        if self.is_buy() {
-            self.get_decimal_corrected_sell_amount()
-        } else {
-            let buy_amount = u256_try_into_u128(buy_amount_actual)?;
-
-            Ok(self.get_buy_token().convert_to_decimal(buy_amount))
-        }
-    }
+    /// The venue that provided the quote
+    pub venue: String,
 }
 
 /// The subset of LiFi quote request query parameters that we support
@@ -334,7 +132,7 @@ pub struct LiFiQuoteParams {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SwapImmediateResponse {
     /// The quote that was executed
-    pub quote: ExecutionQuote,
+    pub quote: ApiExecutionQuote,
     /// The tx hash of the swap
     pub tx_hash: String,
     /// The execution cost in USD

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi.rs
@@ -10,7 +10,10 @@ use serde::Deserialize;
 
 use crate::execution_client::{
     error::ExecutionClientError,
-    venues::{ExecutableQuote, ExecutionQuote, QuoteExecutionData, SupportedExecutionVenue},
+    venues::{
+        quote::{ExecutableQuote, ExecutionQuote, QuoteExecutionData},
+        SupportedExecutionVenue,
+    },
 };
 
 /// Transaction request details from LiFi API
@@ -72,6 +75,7 @@ pub struct LifiQuote {
 }
 
 /// Lifi-specific quote execution data
+#[derive(Debug, Clone)]
 pub struct LifiQuoteExecutionData {
     /// The swap contract address
     pub to: Address,

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -1,11 +1,9 @@
 //! Venue-specific logic for getting quotes and executing swaps
 
-use alloy_primitives::U256;
-use renegade_common::types::{chain::Chain, token::Token};
-
-use crate::execution_client::venues::lifi::LifiQuoteExecutionData;
+use std::fmt::Display;
 
 pub mod lifi;
+pub mod quote;
 
 /// An enum used to specify supported execution venues
 pub enum SupportedExecutionVenue {
@@ -15,37 +13,11 @@ pub enum SupportedExecutionVenue {
     Cowswap,
 }
 
-/// The basic information included in an execution quote,
-/// agnostic of the venue that provided the quote
-pub struct ExecutionQuote {
-    /// The token being sold
-    pub sell_token: Token,
-    /// The token being bought
-    pub buy_token: Token,
-    /// The amount of the token being sold, in atoms
-    pub sell_amount: U256,
-    /// The quoted amount of the token being bought, in atoms
-    pub buy_amount: U256,
-    /// The venue that provided the quote
-    pub venue: SupportedExecutionVenue,
-    /// The chain for which the quote was generated
-    pub chain: Chain,
-}
-
-/// An enum wrapping the venue-specific auxiliary data needed to execute a quote
-pub enum QuoteExecutionData {
-    /// Lifi-specific quote execution data
-    Lifi(LifiQuoteExecutionData),
-    /// Cowswap-specific quote execution data
-    // TODO: Implement Cowswap quote execution data
-    Cowswap(),
-}
-
-/// An executable quote, which includes the basic quote information
-/// along with any auxiliary data needed to execute the quote
-pub struct ExecutableQuote {
-    /// The quote
-    pub quote: ExecutionQuote,
-    /// The venue-specific auxiliary data needed to execute the quote
-    pub execution_data: QuoteExecutionData,
+impl Display for SupportedExecutionVenue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SupportedExecutionVenue::Lifi => write!(f, "Lifi"),
+            SupportedExecutionVenue::Cowswap => write!(f, "Cowswap"),
+        }
+    }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
@@ -1,0 +1,166 @@
+//! Type definitions for execution quotes
+
+use alloy_primitives::U256;
+use funds_manager_api::{quoters::ApiExecutionQuote, u256_try_into_u128};
+use renegade_common::types::{chain::Chain, token::Token};
+
+use crate::execution_client::{
+    error::ExecutionClientError,
+    venues::{lifi::LifiQuoteExecutionData, SupportedExecutionVenue},
+};
+
+/// The basic information included in an execution quote,
+/// agnostic of the venue that provided the quote
+pub struct ExecutionQuote {
+    /// The token being sold
+    pub sell_token: Token,
+    /// The token being bought
+    pub buy_token: Token,
+    /// The amount of the token being sold, in atoms
+    pub sell_amount: U256,
+    /// The quoted amount of the token being bought, in atoms
+    pub buy_amount: U256,
+    /// The venue that provided the quote
+    pub venue: SupportedExecutionVenue,
+    /// The chain for which the quote was generated
+    pub chain: Chain,
+}
+
+impl ExecutionQuote {
+    /// Whether the quote is a sell order in Renegade terms
+    pub fn is_sell(&self) -> bool {
+        self.buy_token == Token::usdc()
+    }
+
+    /// Get the base token
+    pub fn base_token(&self) -> Token {
+        if self.is_sell() {
+            self.sell_token.clone()
+        } else {
+            self.buy_token.clone()
+        }
+    }
+
+    /// Get the base amount
+    pub fn base_amount(&self) -> u128 {
+        let amt_u256 = if self.is_sell() { self.sell_amount } else { self.buy_amount };
+        u256_try_into_u128(amt_u256).expect("Quote amount overflows u128")
+    }
+
+    /// Get the quote token
+    pub fn quote_token(&self) -> Token {
+        if self.is_sell() {
+            self.buy_token.clone()
+        } else {
+            self.sell_token.clone()
+        }
+    }
+
+    /// Get the quote amount
+    pub fn quote_amount(&self) -> u128 {
+        let amt_u256 = if self.is_sell() { self.buy_amount } else { self.sell_amount };
+        u256_try_into_u128(amt_u256).expect("Quote amount overflows u128")
+    }
+
+    /// Get the decimal-corrected quote amount, i.e. in whole units of the quote
+    /// token
+    pub fn quote_amount_decimal(&self) -> f64 {
+        let quote_amount = self.quote_amount();
+        self.quote_token().convert_to_decimal(quote_amount)
+    }
+
+    /// Get the decimal-corrected buy amount, i.e. in whole units of the buy
+    /// token
+    pub fn buy_amount_decimal(&self) -> f64 {
+        let buy_amount = u256_try_into_u128(self.buy_amount).expect("Buy amount overflows u128");
+        self.buy_token.convert_to_decimal(buy_amount)
+    }
+
+    /// Get the decimal-corrected sell amount, i.e. in whole units of the sell
+    /// token
+    pub fn sell_amount_decimal(&self) -> f64 {
+        let sell_amount = u256_try_into_u128(self.sell_amount).expect("Sell amount overflows u128");
+        self.sell_token.convert_to_decimal(sell_amount)
+    }
+
+    /// Get the price in units of USDC per base token.
+    /// If a custom buy amount is provided, it is used in place of the standard
+    /// buy amount.
+    pub fn get_price(&self, buy_amount: Option<U256>) -> f64 {
+        let buy_amount = u256_try_into_u128(buy_amount.unwrap_or(self.buy_amount))
+            .expect("Buy amount overflows u128");
+        let decimal_buy_amount = self.buy_token.convert_to_decimal(buy_amount);
+
+        let decimal_sell_amount = self.sell_amount_decimal();
+
+        let buy_per_sell = decimal_buy_amount / decimal_sell_amount;
+        if self.is_sell() {
+            buy_per_sell
+        } else {
+            1.0 / buy_per_sell
+        }
+    }
+
+    /// Returns the notional volume in USDC, taking into account the actual
+    /// buy amount for sell orders
+    pub fn notional_volume_usdc(&self, buy_amount_actual: U256) -> f64 {
+        if self.is_sell() {
+            let buy_amount =
+                u256_try_into_u128(buy_amount_actual).expect("Buy amount overflows u128");
+
+            self.buy_token.convert_to_decimal(buy_amount)
+        } else {
+            self.sell_amount_decimal()
+        }
+    }
+}
+
+impl From<ExecutionQuote> for ApiExecutionQuote {
+    fn from(value: ExecutionQuote) -> Self {
+        let sell_token_address = value.sell_token.addr;
+        let buy_token_address = value.buy_token.addr;
+        let sell_amount = value.sell_amount;
+        let buy_amount = value.buy_amount;
+        let venue = value.venue.to_string();
+
+        ApiExecutionQuote { sell_token_address, buy_token_address, sell_amount, buy_amount, venue }
+    }
+}
+
+/// An enum wrapping the venue-specific auxiliary data needed to execute a quote
+pub enum QuoteExecutionData {
+    /// Lifi-specific quote execution data
+    Lifi(LifiQuoteExecutionData),
+    /// Cowswap-specific quote execution data
+    // TODO: Implement Cowswap quote execution data
+    Cowswap(),
+}
+
+impl QuoteExecutionData {
+    /// "Unwraps" Lifi quote execution data, returning an error if it is not
+    /// the Lifi variant
+    pub fn lifi(&self) -> Result<LifiQuoteExecutionData, ExecutionClientError> {
+        match &self {
+            QuoteExecutionData::Lifi(data) => Ok(data.clone()),
+            _ => Err(ExecutionClientError::quote_conversion("Non-Lifi quote execution data")),
+        }
+    }
+
+    /// "Unwraps" Cowswap quote execution data, returning an error if it is not
+    /// the Cowswap variant
+    pub fn cowswap(self) -> Result<(), ExecutionClientError> {
+        match self {
+            QuoteExecutionData::Cowswap() => Ok(()),
+            _ => Err(ExecutionClientError::quote_conversion("Non-Cowswap quote execution data")),
+        }
+    }
+}
+
+/// An executable quote, which includes the basic quote information
+/// along with any auxiliary data needed to execute the quote
+pub struct ExecutableQuote {
+    /// The quote
+    pub quote: ExecutionQuote,
+    /// The venue-specific auxiliary data needed to execute the quote
+    pub execution_data: QuoteExecutionData,
+}

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -262,7 +262,7 @@ pub(crate) async fn swap_immediate_handler(
     };
 
     Ok(warp::reply::json(&SwapImmediateResponse {
-        quote: outcome.augmented_quote.quote.clone(),
+        quote: outcome.quote.into(),
         tx_hash: format!("{:#x}", outcome.receipt.transaction_hash),
         execution_cost,
     }))
@@ -300,7 +300,7 @@ pub(crate) async fn swap_into_target_token_handler(
         };
 
         responses.push(SwapImmediateResponse {
-            quote: outcome.augmented_quote.quote.clone(),
+            quote: outcome.quote.into(),
             tx_hash: format!("{:#x}", outcome.receipt.transaction_hash),
             execution_cost,
         });

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -1,9 +1,8 @@
 //! Defines functionality to compute and record data for swap execution
 
 use alloy::rpc::types::TransactionReceipt;
-use alloy_primitives::{Address, Log, TxHash, U256};
-use alloy_sol_types::SolEvent;
-use funds_manager_api::{quoters::AugmentedExecutionQuote, u256_try_into_u128};
+use alloy_primitives::{Address, TxHash, U256};
+use funds_manager_api::u256_try_into_u128;
 use renegade_common::types::{chain::Chain, token::Token};
 use renegade_darkpool_client::conversion::u256_to_amount;
 use serde::Serialize;
@@ -12,11 +11,12 @@ use tracing::{info, warn};
 use super::MetricsRecorder;
 use crate::{
     error::FundsManagerError,
-    execution_client::swap::SwapOutcome,
-    helpers::{to_env_agnostic_name, IERC20::Transfer},
+    execution_client::{swap::SwapOutcome, venues::quote::ExecutionQuote},
+    helpers::to_env_agnostic_name,
     metrics::labels::{
         ASSET_TAG, CHAIN_TAG, HASH_TAG, SWAP_EXECUTION_COST_METRIC_NAME, SWAP_GAS_COST_METRIC_NAME,
         SWAP_NOTIONAL_VOLUME_METRIC_NAME, SWAP_RELATIVE_SPREAD_METRIC_NAME, TRADE_SIDE_FACTOR_TAG,
+        VENUE_TAG,
     },
 };
 
@@ -32,12 +32,6 @@ pub struct SwapExecutionData {
     pub sell_amount: String,
     /// The estimated amount of tokens to be received
     pub buy_amount_estimated: String,
-    /// The minimum amount of tokens to be received
-    pub buy_amount_min: String,
-    /// The address initiating the swap
-    pub from_address: String,
-    /// The address receiving the swap
-    pub to_address: String,
     /// Whether the swap is a buy or sell
     pub is_buy: bool,
 
@@ -60,14 +54,12 @@ pub struct SwapExecutionData {
     pub execution_cost_usdc: f64,
     /// The gas cost of execution in USD
     pub gas_cost_usd: f64,
+    /// The venue that executed the swap
+    pub venue: String,
 
     // Slippage information
-    /// The slippage budget (difference between estimated and minimum)
-    pub slippage_budget: f64,
     /// The difference between estimated and actual amount received
     pub received_delta: f64,
-    /// The percentage of slippage budget consumed
-    pub slippage_consumption_percent: f64,
 }
 
 // --------------------
@@ -89,11 +81,7 @@ impl MetricsRecorder {
         };
 
         // Record metrics from the cost data
-        self.record_metrics_from_cost_data(
-            &swap_outcome.receipt,
-            &swap_outcome.augmented_quote,
-            &cost_data,
-        );
+        self.record_metrics_from_cost_data(&swap_outcome.receipt, &swap_outcome.quote, &cost_data);
         self.log_swap_cost_data(&cost_data, swap_outcome.receipt.transaction_hash);
 
         Ok(cost_data)
@@ -110,57 +98,42 @@ impl MetricsRecorder {
         &self,
         swap_outcome: &SwapOutcome,
     ) -> Result<SwapExecutionData, FundsManagerError> {
-        let SwapOutcome { augmented_quote: quote, receipt, cumulative_gas_cost: swap_gas_cost } =
+        let SwapOutcome { quote, buy_amount_actual, receipt, cumulative_gas_cost: swap_gas_cost } =
             swap_outcome;
 
-        let base_mint = quote.get_base_token().get_alloy_address();
+        let base_mint = quote.base_token().get_alloy_address();
         let binance_price = self.get_price(&base_mint, quote.chain).await?;
 
-        let buy_mint = quote.get_buy_token().get_alloy_address();
-        let buy_amount_actual = self.get_buy_amount_actual(receipt, buy_mint, quote.quote.from)?;
-
-        let execution_price =
-            quote.get_price(Some(buy_amount_actual)).map_err(FundsManagerError::parse)?;
+        let execution_price = quote.get_price(Some(*buy_amount_actual));
         let gas_cost_usd = self.get_wei_cost_usdc(*swap_gas_cost).await?;
-        let notional_volume_usdc =
-            quote.notional_volume_usdc(buy_amount_actual).map_err(FundsManagerError::parse)?;
+        let notional_volume_usdc = quote.notional_volume_usdc(*buy_amount_actual);
 
-        let trade_side_factor = if quote.is_buy() { 1.0 } else { -1.0 };
+        let trade_side_factor = if quote.is_sell() { -1.0 } else { 1.0 };
         let relative_spread = trade_side_factor * (execution_price - binance_price) / binance_price;
         let execution_cost_usdc = notional_volume_usdc * relative_spread;
 
         // Calculate slippage metrics
-        let decimal_corrected_buy_amount_estimated =
-            quote.get_decimal_corrected_buy_amount().map_err(FundsManagerError::parse)?;
-        let decimal_corrected_buy_amount_min =
-            quote.get_decimal_corrected_buy_amount_min().map_err(FundsManagerError::parse)?;
+        let decimal_corrected_buy_amount_estimated = quote.buy_amount_decimal();
 
         let buy_amount_actual =
-            u256_try_into_u128(buy_amount_actual).map_err(FundsManagerError::parse)?;
+            u256_try_into_u128(*buy_amount_actual).map_err(FundsManagerError::parse)?;
+
         let decimal_corrected_buy_amount_actual =
-            quote.get_buy_token().convert_to_decimal(buy_amount_actual);
+            quote.buy_token.convert_to_decimal(buy_amount_actual);
 
-        let sell_amount =
-            quote.get_decimal_corrected_sell_amount().map_err(FundsManagerError::parse)?;
+        let sell_amount = quote.sell_amount_decimal();
 
-        let slippage_budget =
-            decimal_corrected_buy_amount_estimated - decimal_corrected_buy_amount_min;
         let received_delta =
             decimal_corrected_buy_amount_estimated - decimal_corrected_buy_amount_actual;
-        let slippage_consumption_percent =
-            if slippage_budget > 0.0 { (received_delta / slippage_budget) * 100.0 } else { 0.0 };
 
         // Create and return the unified cost data
         Ok(SwapExecutionData {
             // Token information
-            buy_token_address: quote.get_buy_token_address(),
-            sell_token_address: quote.get_sell_token_address(),
+            buy_token_address: quote.buy_token.addr.clone(),
+            sell_token_address: quote.sell_token.addr.clone(),
             sell_amount: sell_amount.to_string(),
             buy_amount_estimated: decimal_corrected_buy_amount_estimated.to_string(),
-            buy_amount_min: decimal_corrected_buy_amount_min.to_string(),
-            from_address: quote.get_from_address(),
-            to_address: quote.get_to_address(),
-            is_buy: quote.is_buy(),
+            is_buy: !quote.is_sell(),
 
             // Market reference data
             binance_price,
@@ -173,11 +146,10 @@ impl MetricsRecorder {
             relative_spread,
             execution_cost_usdc,
             gas_cost_usd,
+            venue: quote.venue.to_string(),
 
             // Slippage information
-            slippage_budget,
             received_delta,
-            slippage_consumption_percent,
         })
     }
 
@@ -185,7 +157,7 @@ impl MetricsRecorder {
     fn record_metrics_from_cost_data(
         &self,
         receipt: &TransactionReceipt,
-        quote: &AugmentedExecutionQuote,
+        quote: &ExecutionQuote,
         cost_data: &SwapExecutionData,
     ) {
         let labels = self.get_labels(quote, receipt);
@@ -201,12 +173,13 @@ impl MetricsRecorder {
     /// Derive the labels given a quote and a transaction receipt
     fn get_labels(
         &self,
-        quote: &AugmentedExecutionQuote,
+        quote: &ExecutionQuote,
         receipt: &TransactionReceipt,
     ) -> Vec<(String, String)> {
-        let mint = format!("{:#x}", quote.get_base_token().get_alloy_address());
-        let asset = quote.get_base_token().get_ticker().unwrap_or(mint);
-        let side_label = if quote.is_buy() { "buy" } else { "sell" };
+        let base_token = quote.base_token();
+        let mint = format!("{:#x}", base_token.get_alloy_address());
+        let asset = base_token.get_ticker().unwrap_or(mint);
+        let side_label = if quote.is_sell() { "sell" } else { "buy" };
         let chain = to_env_agnostic_name(self.chain);
 
         vec![
@@ -214,31 +187,8 @@ impl MetricsRecorder {
             (TRADE_SIDE_FACTOR_TAG.to_string(), side_label.to_string()),
             (HASH_TAG.to_string(), format!("{:#x}", receipt.transaction_hash)),
             (CHAIN_TAG.to_string(), chain),
+            (VENUE_TAG.to_string(), quote.venue.to_string()),
         ]
-    }
-
-    /// Extract the transfer amount from a transaction receipt
-    fn get_buy_amount_actual(
-        &self,
-        receipt: &TransactionReceipt,
-        mint: Address,
-        recipient: Address,
-    ) -> Result<U256, FundsManagerError> {
-        let logs: Vec<Log<Transfer>> = receipt
-            .logs()
-            .iter()
-            .filter_map(|log| {
-                if log.address() != mint {
-                    None
-                } else {
-                    Transfer::decode_log(&log.inner).ok()
-                }
-            })
-            .collect();
-
-        logs.iter()
-            .find_map(|transfer| if transfer.to == recipient { Some(transfer.value) } else { None })
-            .ok_or(FundsManagerError::on_chain("no matching transfer event found"))
     }
 
     /// Get the price for a token
@@ -269,9 +219,6 @@ impl MetricsRecorder {
             sell_token_address = %cost_data.sell_token_address,
             sell_amount = %cost_data.sell_amount,
             buy_amount_estimated = %cost_data.buy_amount_estimated,
-            buy_amount_min = %cost_data.buy_amount_min,
-            from_address = %cost_data.from_address,
-            to_address = %cost_data.to_address,
             is_buy = %cost_data.is_buy,
             binance_price = %cost_data.binance_price,
             transaction_hash = %cost_data.transaction_hash,
@@ -281,10 +228,9 @@ impl MetricsRecorder {
             notional_volume_usdc = %cost_data.notional_volume_usdc,
             relative_spread = %cost_data.relative_spread,
             execution_cost_usdc = %cost_data.execution_cost_usdc,
-            slippage_budget = %cost_data.slippage_budget,
             received_delta = %cost_data.received_delta,
-            slippage_consumption_percent = %cost_data.slippage_consumption_percent,
             chain = %to_env_agnostic_name(self.chain),
+            venue = %cost_data.venue,
             "Swap recorded for tx {tx_hash:#x}");
     }
 }

--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -23,3 +23,6 @@ pub const HASH_TAG: &str = "hash";
 
 /// Metric tag for the (environment-agnostic) chain name
 pub const CHAIN_TAG: &str = "chain";
+
+/// Metric tag for the venue that executed a swap
+pub const VENUE_TAG: &str = "venue";


### PR DESCRIPTION
This PR completes porting over the current execution stack (Lifi-only) to using the new `ExecutionQuote` and `ExecutableQuote` types. This includes some refactoring, notably:
1. I removed the `AugmentedExecutionQuote` type, and moved its helper methods to `ExecutionQuote`. This involved some deduplication of adjacent methods on the old `ExecutionQuote` struct
2. I removed some fields from the `SwapCostData` struct, as they were not relied on in practice, and the fields from which they are computed no longer exist on the new `ExecutionQuote` struct, i.e. are not venue-agnostic.
3. I moved the calculation of `buy_amount_actual` from the `MetricsRecorder` to the `ExecutionClient`. This is largely for ergonomics, since execution venues may expose different ways to determine this amount. For example, Cowswap has a `/trades` endpoint that will report the actual buy amount on a trade instead of having to infer it from the TX logs

### Testing
- [x] Test swaps on local funds manager, assert that metrics and logs line up with what's expected