### PR TITLE
funds-manager: metrics: handle non-transfer logs in self trade volume calc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
  "num-traits",
  "pq-sys",
  "r2d2",
- "uuid 0.8.2",
+ "uuid 1.17.0",
 ]
 
 [[package]]

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -70,5 +70,5 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = { workspace = true }
 tracing = "0.1"
-uuid = "1.16"
+uuid = "=1.17.0"
 serde_qs = { version = "1.0.0-rc.3", features = ["warp"] }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -27,7 +27,7 @@ impl AllExecutionVenues {
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
         // TEMP: We are disabling Cowswap by default until we have a mechanism
         // for self-trade prevention
-        vec![&self.lifi, &self.cowswap]
+        vec![&self.lifi]
     }
 
     /// Get a venue by its specifier

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -248,8 +248,11 @@ impl MetricsRecorder {
                     return Ok(0.0);
                 }
 
-                let transfer =
-                    Transfer::decode_log(&log.inner).map_err(FundsManagerError::parse)?;
+                let transfer = match Transfer::decode_log(&log.inner) {
+                    Ok(transfer) => transfer,
+                    // Failure to decode implies the event is not a transfer
+                    Err(_) => return Ok(0.0),
+                };
 
                 if transfer.to == self.darkpool_address || transfer.from == self.darkpool_address {
                     let value =


### PR DESCRIPTION
This PR has the funds manager's `MetricsRecorder` gracefully handle the processing of non-`Transfer` logs when calculating self-trade volume.