### PR TITLE
funds-manager: helpers: send ERC20 approvals w/ a retry

### DIFF
--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -262,8 +262,7 @@ impl ChainConfig {
             &self.rpc_url,
             price_reporter.clone(),
             quoter_hot_wallet_private_key,
-        )
-        .map_err(FundsManagerError::custom)?;
+        );
 
         // Build a metrics recorder
         let metrics_recorder = MetricsRecorder::new(price_reporter.clone(), &self.rpc_url, chain);

--- a/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/hot_wallets.rs
@@ -158,7 +158,7 @@ impl CustodyClient {
             FundsManagerError::parse(format!("Invalid token address: {token_address}"))
         })?;
 
-        let token = IERC20::new(token_address, self.arbitrum_provider.clone());
+        let token = IERC20::new(token_address, self.get_basic_provider());
         let balance =
             token.balanceOf(wallet_address).call().await.map_err(FundsManagerError::on_chain)?;
 

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -38,18 +38,16 @@ impl ExecutionClient {
         rpc_url: &str,
         price_reporter: PriceReporterClient,
         quoter_hot_wallet: PrivateKeySigner,
-    ) -> Result<Self, ExecutionClientError> {
+    ) -> Self {
         let hot_wallet_address = quoter_hot_wallet.address();
-        let rpc_provider = build_provider(rpc_url).map_err(ExecutionClientError::parse)?;
+        let rpc_provider = build_provider(rpc_url, None /* wallet */);
 
-        let lifi =
-            LifiClient::new(lifi_api_key, rpc_provider.clone(), quoter_hot_wallet.clone(), chain);
-
-        let cowswap = CowswapClient::new(rpc_provider.clone(), quoter_hot_wallet, chain);
+        let lifi = LifiClient::new(lifi_api_key, rpc_url, quoter_hot_wallet.clone(), chain);
+        let cowswap = CowswapClient::new(rpc_url, quoter_hot_wallet, chain);
 
         let venues = AllExecutionVenues { lifi, cowswap };
 
-        Ok(Self { chain, rpc_provider, price_reporter, hot_wallet_address, venues })
+        Self { chain, rpc_provider, price_reporter, hot_wallet_address, venues }
     }
 
     /// Get the erc20 balance of an address

--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use alloy::{
     hex,
-    providers::{DynProvider, ProviderBuilder},
+    providers::DynProvider,
     signers::{local::PrivateKeySigner, SignerSync},
 };
 use alloy_primitives::{Address, FixedBytes, TxHash, U256};
@@ -34,7 +34,7 @@ use crate::{
             ExecutionResult, ExecutionVenue, SupportedExecutionVenue,
         },
     },
-    helpers::{approve_erc20_allowance, handle_http_response, to_chain_id},
+    helpers::{approve_erc20_allowance, build_provider, handle_http_response, to_chain_id},
 };
 
 pub mod abi;
@@ -190,10 +190,8 @@ pub struct CowswapClient {
 
 impl CowswapClient {
     /// Create a new client
-    pub fn new(base_provider: DynProvider, hot_wallet: PrivateKeySigner, chain: Chain) -> Self {
-        let rpc_provider = DynProvider::new(
-            ProviderBuilder::new().wallet(hot_wallet.clone()).connect_provider(base_provider),
-        );
+    pub fn new(rpc_url: &str, hot_wallet: PrivateKeySigner, chain: Chain) -> Self {
+        let rpc_provider = build_provider(rpc_url, Some(hot_wallet.clone()));
 
         Self { http_client: Client::new(), hot_wallet, chain, rpc_provider }
     }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -7,7 +7,7 @@ use alloy::{
     eips::BlockId,
     hex,
     network::TransactionBuilder,
-    providers::{DynProvider, Provider, ProviderBuilder},
+    providers::{DynProvider, Provider},
     rpc::types::{TransactionReceipt, TransactionRequest},
     signers::local::PrivateKeySigner,
 };
@@ -31,8 +31,8 @@ use crate::{
         },
     },
     helpers::{
-        approve_erc20_allowance, get_gas_cost, handle_http_response, send_tx_with_retry,
-        to_chain_id, IERC20::Transfer, ONE_CONFIRMATION,
+        approve_erc20_allowance, build_provider, get_gas_cost, handle_http_response,
+        send_tx_with_retry, to_chain_id, IERC20::Transfer, ONE_CONFIRMATION,
     },
 };
 
@@ -157,14 +157,12 @@ impl LifiClient {
     /// Create a new client
     pub fn new(
         api_key: Option<String>,
-        base_provider: DynProvider,
+        rpc_url: &str,
         hot_wallet: PrivateKeySigner,
         chain: Chain,
     ) -> Self {
         let hot_wallet_address = hot_wallet.address();
-        let rpc_provider = DynProvider::new(
-            ProviderBuilder::new().wallet(hot_wallet).connect_provider(base_provider),
-        );
+        let rpc_provider = build_provider(rpc_url, Some(hot_wallet));
 
         Self { api_key, http_client: Client::new(), rpc_provider, hot_wallet_address, chain }
     }

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -402,7 +402,6 @@ async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, warp
         error!("API Error: {:?}", api_error);
         Ok(warp::reply::with_status(message.clone(), code))
     } else {
-        error!("Unhandled rejection: {:?}", err);
         Err(err)
     }
 }

--- a/funds-manager/funds-manager-server/src/metrics/mod.rs
+++ b/funds-manager/funds-manager-server/src/metrics/mod.rs
@@ -24,7 +24,7 @@ pub struct MetricsRecorder {
 impl MetricsRecorder {
     /// Create a new metrics recorder
     pub fn new(price_reporter: PriceReporterClient, rpc_url: &str, chain: Chain) -> Self {
-        let provider = build_provider(rpc_url).expect("invalid RPC URL");
+        let provider = build_provider(rpc_url, None /* wallet */);
 
         MetricsRecorder { price_reporter, provider, chain }
     }


### PR DESCRIPTION
This PR makes a couple fixes to mitigate nonce issues in the funds manager:

First, we remove usage of `ProviderBuilder::new().connect_provider(base_provider)`. This was implemented on the incorrect assumption that the fillers with which the `base_provider` was constructed would overwrite the "recommended fillers" introduced in `ProviderBuilder::new()`. 
This is not the case - the fillers in the `base_provider` are completely ignored, which I verified by trying to send transactions from a provider constructed with `ProviderBuilder::default().connect_provider(base_provider)` (no fillers are added in `default`). As such, this means the recommended fillers (notably, the `CachedNonceManager`) were used in the constructed provider.
We now construct an appropriately-configured provider in all cases where we need one, instead of trying to incorrectly extend some base provider.

Second, we employ the `send_tx_with_retry` helper when we `approve_erc20_allowance`. Even when fetching the nonce before sending a transaction, it's possible for it to be outdated by the time the transaction is sent.

### Testing
- [x] Run local funds manager, assert the following error reproduces before this fix and is resolved afterwards:
    1. Submit a swap through Lifi (sends a TX onchain)
    2. Deposit funds into Hyperliquid (uses the same private key, but different provider instance, incrementing the nonce in a way that a `CachedNonceManager` wouldn't detect)
    3. Submit another swap through Lifi (this would error before the fix, but now works smoothly)