### PR TITLE
auth-server: metrics: tag external match metrics with shared

### DIFF
--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -273,7 +273,8 @@ impl Server {
         }
 
         let order = &req.signed_quote.quote.order;
-        self.handle_bundle_response(order, ctx)
+        let shared_bundle = req.allow_shared;
+        self.handle_bundle_response(order, ctx, shared_bundle)
     }
 }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -248,6 +248,6 @@ impl Server {
 
         let req = ctx.request();
         let order = &req.external_order;
-        self.handle_bundle_response(order, ctx)
+        self.handle_bundle_response(order, ctx, true /* shared */)
     }
 }

--- a/auth/auth-server/src/server/api_handlers/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/mod.rs
@@ -30,7 +30,9 @@ use super::gas_sponsorship::refund_calculation::{
 };
 use crate::error::AuthServerError;
 use crate::telemetry::helpers::calculate_implied_price;
-use crate::telemetry::labels::{GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG};
+use crate::telemetry::labels::{
+    GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG, SHARED_BUNDLE_TAG,
+};
 use crate::telemetry::{
     helpers::record_external_match_metrics,
     labels::{KEY_DESCRIPTION_METRIC_TAG, REQUEST_ID_METRIC_TAG, REQUEST_PATH_METRIC_TAG},
@@ -166,6 +168,7 @@ impl Server {
         &self,
         order: &ExternalOrder,
         ctx: &MatchBundleResponseCtx<Req>,
+        shared_bundle: bool,
     ) -> Result<(), AuthServerError>
     where
         Req: Serialize + for<'de> Deserialize<'de>,
@@ -183,6 +186,7 @@ impl Server {
             (GAS_SPONSORED_METRIC_TAG.to_string(), is_sponsored.to_string()),
             (SDK_VERSION_METRIC_TAG.to_string(), ctx.sdk_version.clone()),
             (REQUEST_PATH_METRIC_TAG.to_string(), ctx.path.clone()),
+            (SHARED_BUNDLE_TAG.to_string(), shared_bundle.to_string()),
         ];
 
         // Record quote comparisons before settlement, if enabled

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -127,3 +127,6 @@ pub const L2_BASE_FEE_TAG: &str = "l2_base_fee";
 /// Metric tag indicating whether or not the bundle was settled as part of a CoW
 /// Protocol auction
 pub const SETTLED_VIA_COWSWAP_TAG: &str = "settled_via_cowswap";
+
+/// Metric tag indicating whether a bundle is shared
+pub const SHARED_BUNDLE_TAG: &str = "shared"; // values: "true" | "false"


### PR DESCRIPTION
### Purpose
This PR tags external match metrics with `shared: true | false` to add widgets displaying the count of shared vs. exclusive bundles that are propagated.

### Testing
- [x] Test in testnet that metrics are correctly tagged