### PR TITLE
funds-manager-api: slippage_tolerance in QuoteParams

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -72,6 +72,11 @@ pub struct QuoteParams {
     /// 1 USDC (6 decimals))
     #[serde(with = "u256_string_serialization")]
     pub from_amount: U256,
+    /// The slippage tolerance for the quote, as a decimal (e.g. 0.0001 for
+    /// 1 basis point, or 0.01%)
+    ///
+    /// If not provided, the default slippage tolerance will be used.
+    pub slippage_tolerance: Option<f64>,
 }
 
 /// A simplified representation of an execution quote, suitable for API
@@ -91,6 +96,8 @@ pub struct ApiExecutionQuote {
     pub buy_amount: U256,
     /// The venue that provided the quote
     pub venue: String,
+    /// The chain ID that the quote was generated on
+    pub chain_id: u64,
 }
 
 /// The response body for executing an immediate swap

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -23,6 +23,7 @@ use tracing::{info, instrument, warn};
 use crate::{
     execution_client::{
         error::ExecutionClientError,
+        swap::DEFAULT_SLIPPAGE_TOLERANCE,
         venues::{
             lifi::api_types::{LifiQuote, LifiQuoteParams},
             quote::{ExecutableQuote, ExecutionQuote, QuoteExecutionData},
@@ -54,9 +55,6 @@ const LIFI_DIAMOND_ADDRESS: Address =
 
 /// The Lifi api key header
 const LIFI_API_KEY_HEADER: &str = "x-lifi-api-key";
-
-/// The default slippage tolerance for a Lifi quote
-const DEFAULT_SLIPPAGE_TOLERANCE: f64 = 0.005; // 50bps
 
 /// The default max price impact for a Lifi quote.
 ///
@@ -200,7 +198,7 @@ impl LifiClient {
             from_address: self.hot_wallet_address.to_string(),
             from_chain: to_chain_id(self.chain) as usize,
             to_chain: to_chain_id(self.chain) as usize,
-            slippage: Some(DEFAULT_SLIPPAGE_TOLERANCE),
+            slippage: params.slippage_tolerance.or(Some(DEFAULT_SLIPPAGE_TOLERANCE)),
             max_price_impact: Some(DEFAULT_MAX_PRICE_IMPACT),
             swap_step_timing_strategies: Some(vec![DEFAULT_TIMING_STRATEGY.to_string()]),
             order: Some(DEFAULT_ORDER_PREFERENCE.to_string()),

--- a/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
@@ -7,11 +7,15 @@ use renegade_common::types::{
     token::{Token, USDC_TICKER},
 };
 
-use crate::execution_client::{
-    error::ExecutionClientError,
-    venues::{
-        cowswap::CowswapQuoteExecutionData, lifi::LifiQuoteExecutionData, SupportedExecutionVenue,
+use crate::{
+    execution_client::{
+        error::ExecutionClientError,
+        venues::{
+            cowswap::CowswapQuoteExecutionData, lifi::LifiQuoteExecutionData,
+            SupportedExecutionVenue,
+        },
     },
+    helpers::to_chain_id,
 };
 
 /// The basic information included in an execution quote,
@@ -129,7 +133,14 @@ impl From<ExecutionQuote> for ApiExecutionQuote {
         let buy_amount = value.buy_amount;
         let venue = value.venue.to_string();
 
-        ApiExecutionQuote { sell_token_address, buy_token_address, sell_amount, buy_amount, venue }
+        ApiExecutionQuote {
+            sell_token_address,
+            buy_token_address,
+            sell_amount,
+            buy_amount,
+            venue,
+            chain_id: to_chain_id(value.chain),
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a `slippage_tolerance` parameter to the `QuoteParams` struct, so that it can be set by clients.

### Testing
- [x] Test executing swaps at varying levels of slippage, assert that spread (rel. to Binance) is within same ballpark