### PR TITLE
funds-manager: execution_client: check expected swap amt before getting quote

### DIFF
--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -402,7 +402,6 @@ async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, warp
         error!("API Error: {:?}", api_error);
         Ok(warp::reply::with_status(message.clone(), code))
     } else {
-        error!("Unhandled rejection: {:?}", err);
         Err(err)
     }
 }


### PR DESCRIPTION
This PR generalizes the "min swap amount" checks into a single one: before fetching a quote for a swap, we compute the expected notional volume using the renegade price, and error early if it is below our threshold.