### PR TITLE
prover-service: prover: Implement endpoint handlers

### DIFF
--- a/prover-service/server/src/error.rs
+++ b/prover-service/server/src/error.rs
@@ -7,9 +7,12 @@ use warp::reply::{Json, WithStatus};
 /// The error type for the service
 #[derive(Debug, thiserror::Error)]
 pub enum ProverServiceError {
-    /// The request was invalid
-    #[error("invalid request: {0}")]
-    InvalidRequest(String),
+    /// A custom error
+    #[error("error: {0}")]
+    Custom(String),
+    /// An error proving a circuit
+    #[error("error proving circuit: {0}")]
+    Prover(String),
     /// The error occurred while setting up telemetry
     #[error("error setting up server: {0}")]
     Setup(String),
@@ -20,10 +23,16 @@ impl warp::reject::Reject for ProverServiceError {}
 impl ProverServiceError {
     // --- Constructors --- //
 
-    /// Create a new invalid request error
+    /// Create a new custom error
     #[allow(clippy::needless_pass_by_value)]
-    pub fn invalid_request<T: ToString>(msg: T) -> Self {
-        Self::InvalidRequest(msg.to_string())
+    pub fn custom<T: ToString>(msg: T) -> Self {
+        Self::Custom(msg.to_string())
+    }
+
+    /// Create a new prover error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn prover<T: ToString>(msg: T) -> Self {
+        Self::Prover(msg.to_string())
     }
 
     /// Create a new setup error
@@ -36,8 +45,8 @@ impl ProverServiceError {
 
     /// Convert a prover service error to a warp reply
     pub fn to_reply(&self) -> WithStatus<Json> {
+        #[allow(clippy::match_single_binding)]
         let (code, msg) = match self {
-            Self::InvalidRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             x => (StatusCode::INTERNAL_SERVER_ERROR, x.to_string()),
         };
 

--- a/prover-service/server/src/prover.rs
+++ b/prover-service/server/src/prover.rs
@@ -5,87 +5,119 @@
 // ---------------------
 
 use prover_service_api::{
-    ValidCommitmentsRequest, ValidFeeRedemptionRequest, ValidMalleableMatchSettleAtomicRequest,
-    ValidMatchSettleAtomicRequest, ValidMatchSettleRequest, ValidOfflineFeeSettlementRequest,
-    ValidReblindRequest, ValidWalletCreateRequest, ValidWalletUpdateRequest,
+    ProofResponse, ValidCommitmentsRequest, ValidFeeRedemptionRequest,
+    ValidMalleableMatchSettleAtomicRequest, ValidMatchSettleAtomicRequest, ValidMatchSettleRequest,
+    ValidOfflineFeeSettlementRequest, ValidReblindRequest, ValidWalletCreateRequest,
+    ValidWalletUpdateRequest,
 };
+use renegade_circuit_types::traits::SingleProverCircuit;
+use renegade_circuits::{
+    singleprover_prove,
+    zk_circuits::{
+        valid_commitments::SizedValidCommitments, valid_fee_redemption::SizedValidFeeRedemption,
+        valid_malleable_match_settle_atomic::SizedValidMalleableMatchSettleAtomic,
+        valid_match_settle::SizedValidMatchSettle,
+        valid_match_settle_atomic::SizedValidMatchSettleAtomic,
+        valid_offline_fee_settlement::SizedValidOfflineFeeSettlement,
+        valid_reblind::SizedValidReblind, valid_wallet_create::SizedValidWalletCreate,
+        valid_wallet_update::SizedValidWalletUpdate,
+    },
+};
+use tracing::instrument;
 use warp::{reject::Rejection, reply::Json};
 
+use crate::error::ProverServiceError;
+
 /// Handle a request to prove `VALID WALLET CREATE`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_wallet_create(
     request: ValidWalletCreateRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-wallet-create"
-    })))
+    generate_proof_json::<SizedValidWalletCreate>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID WALLET UPDATE`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_wallet_update(
     request: ValidWalletUpdateRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-wallet-update"
-    })))
+    generate_proof_json::<SizedValidWalletUpdate>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID COMMITMENTS`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_commitments(
     request: ValidCommitmentsRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-commitments"
-    })))
+    generate_proof_json::<SizedValidCommitments>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID REBLIND`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_reblind(request: ValidReblindRequest) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-reblind"
-    })))
+    generate_proof_json::<SizedValidReblind>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID MATCH SETTLE`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_match_settle(
     request: ValidMatchSettleRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-match-settle"
-    })))
+    generate_proof_json::<SizedValidMatchSettle>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID MATCH SETTLE ATOMIC`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_match_settle_atomic(
     request: ValidMatchSettleAtomicRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-match-settle-atomic"
-    })))
+    generate_proof_json::<SizedValidMatchSettleAtomic>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_malleable_match_settle_atomic(
     request: ValidMalleableMatchSettleAtomicRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-malleable-match-settle-atomic"
-    })))
+    generate_proof_json::<SizedValidMalleableMatchSettleAtomic>(request.witness, request.statement)
+        .await
 }
 
 /// Handle a request to prove `VALID FEE REDEMPTION`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_fee_redemption(
     request: ValidFeeRedemptionRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-fee-redemption"
-    })))
+    generate_proof_json::<SizedValidFeeRedemption>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID OFFLINE FEE SETTLEMENT`
+#[instrument(skip_all)]
 pub(crate) async fn handle_valid_offline_fee_settlement(
     request: ValidOfflineFeeSettlementRequest,
 ) -> Result<Json, Rejection> {
-    Ok(warp::reply::json(&serde_json::json!({
-        "msg": "valid-offline-fee-settlement"
-    })))
+    generate_proof_json::<SizedValidOfflineFeeSettlement>(request.witness, request.statement).await
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Prove a circuit and return a json-ified proof
+pub(crate) async fn generate_proof_json<C: SingleProverCircuit>(
+    witness: C::Witness,
+    statement: C::Statement,
+) -> Result<Json, Rejection>
+where
+    C::Witness: 'static + Send,
+    C::Statement: 'static + Send,
+{
+    // Spawn on a blocking thread
+    let proof = tokio::task::spawn_blocking(move || singleprover_prove::<C>(witness, statement))
+        .await
+        .map_err(ProverServiceError::custom)? // join error
+        .map_err(ProverServiceError::prover)?; // proof system error
+
+    let resp = ProofResponse { proof };
+    Ok(warp::reply::json(&resp))
 }


### PR DESCRIPTION
### Purpose
This PR implements the endpoint handlers for the prover service which generate the proofs using the relayer helpers.

### Todo
- Add proof linking endpoints + request fields

### Testing
- Will test in tandum with relayer implementation