### PR TITLE
funds-manager: execution_client: venues: lifi: log errant request path

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -335,8 +335,9 @@ impl ExecutionClient {
 
         let mut maybe_best_quote = None;
         for (venue, quote_res) in quote_results {
+            let venue_specifier = venue.venue_specifier();
             if let Err(e) = quote_res {
-                warn!("Error getting quote from {}: {e}", venue.venue_specifier());
+                warn!("Error getting quote from {venue_specifier}: {e}");
                 continue;
             }
 
@@ -350,10 +351,14 @@ impl ExecutionClient {
             let best_quote = maybe_best_quote.as_ref().unwrap();
 
             let quote_price = quote.quote.get_price(None /* buy_amount */);
+
+            let is_sell = quote.quote.is_sell();
+            info!("{venue_specifier} quote price: {quote_price} (is_sell: {is_sell})");
+
             let best_quote_price = best_quote.quote.get_price(None /* buy_amount */);
 
-            let is_better_sell = quote.quote.is_sell() && quote_price > best_quote_price;
-            let is_better_buy = !quote.quote.is_sell() && quote_price < best_quote_price;
+            let is_better_sell = is_sell && quote_price > best_quote_price;
+            let is_better_buy = !is_sell && quote_price < best_quote_price;
 
             if is_better_sell || is_better_buy {
                 maybe_best_quote = Some(quote);

--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
@@ -17,7 +17,7 @@ use funds_manager_api::quoters::QuoteParams;
 use renegade_common::types::chain::Chain;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::{
     execution_client::{
@@ -381,6 +381,8 @@ impl CowswapClient {
 
             // Await for a single trade to be executed on the order
             if let Some(trade) = trades.first() {
+                info!("Cowswap trade executed in tx {:#x}", trade.tx_hash);
+
                 let tx_hash =
                     TxHash::from_str(&trade.tx_hash).map_err(ExecutionClientError::parse)?;
 
@@ -399,6 +401,8 @@ impl CowswapClient {
 
         // TODO: Here, we can cancel the order as it still hasn't been executed,
         // but for now we rely on the `valid_to` field to expire the order.
+
+        warn!("Cowswap trade not executed after {MAX_TRADE_EXECUTION_WAIT_TIME} seconds");
 
         Ok(ExecutionResult { buy_amount_actual: U256::ZERO, gas_cost: U256::ZERO, tx_hash: None })
     }


### PR DESCRIPTION
This PR re-introduces logging of the path invoked when a Lifi request fails. This was not ported over in the process of implementing multi-venue quote selection.