### PR TITLE
prover-service: prover: Add endpoint handler structure

### DIFF
--- a/prover-service/server/src/error.rs
+++ b/prover-service/server/src/error.rs
@@ -15,6 +15,8 @@ pub enum ProverServiceError {
     Setup(String),
 }
 
+impl warp::reject::Reject for ProverServiceError {}
+
 impl ProverServiceError {
     // --- Constructors --- //
 

--- a/prover-service/server/src/main.rs
+++ b/prover-service/server/src/main.rs
@@ -14,6 +14,7 @@ use http::StatusCode;
 use tracing::{error, info, info_span};
 use warp::{
     Filter,
+    filters::body::BodyDeserializeError,
     reject::Rejection,
     reply::{Json, Reply, WithStatus},
 };
@@ -21,10 +22,17 @@ use warp::{
 use crate::{
     cli::Cli,
     error::{ProverServiceError, json_error},
+    prover::{
+        handle_valid_commitments, handle_valid_fee_redemption,
+        handle_valid_malleable_match_settle_atomic, handle_valid_match_settle,
+        handle_valid_match_settle_atomic, handle_valid_offline_fee_settlement,
+        handle_valid_reblind, handle_valid_wallet_create, handle_valid_wallet_update,
+    },
 };
 
 mod cli;
 mod error;
+mod prover;
 
 /// Entrypoint
 #[tokio::main]
@@ -48,7 +56,72 @@ fn setup_routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + C
         .and(warp::get())
         .map(|| warp::reply::with_status("PONG", StatusCode::OK));
 
-    ping.with(with_tracing()).recover(handle_rejection)
+    // Prove valid wallet create
+    let valid_wallet_create = warp::path("prove-valid-wallet-create")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_wallet_create);
+
+    // Prove valid wallet update
+    let valid_wallet_update = warp::path("prove-valid-wallet-update")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_wallet_update);
+
+    // Prove valid commitments
+    let valid_commitments = warp::path("prove-valid-commitments")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_commitments);
+
+    // Prove valid reblind
+    let valid_reblind = warp::path("prove-valid-reblind")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_reblind);
+
+    // Prove valid match settle
+    let valid_match_settle = warp::path("prove-valid-match-settle")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_match_settle);
+
+    // Prove valid match settle atomic
+    let valid_match_settle_atomic = warp::path("prove-valid-match-settle-atomic")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_match_settle_atomic);
+
+    // Prove valid malleable match settle atomic
+    let valid_malleable_match_settle_atomic =
+        warp::path("prove-valid-malleable-match-settle-atomic")
+            .and(warp::post())
+            .and(warp::body::json())
+            .and_then(handle_valid_malleable_match_settle_atomic);
+
+    // Prove valid fee redemption
+    let valid_fee_redemption = warp::path("prove-valid-fee-redemption")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_fee_redemption);
+
+    // Prove valid offline fee settlement
+    let valid_offline_fee_settlement = warp::path("prove-valid-offline-fee-settlement")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_valid_offline_fee_settlement);
+
+    ping.or(valid_wallet_create)
+        .or(valid_wallet_update)
+        .or(valid_commitments)
+        .or(valid_reblind)
+        .or(valid_match_settle)
+        .or(valid_match_settle_atomic)
+        .or(valid_malleable_match_settle_atomic)
+        .or(valid_fee_redemption)
+        .or(valid_offline_fee_settlement)
+        .with(with_tracing())
+        .recover(handle_rejection)
 }
 
 // --- Middleware --- //
@@ -73,6 +146,8 @@ fn with_tracing() -> warp::trace::Trace<impl Fn(warp::trace::Info) -> tracing::S
 async fn handle_rejection(err: Rejection) -> Result<WithStatus<Json>, Rejection> {
     let reply = if let Some(api_error) = err.find::<ProverServiceError>() {
         api_error.to_reply()
+    } else if let Some(err) = err.find::<BodyDeserializeError>() {
+        json_error(&err.to_string(), StatusCode::BAD_REQUEST)
     } else if err.is_not_found() {
         json_error("Not Found", StatusCode::NOT_FOUND)
     } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {

--- a/prover-service/server/src/prover.rs
+++ b/prover-service/server/src/prover.rs
@@ -1,0 +1,91 @@
+//! The prover service implementation
+
+// ---------------------
+// | Endpoint Handlers |
+// ---------------------
+
+use prover_service_api::{
+    ValidCommitmentsRequest, ValidFeeRedemptionRequest, ValidMalleableMatchSettleAtomicRequest,
+    ValidMatchSettleAtomicRequest, ValidMatchSettleRequest, ValidOfflineFeeSettlementRequest,
+    ValidReblindRequest, ValidWalletCreateRequest, ValidWalletUpdateRequest,
+};
+use warp::{reject::Rejection, reply::Json};
+
+/// Handle a request to prove `VALID WALLET CREATE`
+pub(crate) async fn handle_valid_wallet_create(
+    request: ValidWalletCreateRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-wallet-create"
+    })))
+}
+
+/// Handle a request to prove `VALID WALLET UPDATE`
+pub(crate) async fn handle_valid_wallet_update(
+    request: ValidWalletUpdateRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-wallet-update"
+    })))
+}
+
+/// Handle a request to prove `VALID COMMITMENTS`
+pub(crate) async fn handle_valid_commitments(
+    request: ValidCommitmentsRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-commitments"
+    })))
+}
+
+/// Handle a request to prove `VALID REBLIND`
+pub(crate) async fn handle_valid_reblind(request: ValidReblindRequest) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-reblind"
+    })))
+}
+
+/// Handle a request to prove `VALID MATCH SETTLE`
+pub(crate) async fn handle_valid_match_settle(
+    request: ValidMatchSettleRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-match-settle"
+    })))
+}
+
+/// Handle a request to prove `VALID MATCH SETTLE ATOMIC`
+pub(crate) async fn handle_valid_match_settle_atomic(
+    request: ValidMatchSettleAtomicRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-match-settle-atomic"
+    })))
+}
+
+/// Handle a request to prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
+pub(crate) async fn handle_valid_malleable_match_settle_atomic(
+    request: ValidMalleableMatchSettleAtomicRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-malleable-match-settle-atomic"
+    })))
+}
+
+/// Handle a request to prove `VALID FEE REDEMPTION`
+pub(crate) async fn handle_valid_fee_redemption(
+    request: ValidFeeRedemptionRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-fee-redemption"
+    })))
+}
+
+/// Handle a request to prove `VALID OFFLINE FEE SETTLEMENT`
+pub(crate) async fn handle_valid_offline_fee_settlement(
+    request: ValidOfflineFeeSettlementRequest,
+) -> Result<Json, Rejection> {
+    Ok(warp::reply::json(&serde_json::json!({
+        "msg": "valid-offline-fee-settlement"
+    })))
+}


### PR DESCRIPTION
### Purpose
This PR adds the endpoint handler structure for the prover service. This has one endpoint per proof that will be generated.

### Todo
- Add auth, we'll use HTTP basic auth for this service

### Testing
- [x] Tested locally