### PR TITLE
funds-manager: execution_client: temp disable cowswap

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -32,7 +32,7 @@ const SWAP_DECAY_FACTOR: U256 = U256::from_limbs([2, 0, 0, 0]);
 /// The minimum amount of USDC that will be attempted to be swapped recursively
 const MIN_SWAP_QUOTE_AMOUNT: f64 = 10.0; // 10 USDC
 /// The default maximum allowable deviation from the Renegade price in a quote
-const DEFAULT_MAX_PRICE_DEVIATION: f64 = 0.005; // 50bps, or 0.5%
+const DEFAULT_MAX_PRICE_DEVIATION: f64 = 0.0100; // 100bps, or 1%
 /// The buffer to scale the target amount by when executing swaps to cover it,
 /// to account for price drift
 const SWAP_TO_COVER_BUFFER: f64 = 1.1;

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -25,7 +25,9 @@ pub struct AllExecutionVenues {
 impl AllExecutionVenues {
     /// Get all venues
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
-        vec![&self.lifi, &self.cowswap]
+        // TEMP: We are disabling Cowswap by default until we have a mechanism
+        // for self-trade prevention
+        vec![&self.lifi]
     }
 
     /// Get a venue by its specifier


### PR DESCRIPTION
This PR temporarily disables Cowswap execution until we implement a mechanism for self-trade prevention.