### PR TITLE
funds-manager: execution_client: swap: fetch quotes in parallel

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/api_types.rs
@@ -19,8 +19,8 @@ use crate::execution_client::swap::DEFAULT_SLIPPAGE_TOLERANCE;
 // | Constants |
 // -------------
 
-/// The number of seconds for which a quote is valid
-const COWSWAP_QUOTE_VALID_FOR: u32 = 60 * 5; // 5 minutes
+/// The number of seconds for which an order is valid
+const COWSWAP_ORDER_VALID_FOR: u32 = 2 * 60; // 2 minutes
 
 /// The number of basis points in 1 unit
 const BPS_PER_UNIT: f64 = 10_000.0;
@@ -203,7 +203,7 @@ impl OrderQuoteResponse {
             SystemTime::now().duration_since(UNIX_EPOCH).expect("negative timestamp").as_secs()
                 as u32;
 
-        now + COWSWAP_QUOTE_VALID_FOR
+        now + COWSWAP_ORDER_VALID_FOR
     }
 
     /// Sign the order represented by this quote with the given private key,

--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
@@ -451,6 +451,10 @@ impl ExecutionVenue for CowswapClient {
         )
         .await?;
 
+        // We set an extra sleep here, since empirically we've seen the Cowswap API
+        // not index the approval to the VaultRelayer by the time we place an order.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
         let order_request = self.construct_order_request(executable_quote)?;
         let order_id: String =
             self.send_post_request(COWSWAP_ORDER_ENDPOINT, order_request).await?;


### PR DESCRIPTION
This PR tweaks the `ExecutionClient` to fetch quotes across venues in parallel. In addition, we make some other misc changes:
1. Decreasing order validity to 2 minutes on Cowswap - no reason to keep orders around much longer after we've timed out waiting for them to experience a trade, but setting a 1 minute expiry is rejected by the Cowswap API on the grounds of being too short.
2. We add a 1-second sleep after submitting an ERC20 approval for a Cowswap quote. Empirically, we frequently see the Cowswap API reject order placements due to us not having approved, despite this being the case. I tried setting a high number of required confirmations on the approval TX, but this seemed to have literally no effect. Using a direct timeout is simpler.

### Testing
- [x] Ran local funds manager, swapped via local admin panel.