### PR TITLE
funds-manager: execution_client: venues: cowswap: add API type definitions

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/api_types.rs
@@ -1,0 +1,168 @@
+//! Cowswap API type definitions.
+//! See: <https://docs.cow.fi/cow-protocol/reference/apis/orderbook>
+
+use alloy_primitives::U256;
+use serde::{Deserialize, Serialize};
+
+use funds_manager_api::serialization::u256_string_serialization;
+
+/// The kind of order to request a Cowswap quote for.
+///
+/// We only support sell orders, to maintain the convention
+/// of specifying a sell amount in the quote request.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum OrderKind {
+    /// A sell order
+    Sell,
+}
+
+/// The scheme used to sign an order.
+///
+/// We only support EIP-712 signatures.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum SigningScheme {
+    /// EIP-712 signatures
+    Eip712,
+}
+
+/// The subset of Cowswap quote request parameters that we support
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OrderQuoteRequest {
+    /// The address of the token being sold, as a hex string
+    sell_token: String,
+    /// The address of the token being bought, as a hex string
+    buy_token: String,
+    /// The sending wallet address, as a hex string
+    from: String,
+    /// The kind of order (buy/sell) to request a quote for.
+    ///
+    /// In our case, this should *always* be a sell order, such that
+    /// we specify a sell amount as opposed to a buy amount.
+    kind: OrderKind,
+    /// The amount of the token being sold.
+    ///
+    /// Fees are deducted from this value.
+    #[serde(with = "u256_string_serialization")]
+    sell_amount_before_fee: U256,
+    // TODO: Add `app_data` and `app_data_hash` fields,
+    // which will be used to specify slippage tolerance.
+}
+
+/// The parameters of an order that was quoted
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OrderParameters {
+    /// The address of the token being sold, as a hex string
+    sell_token: String,
+    /// The address of the token being bought, as a hex string
+    buy_token: String,
+    /// The amount of the token being sold
+    #[serde(with = "u256_string_serialization")]
+    sell_amount: U256,
+    /// The amount of the token being bought
+    #[serde(with = "u256_string_serialization")]
+    buy_amount: U256,
+    /// The Unix timestamp until which the order is valid
+    valid_to: u32,
+    /// Amount of sell token (in atoms) used to cover network fees.
+    ///
+    /// Needs to be zero (and incorporated into the limit price) when placing
+    /// the order.
+    #[serde(with = "u256_string_serialization")]
+    fee_amount: U256,
+    /// The kind of quote requested.
+    kind: OrderKind,
+    /// Whether the order is partially fillable (otherwise, fill-or-kill)
+    partially_fillable: bool,
+}
+
+/// The parameters of an order that was quoted,
+/// augmented with the *hash* of the `app_data` that was used to request the
+/// quote.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OrderParametersWithAppData {
+    /// The parameters of the order
+    #[serde(flatten)]
+    order: OrderParameters,
+    /// Hex-encoded keccak-256 hash of the `app_data` that the quote
+    /// was requested with.
+    ///
+    /// NOTE: Until we implement specifying `app_data` ourselves, we expect this
+    /// to be
+    /// `0xb48d38f93eaa084033fc5970bf96e559c33c4cdc07d889ab00b4d63f9590739d`,
+    /// the keccak-256 hash of `"{}"`.
+    app_data: String,
+}
+
+/// The response to a Cowswap quote request
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OrderQuoteResponse {
+    /// The parameters of the order that was quoted
+    quote: OrderParametersWithAppData,
+    /// ISO-8601 string represeneting the expiration date of the offered fee.
+    expiration: String,
+    /// The ID of the quote
+    id: u64,
+    /// Whether the quoted amounts were simulated
+    verified: bool,
+}
+
+/// Data required to create an order on Cowswap
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OrderCreation {
+    /// The parameters of the order to create
+    #[serde(flatten)]
+    order: OrderParameters,
+    /// The signature of the order
+    signing_scheme: SigningScheme,
+    /// The EIP-712 signature over the order.
+    ///
+    /// Concretely, the hex-encoded `r || s || v` values, totaling 65 bytes.
+    // TODO: Determine if `v` is expected to be 0/1 or 27/28.
+    signature: String,
+    /// A string encoding of the JSON `app_data` that was used to request the
+    /// quote.
+    ///
+    /// The UTF-8 encoding of this string must be the preimage of the `app_data`
+    /// hash in the quote response.
+    ///
+    /// NOTE: Until we implement specifying `app_data` ourselves, we will set
+    /// this to "{}".
+    app_data: String,
+}
+
+/// A trade that was executed on Cowswap
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Trade {
+    /// The block number at which the trade was executed
+    block_number: u64,
+    /// The index within the block at which the transaction containing the trade
+    /// was included
+    log_index: u64,
+    /// UID of the order matched by this trade, as a hex string
+    order_uid: String,
+    /// The address of the trader, as a hex string
+    owner: String,
+    /// The address of the token being sold, as a hex string
+    sell_token: String,
+    /// The address of the token being bought, as a hex string
+    buy_token: String,
+    /// The amount sold in this trade, including fees
+    #[serde(with = "u256_string_serialization")]
+    sell_amount: U256,
+    /// The amount sold in this trade, without fees
+    #[serde(with = "u256_string_serialization")]
+    sell_amount_before_fees: U256,
+    /// The amount bought in this trade
+    #[serde(with = "u256_string_serialization")]
+    buy_amount: U256,
+    /// The hash of the transaction in which this trade was settled
+    tx_hash: String,
+}

--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
@@ -4,9 +4,10 @@ use alloy_primitives::Address;
 use renegade_common::types::chain::Chain;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tracing::error;
 
 use crate::{execution_client::error::ExecutionClientError, helpers::handle_http_response};
+
+pub mod api_types;
 
 // -------------
 // | Constants |

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/api_types.rs
@@ -1,0 +1,175 @@
+//! Lifi API type definitions
+
+use alloy_primitives::{Address, Bytes, U256};
+use renegade_common::types::{chain::Chain, token::Token};
+use serde::{Deserialize, Serialize};
+
+use funds_manager_api::serialization::u256_string_serialization;
+
+use crate::execution_client::error::ExecutionClientError;
+
+/// The subset of Lifi quote request query parameters that we support
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LifiQuoteParams {
+    /// The token that should be transferred. Can be the address or the symbol
+    pub from_token: String,
+    /// The token that should be transferred to. Can be the address or the
+    /// symbol
+    pub to_token: String,
+    /// The amount that should be sent including all decimals (e.g. 1000000 for
+    /// 1 USDC (6 decimals))
+    #[serde(with = "u256_string_serialization")]
+    pub from_amount: U256,
+    /// The sending wallet address
+    pub from_address: String,
+    /// The receiving wallet address. If none is provided, the fromAddress will
+    /// be used
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_address: Option<String>,
+    /// The ID of the sending chain
+    pub from_chain: usize,
+    /// The ID of the receiving chain
+    pub to_chain: usize,
+    /// The maximum allowed slippage for the transaction as a decimal value.
+    /// 0.005 represents 0.5%.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slippage: Option<f64>,
+    /// The maximum price impact for the transaction
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_price_impact: Option<f64>,
+    /// Timing setting to wait for a certain amount of swap rates. In the format
+    /// minWaitTime-${minWaitTimeMs}-${startingExpectedResults}-${reduceEveryMs}.
+    /// Please check docs.li.fi for more details.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub swap_step_timing_strategies: Option<Vec<String>>,
+    /// Which kind of route should be preferred
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
+    /// Parameter to skip transaction simulation. The quote will be returned
+    /// faster but the transaction gas limit won't be accurate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_simulation: Option<bool>,
+    /// List of exchanges that are allowed for this transaction
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_exchanges: Option<Vec<String>>,
+    /// List of exchanges that are not allowed for this transaction
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny_exchanges: Option<Vec<String>>,
+}
+
+/// Transaction request details from LiFi API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LifiTransactionRequest {
+    /// Destination contract address
+    to: String,
+    /// Hex-encoded calldata for the transaction
+    data: String,
+    /// Amount of native token to send (in hex)
+    value: String,
+    /// Gas limit in hex
+    gas_limit: String,
+}
+
+/// Quote estimate details from LiFi API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Estimate {
+    /// Amount of tokens to sell (including decimals)
+    from_amount: String,
+    /// Amount of tokens to receive (including decimals)
+    to_amount: String,
+}
+
+/// Token information from LiFi API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LifiToken {
+    /// Token contract address
+    address: String,
+}
+
+/// Swap action details from LiFi API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Action {
+    /// Token being sold
+    from_token: LifiToken,
+    /// Token being bought
+    to_token: LifiToken,
+    /// Address initiating the swap
+    from_address: String,
+}
+
+/// Raw quote response structure from LiFi API
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LifiQuote {
+    /// Transaction request details
+    transaction_request: LifiTransactionRequest,
+    /// Quote estimate details
+    estimate: Estimate,
+    /// Swap action details
+    action: Action,
+    /// Tool (venue) providing the route
+    tool: String,
+}
+
+impl LifiQuote {
+    /// Get the token being sold
+    pub fn get_sell_token(&self, chain: Chain) -> Token {
+        Token::from_addr_on_chain(&self.action.from_token.address, chain)
+    }
+
+    /// Get the token being bought
+    pub fn get_buy_token(&self, chain: Chain) -> Token {
+        Token::from_addr_on_chain(&self.action.to_token.address, chain)
+    }
+
+    /// Get the amount of tokens being sold
+    pub fn get_sell_amount(&self) -> Result<U256, ExecutionClientError> {
+        U256::from_str_radix(&self.estimate.from_amount, 10)
+            .map_err(ExecutionClientError::quote_conversion)
+    }
+
+    /// Get the amount of tokens being bought
+    pub fn get_buy_amount(&self) -> Result<U256, ExecutionClientError> {
+        U256::from_str_radix(&self.estimate.to_amount, 10)
+            .map_err(ExecutionClientError::quote_conversion)
+    }
+
+    /// Get the address of the swap contract that will be called
+    pub fn get_to_address(&self) -> Result<Address, ExecutionClientError> {
+        self.transaction_request.to.parse().map_err(ExecutionClientError::quote_conversion)
+    }
+
+    /// Get the address of the submitting address
+    pub fn get_from_address(&self) -> Result<Address, ExecutionClientError> {
+        self.action.from_address.parse().map_err(ExecutionClientError::quote_conversion)
+    }
+
+    /// Get the value of the tx; should be zero
+    pub fn get_value(&self) -> Result<U256, ExecutionClientError> {
+        U256::from_str_radix(self.transaction_request.value.trim_start_matches("0x"), 16)
+            .map_err(ExecutionClientError::quote_conversion)
+    }
+
+    /// Get the calldata for the swap
+    pub fn get_data(&self) -> Result<Bytes, ExecutionClientError> {
+        hex::decode(self.transaction_request.data.trim_start_matches("0x"))
+            .map_err(ExecutionClientError::quote_conversion)
+            .map(Bytes::from)
+    }
+
+    /// Get the gas limit for the swap
+    pub fn get_gas_limit(&self) -> Result<U256, ExecutionClientError> {
+        U256::from_str_radix(self.transaction_request.gas_limit.trim_start_matches("0x"), 16)
+            .map_err(ExecutionClientError::quote_conversion)
+    }
+
+    /// Get the tool (venue) providing the route
+    pub fn get_tool(&self) -> String {
+        self.tool.clone()
+    }
+}

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -14,18 +14,17 @@ use alloy::{
 use alloy_primitives::{Address, Bytes, Log, U256};
 use alloy_sol_types::SolEvent;
 use async_trait::async_trait;
-use funds_manager_api::{
-    quoters::QuoteParams, serialization::u256_string_serialization, u256_try_into_u64,
-};
-use renegade_common::types::{chain::Chain, token::Token};
+use funds_manager_api::{quoters::QuoteParams, u256_try_into_u64};
+use renegade_common::types::chain::Chain;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::{info, instrument, warn};
 
 use crate::{
     execution_client::{
         error::ExecutionClientError,
         venues::{
+            lifi::api_types::{LifiQuote, LifiQuoteParams},
             quote::{ExecutableQuote, ExecutionQuote, QuoteExecutionData},
             ExecutionResult, ExecutionVenue, SupportedExecutionVenue,
         },
@@ -35,6 +34,8 @@ use crate::{
         to_chain_id, IERC20::Transfer, ONE_CONFIRMATION,
     },
 };
+
+pub mod api_types;
 
 // -------------
 // | Constants |
@@ -84,172 +85,6 @@ const DEFAULT_DENIED_EXCHANGES: [&str; 1] = ["sushiswap"];
 // ---------
 // | Types |
 // ---------
-
-/// The subset of Lifi quote request query parameters that we support
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct LifiQuoteParams {
-    /// The token that should be transferred. Can be the address or the symbol
-    pub from_token: String,
-    /// The token that should be transferred to. Can be the address or the
-    /// symbol
-    pub to_token: String,
-    /// The amount that should be sent including all decimals (e.g. 1000000 for
-    /// 1 USDC (6 decimals))
-    #[serde(with = "u256_string_serialization")]
-    pub from_amount: U256,
-    /// The sending wallet address
-    pub from_address: String,
-    /// The receiving wallet address. If none is provided, the fromAddress will
-    /// be used
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub to_address: Option<String>,
-    /// The ID of the sending chain
-    pub from_chain: usize,
-    /// The ID of the receiving chain
-    pub to_chain: usize,
-    /// The maximum allowed slippage for the transaction as a decimal value.
-    /// 0.005 represents 0.5%.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub slippage: Option<f64>,
-    /// The maximum price impact for the transaction
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_price_impact: Option<f64>,
-    /// Timing setting to wait for a certain amount of swap rates. In the format
-    /// minWaitTime-${minWaitTimeMs}-${startingExpectedResults}-${reduceEveryMs}.
-    /// Please check docs.li.fi for more details.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub swap_step_timing_strategies: Option<Vec<String>>,
-    /// Which kind of route should be preferred
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub order: Option<String>,
-    /// Parameter to skip transaction simulation. The quote will be returned
-    /// faster but the transaction gas limit won't be accurate.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub skip_simulation: Option<bool>,
-    /// List of exchanges that are allowed for this transaction
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub allow_exchanges: Option<Vec<String>>,
-    /// List of exchanges that are not allowed for this transaction
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deny_exchanges: Option<Vec<String>>,
-}
-
-/// Transaction request details from LiFi API
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct LifiTransactionRequest {
-    /// Destination contract address
-    to: String,
-    /// Hex-encoded calldata for the transaction
-    data: String,
-    /// Amount of native token to send (in hex)
-    value: String,
-    /// Gas limit in hex
-    gas_limit: String,
-}
-
-/// Quote estimate details from LiFi API
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Estimate {
-    /// Amount of tokens to sell (including decimals)
-    from_amount: String,
-    /// Amount of tokens to receive (including decimals)
-    to_amount: String,
-}
-
-/// Token information from LiFi API
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct LifiToken {
-    /// Token contract address
-    address: String,
-}
-
-/// Swap action details from LiFi API
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Action {
-    /// Token being sold
-    from_token: LifiToken,
-    /// Token being bought
-    to_token: LifiToken,
-    /// Address initiating the swap
-    from_address: String,
-}
-
-/// Raw quote response structure from LiFi API
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct LifiQuote {
-    /// Transaction request details
-    transaction_request: LifiTransactionRequest,
-    /// Quote estimate details
-    estimate: Estimate,
-    /// Swap action details
-    action: Action,
-    /// Tool (venue) providing the route
-    tool: String,
-}
-
-impl LifiQuote {
-    /// Get the token being sold
-    fn get_sell_token(&self, chain: Chain) -> Token {
-        Token::from_addr_on_chain(&self.action.from_token.address, chain)
-    }
-
-    /// Get the token being bought
-    fn get_buy_token(&self, chain: Chain) -> Token {
-        Token::from_addr_on_chain(&self.action.to_token.address, chain)
-    }
-
-    /// Get the amount of tokens being sold
-    fn get_sell_amount(&self) -> Result<U256, ExecutionClientError> {
-        U256::from_str_radix(&self.estimate.from_amount, 10)
-            .map_err(ExecutionClientError::quote_conversion)
-    }
-
-    /// Get the amount of tokens being bought
-    fn get_buy_amount(&self) -> Result<U256, ExecutionClientError> {
-        U256::from_str_radix(&self.estimate.to_amount, 10)
-            .map_err(ExecutionClientError::quote_conversion)
-    }
-
-    /// Get the address of the swap contract that will be called
-    fn get_to_address(&self) -> Result<Address, ExecutionClientError> {
-        self.transaction_request.to.parse().map_err(ExecutionClientError::quote_conversion)
-    }
-
-    /// Get the address of the submitting address
-    fn get_from_address(&self) -> Result<Address, ExecutionClientError> {
-        self.action.from_address.parse().map_err(ExecutionClientError::quote_conversion)
-    }
-
-    /// Get the value of the tx; should be zero
-    fn get_value(&self) -> Result<U256, ExecutionClientError> {
-        U256::from_str_radix(self.transaction_request.value.trim_start_matches("0x"), 16)
-            .map_err(ExecutionClientError::quote_conversion)
-    }
-
-    /// Get the calldata for the swap
-    fn get_data(&self) -> Result<Bytes, ExecutionClientError> {
-        hex::decode(self.transaction_request.data.trim_start_matches("0x"))
-            .map_err(ExecutionClientError::quote_conversion)
-            .map(Bytes::from)
-    }
-
-    /// Get the gas limit for the swap
-    fn get_gas_limit(&self) -> Result<U256, ExecutionClientError> {
-        U256::from_str_radix(self.transaction_request.gas_limit.trim_start_matches("0x"), 16)
-            .map_err(ExecutionClientError::quote_conversion)
-    }
-
-    /// Get the tool (venue) providing the route
-    fn get_tool(&self) -> String {
-        self.tool.clone()
-    }
-}
 
 /// Lifi-specific quote execution data
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR adds definitions for Cowswap API types involved in getting quotes, creating orders, and querying trades on orders. None of these types are used yet, as such the fields on them may get pared down further as I implement the associated functionality.