### PR TITLE
funds-manager: execution_client: cowswap: log tx hash string correctly

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
@@ -381,7 +381,7 @@ impl CowswapClient {
 
             // Await for a single trade to be executed on the order
             if let Some(trade) = trades.first() {
-                info!("Cowswap trade executed in tx {:#x}", trade.tx_hash);
+                info!("Cowswap trade executed in tx {}", trade.tx_hash);
 
                 let tx_hash =
                     TxHash::from_str(&trade.tx_hash).map_err(ExecutionClientError::parse)?;


### PR DESCRIPTION
The TX hash returned by the Cowswap API is a `String` and as such doesn't implement `LowerHex`, I merged this as-is hastily.