### PR TITLE
funds-manager: execution_client: specify venue in API

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -1,4 +1,6 @@
 //! API types for quoter management
+use std::fmt::Display;
+
 use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 
@@ -59,6 +61,24 @@ pub struct WithdrawFundsRequest {
 
 // --- Execution --- //
 
+/// An enum used to specify supported execution venues
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum SupportedExecutionVenue {
+    /// The Lifi venue
+    Lifi,
+    /// The Cowswap venue
+    Cowswap,
+}
+
+impl Display for SupportedExecutionVenue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SupportedExecutionVenue::Lifi => write!(f, "Lifi"),
+            SupportedExecutionVenue::Cowswap => write!(f, "Cowswap"),
+        }
+    }
+}
+
 /// Parameters for requesting a quote to be executed
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -77,6 +97,9 @@ pub struct QuoteParams {
     ///
     /// If not provided, the default slippage tolerance will be used.
     pub slippage_tolerance: Option<f64>,
+    /// The venue to use for the quote. If not provided, the best quote across
+    /// all venues will be selected.
+    pub venue: Option<SupportedExecutionVenue>,
 }
 
 /// A simplified representation of an execution quote, suitable for API

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -1,10 +1,8 @@
 //! Venue-specific logic for getting quotes and executing swaps
 
-use std::fmt::Display;
-
 use alloy_primitives::{TxHash, U256};
 use async_trait::async_trait;
-use funds_manager_api::quoters::QuoteParams;
+use funds_manager_api::quoters::{QuoteParams, SupportedExecutionVenue};
 
 use crate::execution_client::{
     error::ExecutionClientError,
@@ -14,24 +12,6 @@ use crate::execution_client::{
 pub mod cowswap;
 pub mod lifi;
 pub mod quote;
-
-/// An enum used to specify supported execution venues
-#[derive(Debug)]
-pub enum SupportedExecutionVenue {
-    /// The Lifi venue
-    Lifi,
-    /// The Cowswap venue
-    Cowswap,
-}
-
-impl Display for SupportedExecutionVenue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SupportedExecutionVenue::Lifi => write!(f, "Lifi"),
-            SupportedExecutionVenue::Cowswap => write!(f, "Cowswap"),
-        }
-    }
-}
 
 /// A collection of all execution venues used by the execution client
 #[derive(Clone)]
@@ -46,6 +26,14 @@ impl AllExecutionVenues {
     /// Get all venues
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
         vec![&self.lifi, &self.cowswap]
+    }
+
+    /// Get a venue by its specifier
+    pub fn get_venue(&self, venue: SupportedExecutionVenue) -> &dyn ExecutionVenue {
+        match venue {
+            SupportedExecutionVenue::Lifi => &self.lifi,
+            SupportedExecutionVenue::Cowswap => &self.cowswap,
+        }
     }
 }
 

--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -12,6 +12,9 @@ pub const SWAP_NOTIONAL_VOLUME_METRIC_NAME: &str = "swap_notional_volume";
 /// Metric for the relative spread between execution price and Binance price
 pub const SWAP_RELATIVE_SPREAD_METRIC_NAME: &str = "swap_relative_spread";
 
+/// Metric describing the price deviation of a quote from the Renegade price
+pub const QUOTE_PRICE_DEVIATION: &str = "quote_price_deviation";
+
 /// Metric tag for the asset's ticker symbol or address
 pub const ASSET_TAG: &str = "asset";
 


### PR DESCRIPTION
This PR tweaks the `QuoteParams` type to allow clients to optionally specify the venue on which they want to execute the requested swap.

Additionally, we allow the `slippage_tolerance` field to override the configured max price deviation if it is set to a higher value, so that clients can "force through" costly swaps. This is a bit of parameter conflation: `slippage_tolerance` is intended to indicate the tolerance for price impact on each venue, i.e. the deviation between the trade price & the venue midpoint, whereas the price deviation check is between the trade price & the "Renegade" price. Still, this keeps the API simple while allowing for costly swaps in a pinch.

### Testing
- [x] Run local funds manager + admin panel & invoke swaps which quote across all venues, and across specific ones
- [x] Invoke swaps w/ high slippage tolerance set, asserting that they are not blocked by the default price deviation