### PR TITLE
funds-manager: execution_client: port over misc fixes

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -80,6 +80,12 @@ impl ExecutionClient {
     ) -> Result<Option<DecayingSwapOutcome>, ExecutionClientError> {
         let mut cumulative_gas_cost = U256::ZERO;
         loop {
+            // The from amount may have decayed to zero,
+            // in which case fetching a quote is impossible
+            if params.from_amount == U256::ZERO {
+                return Ok(None);
+            }
+
             let executable_quote = self.get_best_quote(params.clone()).await?;
             let quote_amount = executable_quote.quote.quote_amount_decimal();
 

--- a/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
@@ -2,7 +2,10 @@
 
 use alloy_primitives::U256;
 use funds_manager_api::{quoters::ApiExecutionQuote, u256_try_into_u128};
-use renegade_common::types::{chain::Chain, token::Token};
+use renegade_common::types::{
+    chain::Chain,
+    token::{Token, USDC_TICKER},
+};
 
 use crate::execution_client::{
     error::ExecutionClientError,
@@ -29,7 +32,7 @@ pub struct ExecutionQuote {
 impl ExecutionQuote {
     /// Whether the quote is a sell order in Renegade terms
     pub fn is_sell(&self) -> bool {
-        self.buy_token == Token::usdc()
+        self.buy_token == Token::from_ticker_on_chain(USDC_TICKER, self.chain)
     }
 
     /// Get the base token


### PR DESCRIPTION
This PR ports over the fixes from #327 & #328 so they are not lost when `andrew/multi-venue-quote-selection` is merged.