### PR TITLE
funds-manager: metrics: self-trade volume

### DIFF
--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -274,7 +274,11 @@ impl ChainConfig {
         );
 
         // Build a metrics recorder
-        let metrics_recorder = MetricsRecorder::new(price_reporter.clone(), &self.rpc_url, chain);
+        let darkpool_address =
+            Address::from_str(&self.darkpool_address).map_err(FundsManagerError::parse)?;
+
+        let metrics_recorder =
+            MetricsRecorder::new(price_reporter.clone(), &self.rpc_url, chain, darkpool_address);
 
         // Build a fee indexer
         let mut decryption_keys = vec![DecryptionKey::from_hex_str(&self.relayer_decryption_key)

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -27,7 +27,7 @@ impl AllExecutionVenues {
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
         // TEMP: We are disabling Cowswap by default until we have a mechanism
         // for self-trade prevention
-        vec![&self.lifi]
+        vec![&self.lifi, &self.cowswap]
     }
 
     /// Get a venue by its specifier

--- a/funds-manager/funds-manager-server/src/metrics/labels.rs
+++ b/funds-manager/funds-manager-server/src/metrics/labels.rs
@@ -15,6 +15,9 @@ pub const SWAP_RELATIVE_SPREAD_METRIC_NAME: &str = "swap_relative_spread";
 /// Metric describing the price deviation of a quote from the Renegade price
 pub const QUOTE_PRICE_DEVIATION: &str = "quote_price_deviation";
 
+/// Metric for the USDC volume transferred through the darkpool in the swap
+pub const SELF_TRADE_VOLUME_USDC_METRIC_NAME: &str = "self_trade_volume";
+
 /// Metric tag for the asset's ticker symbol or address
 pub const ASSET_TAG: &str = "asset";
 

--- a/funds-manager/funds-manager-server/src/metrics/mod.rs
+++ b/funds-manager/funds-manager-server/src/metrics/mod.rs
@@ -1,6 +1,7 @@
 //! General metrics recording functionality
 
 use alloy::providers::DynProvider;
+use alloy_primitives::Address;
 use price_reporter_client::PriceReporterClient;
 use renegade_common::types::chain::Chain;
 
@@ -19,13 +20,20 @@ pub struct MetricsRecorder {
     pub provider: DynProvider,
     /// The chain for which metrics are being recorded
     pub chain: Chain,
+    /// The address of the darkpool contract
+    pub darkpool_address: Address,
 }
 
 impl MetricsRecorder {
     /// Create a new metrics recorder
-    pub fn new(price_reporter: PriceReporterClient, rpc_url: &str, chain: Chain) -> Self {
+    pub fn new(
+        price_reporter: PriceReporterClient,
+        rpc_url: &str,
+        chain: Chain,
+        darkpool_address: Address,
+    ) -> Self {
         let provider = build_provider(rpc_url, None /* wallet */);
 
-        MetricsRecorder { price_reporter, provider, chain }
+        MetricsRecorder { price_reporter, provider, chain, darkpool_address }
     }
 }


### PR DESCRIPTION
This PR adds the recording of self-trade volume through the darkpool when executing swaps.

We will use this too see how much we self-trade when using Cowswap as an execution venue, so we also re-enable usage of Cowswap.

### Testing
- [x] Ran a local funds manager w/ a testing endpoint that invokes `get_self_trade_volume` for a provided TX hash, tested w/ a [known self-trade](https://arbiscan.io/tx/0xfa104dfe1862c8f1ef4d907cd509cd1efb15f72a8bae4f6fa3d7da7cc59c0b93) and asserted that the calculated volume matched what was expected