### PR TITLE
prover-service: prover: Add proof linking types to request/response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
  "clap",
  "common",
  "config",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "contracts-common",
  "darkpool-client",
  "dashmap",
@@ -1395,7 +1395,7 @@ dependencies = [
  "rand 0.8.5",
  "ratelimit",
  "redis",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0)",
  "reqwest 0.11.27",
  "rustls 0.23.31",
  "serde",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "circuit-macros"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -2436,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "circuit-types"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2447,7 +2447,7 @@ dependencies = [
  "bigdecimal 0.3.1",
  "byteorder",
  "circuit-macros",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "futures",
  "hex",
  "itertools 0.10.5",
@@ -2460,7 +2460,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "serde",
  "serde_json",
 ]
@@ -2468,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "circuits"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -2478,7 +2478,7 @@ dependencies = [
  "bitvec",
  "circuit-macros",
  "circuit-types",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "futures",
  "itertools 0.10.5",
  "jf-primitives",
@@ -2488,7 +2488,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "serde",
  "serde_json",
  "util",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "alloy",
  "ark-mpc",
@@ -2668,7 +2668,7 @@ dependencies = [
  "bimap",
  "circuit-types",
  "circuits",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "crossbeam",
  "derivative",
  "ed25519-dalek 1.0.1",
@@ -2683,7 +2683,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2722,7 +2722,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "alloy",
  "base64 0.13.1",
@@ -2731,7 +2731,7 @@ dependencies = [
  "clap",
  "colored",
  "common",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "darkpool-client",
  "ed25519-dalek 1.0.1",
  "json",
@@ -2791,6 +2791,17 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constants"
+version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ed-on-bn254",
+ "ark-mpc",
+]
 
 [[package]]
 name = "constants"
@@ -3093,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "darkpool-client"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "abi",
  "alloy",
@@ -3107,13 +3118,13 @@ dependencies = [
  "circuit-types",
  "circuits",
  "common",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "itertools 0.12.1",
  "lazy_static",
  "num-bigint",
  "num-traits",
  "postcard",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "ruint",
  "serde",
  "serde_with",
@@ -3990,19 +4001,19 @@ dependencies = [
 [[package]]
 name = "external-api"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "alloy",
  "base64 0.22.1",
  "circuit-types",
  "common",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "hex",
  "http 1.3.1",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -4212,7 +4223,7 @@ dependencies = [
  "clap",
  "common",
  "config",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "darkpool-client",
  "diesel",
  "diesel-async",
@@ -4232,7 +4243,7 @@ dependencies = [
  "postgres-native-tls",
  "price-reporter-client",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0)",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -7298,13 +7309,31 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "renegade-crypto"
 version = "0.1.0"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-mpc",
+ "bigdecimal 0.3.1",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
+ "itertools 0.10.5",
+ "lazy_static",
+ "num-bigint",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "renegade-crypto"
+version = "0.1.0"
 source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",
  "ark-mpc",
  "bigdecimal 0.3.1",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0)",
  "itertools 0.10.5",
  "lazy_static",
  "num-bigint",
@@ -7416,7 +7445,7 @@ dependencies = [
  "clap",
  "common",
  "config",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "lru 0.12.5",
  "price-reporter-client",
  "renegade-sdk",
@@ -8753,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "system-clock"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "tokio",
  "tokio-cron-scheduler",
@@ -9665,14 +9694,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/renegade-fi/renegade.git?rev=dd1c9a0#dd1c9a01b8b5912d2bd32d91a51a7ad0c6cf90eb"
+source = "git+https://github.com/renegade-fi/renegade.git?rev=c9950c1#c9950c1a07a3deef305c1178f5adae09ecf8655f"
 dependencies = [
  "alloy",
  "ark-ec",
  "ark-serialize 0.4.2",
  "chrono",
  "circuit-types",
- "constants",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "crossbeam",
  "eyre",
  "futures",
@@ -9691,7 +9720,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.8.5",
- "renegade-crypto",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git?rev=c9950c1)",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,22 +26,22 @@ lto = true
 
 [workspace.dependencies]
 # === Renegade Dependencies === #
-renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
+renegade-darkpool-client = { package = "darkpool-client", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
 contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
-renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0", features = [
+renegade-api = { package = "external-api", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1", features = [
     "auth",
 ] }
-renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
-renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
-renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
-renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
-renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
+renegade-common = { package = "common", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
+renegade-config = { package = "config", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
+renegade-constants = { package = "constants", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
+renegade-circuits = { package = "circuits", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
+renegade-circuit-types = { package = "circuit-types", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
 renegade-crypto = { git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
-renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0", features = [
+renegade-util = { package = "util", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1", features = [
     "channels",
 ] }
-renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
-renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git", rev = "dd1c9a0" }
+renegade-price-reporter = { package = "price-reporter", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
+renegade-system-clock = { package = "system-clock", git = "https://github.com/renegade-fi/renegade.git", rev = "c9950c1" }
 renegade-solidity-abi = { package = "abi", git = "https://github.com/renegade-fi/renegade-solidity-contracts" }
 
 

--- a/prover-service/api/src/lib.rs
+++ b/prover-service/api/src/lib.rs
@@ -35,9 +35,16 @@ use serde::{Deserialize, Serialize};
 // | Response Types |
 // ------------------
 
-/// A generic response type representing a proof
+/// A generic repsonse representing a Plonk proof
 #[derive(Serialize, Deserialize)]
 pub struct ProofResponse {
+    /// The proof
+    pub proof: PlonkProof,
+}
+
+/// A generic response type representing a Plonk proof and a linking hint
+#[derive(Serialize, Deserialize)]
+pub struct ProofAndHintResponse {
     /// The proof
     pub proof: PlonkProof,
     /// The proof's link hint

--- a/prover-service/api/src/lib.rs
+++ b/prover-service/api/src/lib.rs
@@ -57,6 +57,7 @@ pub struct ProofLinkResponse {
 ///
 /// This type is returned in response to requests which themselves include a
 /// link hint for the prover service to link against
+#[derive(Serialize, Deserialize)]
 pub struct ProofAndLinkResponse {
     /// The plonk proof
     pub plonk_proof: PlonkProof,
@@ -121,6 +122,23 @@ pub struct ValidMatchSettleRequest {
     pub statement: SizedValidMatchSettleStatement,
     /// The witness
     pub witness: SizedValidMatchSettleWitness,
+    /// The link hint for `VALID COMMITMENTS` for party 0
+    pub valid_commitments_hint0: ProofLinkingHint,
+    /// The link hint for `VALID COMMITMENTS` for party 1
+    pub valid_commitments_hint1: ProofLinkingHint,
+}
+
+/// A response to a request to prove `VALID MATCH SETTLE`
+///
+/// This type includes two link proofs, so it warrants its own type
+#[derive(Serialize, Deserialize)]
+pub struct ValidMatchSettleResponse {
+    /// The plonk proof
+    pub plonk_proof: PlonkProof,
+    /// The proof-linking proof for party 0
+    pub link_proof0: PlonkLinkProof,
+    /// The proof-linking proof for party 1
+    pub link_proof1: PlonkLinkProof,
 }
 
 /// A request to prove `VALID MATCH SETTLE ATOMIC`
@@ -130,6 +148,8 @@ pub struct ValidMatchSettleAtomicRequest {
     pub statement: SizedValidMatchSettleAtomicStatement,
     /// The witness
     pub witness: SizedValidMatchSettleAtomicWitness,
+    /// The link hint for `VALID COMMITMENTS`
+    pub valid_commitments_hint: ProofLinkingHint,
 }
 
 /// A request to prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
@@ -139,6 +159,8 @@ pub struct ValidMalleableMatchSettleAtomicRequest {
     pub statement: SizedValidMalleableMatchSettleAtomicStatement,
     /// The witness
     pub witness: SizedValidMalleableMatchSettleAtomicWitness,
+    /// The link hint for `VALID COMMITMENTS`
+    pub valid_commitments_hint: ProofLinkingHint,
 }
 
 /// A request to prove `VALID FEE REDEMPTION`

--- a/prover-service/api/src/lib.rs
+++ b/prover-service/api/src/lib.rs
@@ -7,7 +7,7 @@
 #![deny(clippy::needless_pass_by_value)]
 #![deny(clippy::unused_async)]
 
-use renegade_circuit_types::PlonkProof;
+use renegade_circuit_types::{PlonkLinkProof, PlonkProof, ProofLinkingHint};
 use renegade_circuits::{
     self,
     zk_circuits::{
@@ -40,6 +40,28 @@ use serde::{Deserialize, Serialize};
 pub struct ProofResponse {
     /// The proof
     pub proof: PlonkProof,
+    /// The proof's link hint
+    pub link_hint: ProofLinkingHint,
+}
+
+/// A proof-link response
+///
+/// Sent by the prover service when only a linking proof has been requested
+#[derive(Serialize, Deserialize)]
+pub struct ProofLinkResponse {
+    /// The proof-linking proof
+    pub link_proof: PlonkLinkProof,
+}
+
+/// A response including a plonk proof and a proof-linking proof
+///
+/// This type is returned in response to requests which themselves include a
+/// link hint for the prover service to link against
+pub struct ProofAndLinkResponse {
+    /// The plonk proof
+    pub plonk_proof: PlonkProof,
+    /// The proof-linking proof
+    pub link_proof: PlonkLinkProof,
 }
 
 // -----------------
@@ -71,6 +93,16 @@ pub struct ValidCommitmentsRequest {
     pub statement: ValidCommitmentsStatement,
     /// The witness
     pub witness: SizedValidCommitmentsWitness,
+}
+
+/// A request to generate a proof-link of `VALID COMMITMENTS` <-> `VALID
+/// REBLIND`
+#[derive(Serialize, Deserialize)]
+pub struct LinkCommitmentsReblindRequest {
+    /// The link hint for `VALID COMMITMENTS`
+    pub valid_commitments_hint: ProofLinkingHint,
+    /// The link hint for `VALID REBLIND`
+    pub valid_reblind_hint: ProofLinkingHint,
 }
 
 /// A request to prove `VALID REBLIND`

--- a/prover-service/server/src/main.rs
+++ b/prover-service/server/src/main.rs
@@ -23,7 +23,7 @@ use crate::{
     cli::Cli,
     error::{ProverServiceError, json_error},
     prover::{
-        handle_valid_commitments, handle_valid_fee_redemption,
+        handle_link_commitments_reblind, handle_valid_commitments, handle_valid_fee_redemption,
         handle_valid_malleable_match_settle_atomic, handle_valid_match_settle,
         handle_valid_match_settle_atomic, handle_valid_offline_fee_settlement,
         handle_valid_reblind, handle_valid_wallet_create, handle_valid_wallet_update,
@@ -80,6 +80,11 @@ fn setup_routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + C
         .and(warp::body::json())
         .and_then(handle_valid_reblind);
 
+    let link_commitments_reblind = warp::path("link-commitments-reblind")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and_then(handle_link_commitments_reblind);
+
     // Prove valid match settle
     let valid_match_settle = warp::path("prove-valid-match-settle")
         .and(warp::post())
@@ -115,6 +120,7 @@ fn setup_routes() -> impl Filter<Extract = (impl Reply,), Error = Rejection> + C
         .or(valid_wallet_update)
         .or(valid_commitments)
         .or(valid_reblind)
+        .or(link_commitments_reblind)
         .or(valid_match_settle)
         .or(valid_match_settle_atomic)
         .or(valid_malleable_match_settle_atomic)

--- a/prover-service/server/src/prover.rs
+++ b/prover-service/server/src/prover.rs
@@ -5,11 +5,11 @@
 // ---------------------
 
 use prover_service_api::{
-    LinkCommitmentsReblindRequest, ProofAndLinkResponse, ProofLinkResponse, ProofResponse,
-    ValidCommitmentsRequest, ValidFeeRedemptionRequest, ValidMalleableMatchSettleAtomicRequest,
-    ValidMatchSettleAtomicRequest, ValidMatchSettleRequest, ValidMatchSettleResponse,
-    ValidOfflineFeeSettlementRequest, ValidReblindRequest, ValidWalletCreateRequest,
-    ValidWalletUpdateRequest,
+    LinkCommitmentsReblindRequest, ProofAndHintResponse, ProofAndLinkResponse, ProofLinkResponse,
+    ProofResponse, ValidCommitmentsRequest, ValidFeeRedemptionRequest,
+    ValidMalleableMatchSettleAtomicRequest, ValidMatchSettleAtomicRequest, ValidMatchSettleRequest,
+    ValidMatchSettleResponse, ValidOfflineFeeSettlementRequest, ValidReblindRequest,
+    ValidWalletCreateRequest, ValidWalletUpdateRequest,
 };
 use renegade_circuit_types::{
     PlonkLinkProof, PlonkProof, ProofLinkingHint, errors::ProverError, traits::SingleProverCircuit,
@@ -58,13 +58,13 @@ pub(crate) async fn handle_valid_wallet_update(
 pub(crate) async fn handle_valid_commitments(
     request: ValidCommitmentsRequest,
 ) -> Result<Json, Rejection> {
-    generate_proof_json::<SizedValidCommitments>(request.witness, request.statement).await
+    generate_proof_and_hint_json::<SizedValidCommitments>(request.witness, request.statement).await
 }
 
 /// Handle a request to prove `VALID REBLIND`
 #[instrument(skip_all)]
 pub(crate) async fn handle_valid_reblind(request: ValidReblindRequest) -> Result<Json, Rejection> {
-    generate_proof_json::<SizedValidReblind>(request.witness, request.statement).await
+    generate_proof_and_hint_json::<SizedValidReblind>(request.witness, request.statement).await
 }
 
 /// Handle a request to generate a proof-link of `VALID COMMITMENTS` <-> `VALID
@@ -90,21 +90,27 @@ pub(crate) async fn handle_valid_match_settle(
     let (plonk_proof, link_hint) =
         prove_circuit::<SizedValidMatchSettle>(request.witness, request.statement).await?;
 
-    // Generate the link proofs
-    let link_proof0 = link_commitments_match_settle(
-        0, // party
-        request.valid_commitments_hint0,
-        link_hint.clone(),
-    )
-    .await?;
+    // Generate the link proofs in parallel
+    let hint = link_hint.clone();
+    let proof0_fut = run_blocking(move || {
+        link_sized_commitments_match_settle(
+            0, // party
+            &request.valid_commitments_hint0,
+            &hint,
+        )
+    });
 
-    let link_proof1 = link_commitments_match_settle(
-        1, // party
-        request.valid_commitments_hint1,
-        link_hint,
-    )
-    .await?;
+    let proof1_fut = run_blocking(move || {
+        link_sized_commitments_match_settle(
+            1, // party
+            &request.valid_commitments_hint1,
+            &link_hint.clone(),
+        )
+    });
 
+    // Join the proofs
+    let (maybe_proof0, maybe_proof1) = tokio::join!(proof0_fut, proof1_fut);
+    let (link_proof0, link_proof1) = (maybe_proof0?, maybe_proof1?);
     let resp = ValidMatchSettleResponse { plonk_proof, link_proof0, link_proof1 };
     Ok(warp::reply::json(&resp))
 }
@@ -175,8 +181,22 @@ where
     C::Statement: 'static + Send,
 {
     // Spawn on a blocking thread
+    let (proof, _link_hint) = prove_circuit::<C>(witness, statement).await?;
+    let resp = ProofResponse { proof };
+    Ok(warp::reply::json(&resp))
+}
+
+/// Prove a circuit and return a json-ified proof and link hint
+async fn generate_proof_and_hint_json<C: SingleProverCircuit>(
+    witness: C::Witness,
+    statement: C::Statement,
+) -> Result<Json, Rejection>
+where
+    C::Witness: 'static + Send,
+    C::Statement: 'static + Send,
+{
     let (proof, link_hint) = prove_circuit::<C>(witness, statement).await?;
-    let resp = ProofResponse { proof, link_hint };
+    let resp = ProofAndHintResponse { proof, link_hint };
     Ok(warp::reply::json(&resp))
 }
 
@@ -200,18 +220,6 @@ async fn link_reblind_commitments(
     commitments_hint: ProofLinkingHint,
 ) -> Result<PlonkLinkProof, Rejection> {
     run_blocking(move || link_sized_commitments_reblind(&reblind_hint, &commitments_hint)).await
-}
-
-/// Generate a proof-link of `VALID COMMITMENTS` <-> `VALID MATCH SETTLE`
-async fn link_commitments_match_settle(
-    party: u64,
-    commitments_hint: ProofLinkingHint,
-    match_settle_hint: ProofLinkingHint,
-) -> Result<PlonkLinkProof, Rejection> {
-    run_blocking(move || {
-        link_sized_commitments_match_settle(party, &commitments_hint, &match_settle_hint)
-    })
-    .await
 }
 
 /// Generate a proof-link of `VALID COMMITMENTS` <-> `VALID MATCH SETTLE ATOMIC`

--- a/prover-service/server/src/prover.rs
+++ b/prover-service/server/src/prover.rs
@@ -5,22 +5,30 @@
 // ---------------------
 
 use prover_service_api::{
-    LinkCommitmentsReblindRequest, ProofLinkResponse, ProofResponse, ValidCommitmentsRequest,
-    ValidFeeRedemptionRequest, ValidMalleableMatchSettleAtomicRequest,
-    ValidMatchSettleAtomicRequest, ValidMatchSettleRequest, ValidOfflineFeeSettlementRequest,
-    ValidReblindRequest, ValidWalletCreateRequest, ValidWalletUpdateRequest,
+    LinkCommitmentsReblindRequest, ProofAndLinkResponse, ProofLinkResponse, ProofResponse,
+    ValidCommitmentsRequest, ValidFeeRedemptionRequest, ValidMalleableMatchSettleAtomicRequest,
+    ValidMatchSettleAtomicRequest, ValidMatchSettleRequest, ValidMatchSettleResponse,
+    ValidOfflineFeeSettlementRequest, ValidReblindRequest, ValidWalletCreateRequest,
+    ValidWalletUpdateRequest,
 };
-use renegade_circuit_types::traits::SingleProverCircuit;
+use renegade_circuit_types::{
+    PlonkLinkProof, PlonkProof, ProofLinkingHint, errors::ProverError, traits::SingleProverCircuit,
+};
 use renegade_circuits::{
     singleprover_prove_with_hint,
     zk_circuits::{
-        proof_linking::link_sized_commitments_reblind, valid_commitments::SizedValidCommitments,
+        proof_linking::{
+            link_sized_commitments_atomic_match_settle, link_sized_commitments_match_settle,
+            link_sized_commitments_reblind,
+        },
+        valid_commitments::SizedValidCommitments,
         valid_fee_redemption::SizedValidFeeRedemption,
         valid_malleable_match_settle_atomic::SizedValidMalleableMatchSettleAtomic,
         valid_match_settle::SizedValidMatchSettle,
         valid_match_settle_atomic::SizedValidMatchSettleAtomic,
         valid_offline_fee_settlement::SizedValidOfflineFeeSettlement,
-        valid_reblind::SizedValidReblind, valid_wallet_create::SizedValidWalletCreate,
+        valid_reblind::SizedValidReblind,
+        valid_wallet_create::SizedValidWalletCreate,
         valid_wallet_update::SizedValidWalletUpdate,
     },
 };
@@ -65,13 +73,9 @@ pub(crate) async fn handle_valid_reblind(request: ValidReblindRequest) -> Result
 pub(crate) async fn handle_link_commitments_reblind(
     request: LinkCommitmentsReblindRequest,
 ) -> Result<Json, Rejection> {
-    // Spawn on a blocking thread to avoid blocking the async pool
-    let link_proof = tokio::task::spawn_blocking(move || {
-        link_sized_commitments_reblind(&request.valid_reblind_hint, &request.valid_commitments_hint)
-    })
-    .await
-    .map_err(ProverServiceError::custom)? // join error
-    .map_err(ProverServiceError::prover)?; // proof system error
+    let link_proof =
+        link_reblind_commitments(request.valid_reblind_hint, request.valid_commitments_hint)
+            .await?;
 
     let resp = ProofLinkResponse { link_proof };
     Ok(warp::reply::json(&resp))
@@ -82,7 +86,27 @@ pub(crate) async fn handle_link_commitments_reblind(
 pub(crate) async fn handle_valid_match_settle(
     request: ValidMatchSettleRequest,
 ) -> Result<Json, Rejection> {
-    generate_proof_json::<SizedValidMatchSettle>(request.witness, request.statement).await
+    // Prove `VALID MATCH SETTLE` and generate a link hint
+    let (plonk_proof, link_hint) =
+        prove_circuit::<SizedValidMatchSettle>(request.witness, request.statement).await?;
+
+    // Generate the link proofs
+    let link_proof0 = link_commitments_match_settle(
+        0, // party
+        request.valid_commitments_hint0,
+        link_hint.clone(),
+    )
+    .await?;
+
+    let link_proof1 = link_commitments_match_settle(
+        1, // party
+        request.valid_commitments_hint1,
+        link_hint,
+    )
+    .await?;
+
+    let resp = ValidMatchSettleResponse { plonk_proof, link_proof0, link_proof1 };
+    Ok(warp::reply::json(&resp))
 }
 
 /// Handle a request to prove `VALID MATCH SETTLE ATOMIC`
@@ -90,7 +114,15 @@ pub(crate) async fn handle_valid_match_settle(
 pub(crate) async fn handle_valid_match_settle_atomic(
     request: ValidMatchSettleAtomicRequest,
 ) -> Result<Json, Rejection> {
-    generate_proof_json::<SizedValidMatchSettleAtomic>(request.witness, request.statement).await
+    // Prove `VALID MATCH SETTLE ATOMIC` and generate a link hint
+    let (plonk_proof, link_hint) =
+        prove_circuit::<SizedValidMatchSettleAtomic>(request.witness, request.statement).await?;
+
+    // Generate the link proof
+    let link_proof =
+        link_commitments_match_settle_atomic(request.valid_commitments_hint, link_hint).await?;
+    let resp = ProofAndLinkResponse { plonk_proof, link_proof };
+    Ok(warp::reply::json(&resp))
 }
 
 /// Handle a request to prove `VALID MALLEABLE MATCH SETTLE ATOMIC`
@@ -98,8 +130,17 @@ pub(crate) async fn handle_valid_match_settle_atomic(
 pub(crate) async fn handle_valid_malleable_match_settle_atomic(
     request: ValidMalleableMatchSettleAtomicRequest,
 ) -> Result<Json, Rejection> {
-    generate_proof_json::<SizedValidMalleableMatchSettleAtomic>(request.witness, request.statement)
-        .await
+    // Prove `VALID MALLEABLE MATCH SETTLE ATOMIC` and generate a link hint
+    let (plonk_proof, link_hint) =
+        prove_circuit::<SizedValidMalleableMatchSettleAtomic>(request.witness, request.statement)
+            .await?;
+
+    // Generate the link proof
+    let link_proof =
+        link_commitments_malleable_match_settle_atomic(request.valid_commitments_hint, link_hint)
+            .await?;
+    let resp = ProofAndLinkResponse { plonk_proof, link_proof };
+    Ok(warp::reply::json(&resp))
 }
 
 /// Handle a request to prove `VALID FEE REDEMPTION`
@@ -122,8 +163,10 @@ pub(crate) async fn handle_valid_offline_fee_settlement(
 // | Helpers |
 // -----------
 
+// --- Plonk Prover --- //
+
 /// Prove a circuit and return a json-ified proof
-pub(crate) async fn generate_proof_json<C: SingleProverCircuit>(
+async fn generate_proof_json<C: SingleProverCircuit>(
     witness: C::Witness,
     statement: C::Statement,
 ) -> Result<Json, Rejection>
@@ -132,11 +175,80 @@ where
     C::Statement: 'static + Send,
 {
     // Spawn on a blocking thread
-    let (proof, link_hint) = tokio::task::spawn_blocking(move || singleprover_prove_with_hint::<C>(witness, statement))
+    let (proof, link_hint) = prove_circuit::<C>(witness, statement).await?;
+    let resp = ProofResponse { proof, link_hint };
+    Ok(warp::reply::json(&resp))
+}
+
+/// Prove a circuit; return the proof and link hint
+async fn prove_circuit<C: SingleProverCircuit>(
+    witness: C::Witness,
+    statement: C::Statement,
+) -> Result<(PlonkProof, ProofLinkingHint), Rejection>
+where
+    C::Witness: 'static + Send,
+    C::Statement: 'static + Send,
+{
+    run_blocking(move || singleprover_prove_with_hint::<C>(witness, statement)).await
+}
+
+// --- Proof Linking --- //
+
+/// Generate a proof-link of `VALID COMMITMENTS` <-> `VALID REBLIND`
+async fn link_reblind_commitments(
+    reblind_hint: ProofLinkingHint,
+    commitments_hint: ProofLinkingHint,
+) -> Result<PlonkLinkProof, Rejection> {
+    run_blocking(move || link_sized_commitments_reblind(&reblind_hint, &commitments_hint)).await
+}
+
+/// Generate a proof-link of `VALID COMMITMENTS` <-> `VALID MATCH SETTLE`
+async fn link_commitments_match_settle(
+    party: u64,
+    commitments_hint: ProofLinkingHint,
+    match_settle_hint: ProofLinkingHint,
+) -> Result<PlonkLinkProof, Rejection> {
+    run_blocking(move || {
+        link_sized_commitments_match_settle(party, &commitments_hint, &match_settle_hint)
+    })
+    .await
+}
+
+/// Generate a proof-link of `VALID COMMITMENTS` <-> `VALID MATCH SETTLE ATOMIC`
+async fn link_commitments_match_settle_atomic(
+    commitments_hint: ProofLinkingHint,
+    match_settle_hint: ProofLinkingHint,
+) -> Result<PlonkLinkProof, Rejection> {
+    run_blocking(move || {
+        link_sized_commitments_atomic_match_settle(&commitments_hint, &match_settle_hint)
+    })
+    .await
+}
+
+/// Generate a proof-link of `VALID COMMITMENTS` <-> `VALID MALLEABLE MATCH
+/// SETTLE ATOMIC`
+async fn link_commitments_malleable_match_settle_atomic(
+    commitments_hint: ProofLinkingHint,
+    malleable_match_settle_hint: ProofLinkingHint,
+) -> Result<PlonkLinkProof, Rejection> {
+    run_blocking(move || {
+        link_sized_commitments_atomic_match_settle(&commitments_hint, &malleable_match_settle_hint)
+    })
+    .await
+}
+
+// --- Runtime --- //
+
+/// Block on a prover callback and handle errors
+async fn run_blocking<F, R>(f: F) -> Result<R, Rejection>
+where
+    F: FnOnce() -> Result<R, ProverError> + Send + 'static,
+    R: Send + 'static,
+{
+    let r = tokio::task::spawn_blocking(f)
         .await
         .map_err(ProverServiceError::custom)? // join error
         .map_err(ProverServiceError::prover)?; // proof system error
 
-    let resp = ProofResponse { proof, link_hint };
-    Ok(warp::reply::json(&resp))
+    Ok(r)
 }


### PR DESCRIPTION
### Purpose
This PR adds proof linking types to the request response types of the prover service. This can take two forms:
- Proof linking requests on their own -- used in the `VALID COMMITMENTS` <-> `VALID REBLIND` link
- Proof linking requests piggybacked on Plonk proof requests -- used in all the match circuits.

These patterns mirror those currently used in the relayer to generate proof links.

### Testing
- Deferred until relayer integration