### PR TITLE
funds-manger: execution_client: record quote price deviation metric

### DIFF
--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -12,6 +12,9 @@ pub const SWAP_NOTIONAL_VOLUME_METRIC_NAME: &str = "swap_notional_volume";
 /// Metric for the relative spread between execution price and Binance price
 pub const SWAP_RELATIVE_SPREAD_METRIC_NAME: &str = "swap_relative_spread";
 
+/// Metric describing the price deviation of a quote from the Renegade price
+pub const QUOTE_PRICE_DEVIATION: &str = "quote_price_deviation";
+
 /// Metric tag for the asset's ticker symbol or address
 pub const ASSET_TAG: &str = "asset";
 


### PR DESCRIPTION
This PR has the funds manager record the best quote's deviation from the renegade price when swapping, regardless of if the quote exceeds the deviation threshold. We will use this metric to tune the per-asset maximum price deviations.

### Testing
- [x] Run local funds manager, invoke swaps, check that metrics were recorded