### PR TITLE
funds-manager: execution_client: bebop: get quotes

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -100,6 +100,10 @@ pub struct QuoteParams {
     ///
     /// If not provided, the default slippage tolerance will be used.
     pub slippage_tolerance: Option<f64>,
+    /// Whether to increase the price deviation tolerance when it is exceeded
+    /// in fetched quotes
+    #[serde(default)]
+    pub increase_price_deviation: bool,
     /// The venue to use for the quote. If not provided, the best quote across
     /// all venues will be selected.
     pub venue: Option<SupportedExecutionVenue>,

--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -68,6 +68,8 @@ pub enum SupportedExecutionVenue {
     Lifi,
     /// The Cowswap venue
     Cowswap,
+    /// The Bebop venue
+    Bebop,
 }
 
 impl Display for SupportedExecutionVenue {
@@ -75,6 +77,7 @@ impl Display for SupportedExecutionVenue {
         match self {
             SupportedExecutionVenue::Lifi => write!(f, "Lifi"),
             SupportedExecutionVenue::Cowswap => write!(f, "Cowswap"),
+            SupportedExecutionVenue::Bebop => write!(f, "Bebop"),
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -10,7 +10,9 @@ use renegade_common::types::chain::Chain;
 
 use crate::{
     cli::MaxPriceDeviations,
-    execution_client::venues::{cowswap::CowswapClient, lifi::LifiClient, AllExecutionVenues},
+    execution_client::venues::{
+        bebop::BebopClient, cowswap::CowswapClient, lifi::LifiClient, AllExecutionVenues,
+    },
     helpers::{build_provider, get_erc20_balance},
 };
 
@@ -47,9 +49,10 @@ impl ExecutionClient {
         let rpc_provider = build_provider(rpc_url, None /* wallet */);
 
         let lifi = LifiClient::new(lifi_api_key, rpc_url, quoter_hot_wallet.clone(), chain);
-        let cowswap = CowswapClient::new(rpc_url, quoter_hot_wallet, chain);
+        let cowswap = CowswapClient::new(rpc_url, quoter_hot_wallet.clone(), chain);
+        let bebop = BebopClient::new(rpc_url, quoter_hot_wallet, chain);
 
-        let venues = AllExecutionVenues { lifi, cowswap };
+        let venues = AllExecutionVenues { lifi, cowswap, bebop };
 
         Self {
             chain,

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -4,7 +4,7 @@ pub mod swap;
 pub mod venues;
 
 use alloy::{providers::DynProvider, signers::local::PrivateKeySigner};
-use alloy_primitives::Address;
+use alloy_primitives::{Address, U256};
 use price_reporter_client::PriceReporterClient;
 use renegade_common::types::chain::Chain;
 
@@ -13,7 +13,7 @@ use crate::{
     execution_client::venues::{
         bebop::BebopClient, cowswap::CowswapClient, lifi::LifiClient, AllExecutionVenues,
     },
-    helpers::{build_provider, get_erc20_balance},
+    helpers::{build_provider, get_erc20_balance, get_erc20_balance_raw},
 };
 
 use self::error::ExecutionClientError;
@@ -62,6 +62,20 @@ impl ExecutionClient {
             venues,
             max_price_deviations,
         }
+    }
+
+    /// Get the erc20 balance of an address, as a U256
+    pub(crate) async fn get_erc20_balance_raw(
+        &self,
+        token_address: &str,
+    ) -> Result<U256, ExecutionClientError> {
+        get_erc20_balance_raw(
+            token_address,
+            &self.hot_wallet_address.to_string(),
+            self.rpc_provider.clone(),
+        )
+        .await
+        .map_err(ExecutionClientError::onchain)
     }
 
     /// Get the erc20 balance of an address

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
@@ -52,163 +52,82 @@ pub enum ApprovalType {
     Standard,
 }
 
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum BebopQuoteResponse {
-    Successful(BebopSuccessfulQuoteResponse),
-    Error(BebopQuoteErrorResponse),
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct BebopSuccessfulQuoteResponse {
+pub struct BebopQuoteResponse {
     routes: Vec<BebopRoute>,
-    errors: BebopQuoteError,
     best_price: BebopRouteSource,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct BebopRoute {
-    #[serde(rename = "type")]
-    pub route_type: BebopRouteSource,
-    quote: BebopQuote,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub enum BebopRouteSource {
-    #[serde(rename = "JAMv2")]
-    JAM,
-    #[serde(rename = "PMMv3")]
-    PMM,
+    JAMv2,
+    PMMv3,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-pub enum BebopQuote {
-    JAM(BebopJamQuote),
-    PMM(BebopPmmQuote),
+#[serde(tag = "type", content = "quote")]
+pub enum BebopRoute {
+    JAMv2(BebopJamQuote),
+    PMMv3(BebopPmmQuote),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BebopJamQuote {
-    #[serde(flatten)]
-    quote: BebopQuoteInfo,
-    hooks_hash: String,
-    to_sign: BebopSignableJamOrder,
+    slippage: f64,
+    buy_tokens: HashMap<String, BebopBuyToken>,
+    sell_tokens: HashMap<String, BebopSellToken>,
+    settlement_address: String,
+    approval_target: String,
+    price_impact: f64,
+    tx: BebopTxData,
     solver: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BebopPmmQuote {
-    #[serde(flatten)]
-    quote: BebopQuoteInfo,
-    makers: Vec<String>,
-    to_sign: BebopSignablePmmOrder,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopQuoteInfo {
     slippage: f64,
-    gas_fee: BebopGasFee,
-    buy_tokens: BebopBuyToken,
-    sell_tokens: BebopQuotedTokenInfo,
+    buy_tokens: HashMap<String, BebopBuyToken>,
+    sell_tokens: HashMap<String, BebopSellToken>,
     settlement_address: String,
     approval_target: String,
-    required_signatures: Vec<String>,
-    price_impact: Option<f64>,
-    tx: Option<BebopTxData>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopGasFee {
-    native: String,
-    usd: Option<f64>,
+    price_impact: f64,
+    tx: BebopTxData,
+    makers: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BebopBuyToken {
-    #[serde(flatten)]
-    info: BebopQuotedTokenInfo,
+    amount: String,
+    decimals: u8,
+    price_usd: f64,
+    symbol: String,
+    price: f64,
+    price_before_fee: f64,
     minimum_amount: String,
-    amount_before_fee: Option<String>,
-    delta_from_expected: Option<f64>,
+    amount_before_fee: String,
+    delta_from_expected: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct BebopQuotedTokenInfo {
+pub struct BebopSellToken {
     amount: String,
     decimals: u8,
-    price_usd: Option<f64>,
+    price_usd: f64,
     symbol: String,
-    price: Option<f64>,
-    price_before_fee: Option<f64>,
+    price: f64,
+    price_before_fee: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BebopTxData {
-    from: Option<String>,
+    from: String,
     to: String,
     value: String,
     data: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopSignableJamOrder {
-    taker: String,
-    receiver: String,
-    expiry: u128,
-    exclusivity_deadline: u128,
-    nonce: String,
-    executor: String,
-    partner_info: String,
-    sell_tokens: Vec<String>,
-    buy_tokens: Vec<String>,
-    sell_amounts: Vec<String>,
-    buy_amounts: Vec<String>,
-    hooks_hash: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct BebopSignablePmmOrder {
-    partner_id: u128,
-    expiry: u128,
-    taker_address: String,
-    maker_address: String,
-    maker_nonce: String,
-    taker_token: String,
-    maker_token: String,
-    taker_amount: String,
-    maker_amount: String,
-    receiver: String,
-    packed_commands: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopQuoteError {
-    error_code: u128,
-    message: Option<String>,
-    fee: Option<BebopMinSizeFee>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopMinSizeFee {
-    ether: f64,
-    usd: f64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopQuoteErrorResponse {
-    error: BebopQuoteError,
-    route_errors: HashMap<BebopRouteSource, BebopQuoteError>,
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
@@ -2,26 +2,40 @@
 
 use std::str::FromStr;
 
-use alloy::{providers::DynProvider, signers::local::PrivateKeySigner};
-use alloy_primitives::Address;
+use alloy::{
+    eips::BlockId,
+    network::TransactionBuilder,
+    providers::{DynProvider, Provider},
+    rpc::types::{TransactionReceipt, TransactionRequest},
+    signers::local::PrivateKeySigner,
+};
+use alloy_primitives::{Address, Bytes, U256};
 use async_trait::async_trait;
-use funds_manager_api::quoters::{QuoteParams, SupportedExecutionVenue};
+use funds_manager_api::{
+    quoters::{QuoteParams, SupportedExecutionVenue},
+    u256_try_into_u64,
+};
 use renegade_common::types::chain::Chain;
 use reqwest::Client;
 use serde::Deserialize;
-use tracing::instrument;
+use tracing::{info, instrument, warn};
 
 use crate::{
     execution_client::{
         error::ExecutionClientError,
         swap::DEFAULT_SLIPPAGE_TOLERANCE,
         venues::{
-            bebop::api_types::{ApprovalType, BebopQuoteParams, BebopQuoteResponse},
-            quote::ExecutableQuote,
+            bebop::api_types::{
+                ApprovalType, BebopQuoteParams, BebopQuoteResponse, BebopRouteSource,
+            },
+            quote::{ExecutableQuote, ExecutionQuote, QuoteExecutionData},
             ExecutionResult, ExecutionVenue,
         },
     },
-    helpers::{build_provider, handle_http_response},
+    helpers::{
+        approve_erc20_allowance, build_provider, get_gas_cost, get_received_amount,
+        handle_http_response, send_tx_with_retry, ONE_CONFIRMATION,
+    },
 };
 
 pub mod api_types;
@@ -36,6 +50,71 @@ const BEBOP_BASE_URL: &str = "https://api.bebop.xyz/router";
 /// The endpoint for getting a quote
 const BEBOP_QUOTE_ENDPOINT: &str = "v1/quote";
 
+// ---------
+// | Types |
+// ---------
+
+/// Bebop quote execution data
+#[derive(Debug, Clone)]
+pub struct BebopQuoteExecutionData {
+    /// The address of the swap contract
+    pub to: Address,
+    /// The submitting address
+    pub from: Address,
+    /// The value of the tx; should be zero
+    pub value: U256,
+    /// The calldata for the swap
+    pub data: Bytes,
+    /// The gas limit for the swap
+    pub gas_limit: U256,
+    /// The approval target for the swap
+    pub approval_target: Address,
+    /// The source of the solution for the quote
+    pub route_source: BebopRouteSource,
+}
+
+impl ExecutableQuote {
+    /// Convert a Bebop quote into an executable quote
+    pub fn from_bebop_quote(
+        bebop_quote: BebopQuoteResponse,
+        chain: Chain,
+    ) -> Result<Self, ExecutionClientError> {
+        let sell_token = bebop_quote.sell_token(chain)?;
+        let buy_token = bebop_quote.buy_token(chain)?;
+        let sell_amount = bebop_quote.sell_amount()?;
+        let buy_amount = bebop_quote.buy_amount()?;
+
+        let quote = ExecutionQuote {
+            sell_token,
+            buy_token,
+            sell_amount,
+            buy_amount,
+            venue: SupportedExecutionVenue::Bebop,
+            chain,
+        };
+
+        let to = bebop_quote.get_to_address()?;
+        let from = bebop_quote.get_from_address()?;
+        let value = bebop_quote.get_value()?;
+        let data = bebop_quote.get_data()?;
+        let gas_limit = bebop_quote.get_gas_limit()?;
+        let approval_target = bebop_quote.get_approval_target()?;
+        let route_source = bebop_quote.get_route_source()?;
+
+        let execution_data = BebopQuoteExecutionData {
+            to,
+            from,
+            value,
+            data,
+            gas_limit,
+            approval_target,
+            route_source,
+        };
+
+        Ok(ExecutableQuote { quote, execution_data: QuoteExecutionData::Bebop(execution_data) })
+    }
+}
+
 // ----------
 // | Client |
 // ----------
@@ -46,7 +125,7 @@ pub struct BebopClient {
     /// The underlying HTTP client
     http_client: Client,
     /// The RPC provider
-    _rpc_provider: DynProvider,
+    rpc_provider: DynProvider,
     /// The address of the hot wallet used for executing quotes
     hot_wallet_address: Address,
     /// The chain on which the client is operating
@@ -57,9 +136,9 @@ impl BebopClient {
     /// Create a new client
     pub fn new(rpc_url: &str, hot_wallet: PrivateKeySigner, chain: Chain) -> Self {
         let hot_wallet_address = hot_wallet.address();
-        let _rpc_provider = build_provider(rpc_url, Some(hot_wallet));
+        let rpc_provider = build_provider(rpc_url, Some(hot_wallet));
 
-        Self { http_client: Client::new(), _rpc_provider, hot_wallet_address, chain }
+        Self { http_client: Client::new(), rpc_provider, hot_wallet_address, chain }
     }
 
     /// Build a Bebop API URL for a given path
@@ -103,6 +182,69 @@ impl BebopClient {
             skip_taker_checks: true,
         })
     }
+
+    /// Approve an erc20 allowance for the given approval target
+    #[instrument(skip(self))]
+    async fn approve_erc20_allowance(
+        &self,
+        token_address: Address,
+        amount: U256,
+        approval_target: Address,
+    ) -> Result<(), ExecutionClientError> {
+        approve_erc20_allowance(
+            token_address,
+            approval_target,
+            self.hot_wallet_address,
+            amount,
+            self.rpc_provider.clone(),
+        )
+        .await
+        .map_err(ExecutionClientError::onchain)
+    }
+
+    /// Build a swap transaction from Bebop execution data
+    async fn build_swap_tx(
+        &self,
+        execution_data: &BebopQuoteExecutionData,
+    ) -> Result<TransactionRequest, ExecutionClientError> {
+        let latest_block = self
+            .rpc_provider
+            .get_block(BlockId::latest())
+            .await
+            .map_err(ExecutionClientError::onchain)?
+            .ok_or(ExecutionClientError::onchain("No latest block found"))?;
+
+        let latest_basefee = latest_block
+            .header
+            .base_fee_per_gas
+            .ok_or(ExecutionClientError::onchain("No basefee found"))?
+            as u128;
+
+        let gas_limit =
+            u256_try_into_u64(execution_data.gas_limit).map_err(ExecutionClientError::onchain)?;
+
+        let tx = TransactionRequest::default()
+            .with_to(execution_data.to)
+            .with_from(execution_data.from)
+            .with_value(execution_data.value)
+            .with_input(execution_data.data.clone())
+            .with_max_fee_per_gas(latest_basefee * 2)
+            .with_max_priority_fee_per_gas(latest_basefee * 2)
+            .with_gas_limit(gas_limit * 2);
+
+        Ok(tx)
+    }
+
+    /// Send an onchain transaction with the configured RPC provider
+    /// (expected to be configured with a signer)
+    async fn send_tx(
+        &self,
+        tx: TransactionRequest,
+    ) -> Result<TransactionReceipt, ExecutionClientError> {
+        send_tx_with_retry(tx, &self.rpc_provider, ONE_CONFIRMATION)
+            .await
+            .map_err(ExecutionClientError::onchain)
+    }
 }
 
 // ------------------------
@@ -128,7 +270,7 @@ impl ExecutionVenue for BebopClient {
 
         let path = format!("{BEBOP_QUOTE_ENDPOINT}?{query_string}");
         let quote_response: BebopQuoteResponse = self.send_get_request(&path).await?;
-        let executable_quote = todo!();
+        let executable_quote = ExecutableQuote::from_bebop_quote(quote_response, self.chain)?;
 
         Ok(executable_quote)
     }
@@ -137,9 +279,39 @@ impl ExecutionVenue for BebopClient {
     #[instrument(skip_all)]
     async fn execute_quote(
         &self,
-        _executable_quote: &ExecutableQuote,
+        executable_quote: &ExecutableQuote,
     ) -> Result<ExecutionResult, ExecutionClientError> {
-        todo!()
+        let ExecutableQuote { quote, execution_data } = executable_quote;
+        let bebop_execution_data = execution_data.bebop()?;
+
+        self.approve_erc20_allowance(
+            quote.sell_token.get_alloy_address(),
+            quote.sell_amount,
+            bebop_execution_data.approval_target,
+        )
+        .await?;
+
+        let tx = self.build_swap_tx(&bebop_execution_data).await?;
+
+        info!("Executing Bebop {} quote", bebop_execution_data.route_source);
+
+        let receipt = self.send_tx(tx).await?;
+        let gas_cost = get_gas_cost(&receipt);
+        let tx_hash = receipt.transaction_hash;
+
+        if receipt.status() {
+            let recipient = bebop_execution_data.from;
+            let buy_token_address = quote.buy_token.get_alloy_address();
+            let buy_amount_actual = get_received_amount(&receipt, buy_token_address, recipient)
+                .map_err(ExecutionClientError::onchain)?;
+
+            Ok(ExecutionResult { buy_amount_actual, gas_cost, tx_hash: Some(tx_hash) })
+        } else {
+            warn!("tx ({:#x}) failed", tx_hash);
+            // For an unsuccessful swap, we exclude the TX hash and report
+            // an actual buy amount of zero, but we still include the gas cost
+            Ok(ExecutionResult { buy_amount_actual: U256::ZERO, gas_cost, tx_hash: None })
+        }
     }
 }
 

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
@@ -1,3 +1,160 @@
 //! Bebop-specific logic for getting quotes and executing swaps
 
+use alloy::{providers::DynProvider, signers::local::PrivateKeySigner};
+use alloy_primitives::Address;
+use async_trait::async_trait;
+use funds_manager_api::quoters::{QuoteParams, SupportedExecutionVenue};
+use renegade_common::types::chain::Chain;
+use reqwest::Client;
+use serde::Deserialize;
+use tracing::{info, instrument};
+
+use crate::{
+    execution_client::{
+        error::ExecutionClientError,
+        swap::DEFAULT_SLIPPAGE_TOLERANCE,
+        venues::{
+            bebop::api_types::{ApprovalType, BebopQuoteParams, BebopQuoteResponse},
+            quote::ExecutableQuote,
+            ExecutionResult, ExecutionVenue,
+        },
+    },
+    helpers::{build_provider, handle_http_response},
+};
+
 pub mod api_types;
+
+// -------------
+// | Constants |
+// -------------
+
+/// The base URL for the Bebop API
+const BEBOP_BASE_URL: &str = "https://api.bebop.xyz/router";
+
+/// The endpoint for getting a quote
+const BEBOP_QUOTE_ENDPOINT: &str = "v1/quote";
+
+// ----------
+// | Client |
+// ----------
+
+/// A client for interacting with the Bebop API
+#[derive(Clone)]
+pub struct BebopClient {
+    /// The underlying HTTP client
+    http_client: Client,
+    /// The RPC provider
+    _rpc_provider: DynProvider,
+    /// The address of the hot wallet used for executing quotes
+    hot_wallet_address: Address,
+    /// The chain on which the client is operating
+    chain: Chain,
+}
+
+impl BebopClient {
+    /// Create a new client
+    pub fn new(rpc_url: &str, hot_wallet: PrivateKeySigner, chain: Chain) -> Self {
+        let hot_wallet_address = hot_wallet.address();
+        let _rpc_provider = build_provider(rpc_url, Some(hot_wallet));
+
+        Self { http_client: Client::new(), _rpc_provider, hot_wallet_address, chain }
+    }
+
+    /// Build a Bebop API URL for a given path
+    fn build_bebop_url(&self, path: &str) -> Result<String, ExecutionClientError> {
+        let chain = to_bebop_chain(self.chain)?;
+        let url = format!("{BEBOP_BASE_URL}/{chain}/{path}");
+        Ok(url)
+    }
+
+    /// Send a get request to Bebop
+    async fn send_get_request<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+    ) -> Result<T, ExecutionClientError> {
+        let url = self.build_bebop_url(path)?;
+
+        let response = self.http_client.get(url).send().await?;
+        handle_http_response(response).await.map_err(ExecutionClientError::http)
+    }
+
+    /// Construct Bebop quote parameters from a venue-agnostic quote params
+    /// object, with reasonable defaults.
+    fn construct_quote_params(&self, params: QuoteParams) -> BebopQuoteParams {
+        BebopQuoteParams {
+            sell_tokens: params.from_token,
+            buy_tokens: params.to_token,
+            sell_amounts: params.from_amount.to_string(),
+            taker_address: self.hot_wallet_address.to_string(),
+            approval_type: ApprovalType::Standard,
+            gasless: false, // We want to self-execute the quote
+            slippage: params.slippage_tolerance.unwrap_or(DEFAULT_SLIPPAGE_TOLERANCE),
+            // We skip taker checks (approvals, gas estimate, balance) when requesting a quote,
+            // as we only want these constraints to be enforced if/when we execute the quote.
+            skip_validation: true,
+            skip_taker_checks: true,
+        }
+    }
+}
+
+// ------------------------
+// | Execution Venue Impl |
+// ------------------------
+
+#[async_trait]
+impl ExecutionVenue for BebopClient {
+    /// Get the name of the venue
+    fn venue_specifier(&self) -> SupportedExecutionVenue {
+        SupportedExecutionVenue::Bebop
+    }
+
+    /// Get a quote from the Bebop API
+    #[instrument(skip_all)]
+    async fn get_quote(
+        &self,
+        params: QuoteParams,
+    ) -> Result<ExecutableQuote, ExecutionClientError> {
+        let quote_params = self.construct_quote_params(params);
+        let query_string =
+            serde_qs::to_string(&quote_params).map_err(ExecutionClientError::parse)?;
+
+        let path = format!("{BEBOP_QUOTE_ENDPOINT}?{query_string}");
+        let quote_response: BebopQuoteResponse = self.send_get_request(&path).await?;
+
+        let _executable_quote = match quote_response {
+            BebopQuoteResponse::Error(error_response) => {
+                return Err(ExecutionClientError::custom(format!(
+                    "Error getting Bebop quote: {error_response:?}"
+                )))
+            },
+            BebopQuoteResponse::Successful(quote_response) => {
+                info!("Bebop quote response: {quote_response:?}");
+                todo!()
+            },
+        };
+
+        Ok(_executable_quote)
+    }
+
+    /// Execute a quote from the Bebop API
+    #[instrument(skip_all)]
+    async fn execute_quote(
+        &self,
+        _executable_quote: &ExecutableQuote,
+    ) -> Result<ExecutionResult, ExecutionClientError> {
+        todo!()
+    }
+}
+
+// -----------
+// | Helpers |
+// -----------
+
+/// Convert a `Chain` to a Bebop chain name
+fn to_bebop_chain(chain: Chain) -> Result<String, ExecutionClientError> {
+    match chain {
+        Chain::ArbitrumOne => Ok("arbitrum".to_string()),
+        Chain::BaseMainnet => Ok("base".to_string()),
+        _ => Err(ExecutionClientError::onchain(format!("Bebop does not support chain: {chain}"))),
+    }
+}

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -308,7 +308,9 @@ impl ExecutionVenue for LifiClient {
     ) -> Result<ExecutableQuote, ExecutionClientError> {
         let lifi_params = self.construct_quote_params(params);
         let qs_config = serde_qs::Config::new().array_format(serde_qs::ArrayFormat::Unindexed);
-        let query_string = qs_config.serialize_string(&lifi_params).unwrap();
+        let query_string =
+            qs_config.serialize_string(&lifi_params).map_err(ExecutionClientError::parse)?;
+
         let path = format!("{LIFI_QUOTE_ENDPOINT}?{query_string}");
 
         // Log the request path if the quote fails

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -32,7 +32,7 @@ impl AllExecutionVenues {
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
         // TEMP: We are disabling Cowswap by default until we have a mechanism
         // for self-trade prevention
-        vec![&self.lifi, &self.cowswap]
+        vec![&self.lifi, &self.bebop]
     }
 
     /// Get a venue by its specifier

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -6,7 +6,9 @@ use funds_manager_api::quoters::{QuoteParams, SupportedExecutionVenue};
 
 use crate::execution_client::{
     error::ExecutionClientError,
-    venues::{cowswap::CowswapClient, lifi::LifiClient, quote::ExecutableQuote},
+    venues::{
+        bebop::BebopClient, cowswap::CowswapClient, lifi::LifiClient, quote::ExecutableQuote,
+    },
 };
 
 pub mod bebop;
@@ -21,6 +23,8 @@ pub struct AllExecutionVenues {
     pub lifi: LifiClient,
     /// The Cowswap client
     pub cowswap: CowswapClient,
+    /// The Bebop client
+    pub bebop: BebopClient,
 }
 
 impl AllExecutionVenues {
@@ -36,6 +40,7 @@ impl AllExecutionVenues {
         match venue {
             SupportedExecutionVenue::Lifi => &self.lifi,
             SupportedExecutionVenue::Cowswap => &self.cowswap,
+            SupportedExecutionVenue::Bebop => &self.bebop,
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
@@ -11,8 +11,8 @@ use crate::{
     execution_client::{
         error::ExecutionClientError,
         venues::{
-            cowswap::CowswapQuoteExecutionData, lifi::LifiQuoteExecutionData,
-            SupportedExecutionVenue,
+            bebop::BebopQuoteExecutionData, cowswap::CowswapQuoteExecutionData,
+            lifi::LifiQuoteExecutionData, SupportedExecutionVenue,
         },
     },
     helpers::to_chain_id,
@@ -151,6 +151,8 @@ pub enum QuoteExecutionData {
     Lifi(LifiQuoteExecutionData),
     /// Cowswap-specific quote execution data
     Cowswap(CowswapQuoteExecutionData),
+    /// Bebop-specific quote execution data
+    Bebop(BebopQuoteExecutionData),
 }
 
 impl QuoteExecutionData {
@@ -169,6 +171,15 @@ impl QuoteExecutionData {
         match self {
             QuoteExecutionData::Cowswap(data) => Ok(data.clone()),
             _ => Err(ExecutionClientError::quote_conversion("Non-Cowswap quote execution data")),
+        }
+    }
+
+    /// "Unwraps" Bebop quote execution data, returning an error if it is not
+    /// the Bebop variant
+    pub fn bebop(&self) -> Result<BebopQuoteExecutionData, ExecutionClientError> {
+        match self {
+            QuoteExecutionData::Bebop(data) => Ok(data.clone()),
+            _ => Err(ExecutionClientError::quote_conversion("Non-Bebop quote execution data")),
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -74,8 +74,23 @@ use crate::handlers::{
 // | Cli |
 // -------
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+/// The runtime stack size to use for the server
+const RUNTIME_STACK_SIZE: usize = 50 * 1024 * 1024; // 50MB
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Create a custom tokio runtime with 50MB stack size.
+    // We sometimes see stack overflows in debug mode; so we manually setup the
+    // stack
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(RUNTIME_STACK_SIZE)
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime")
+        .block_on(async_main())
+}
+
+/// Async main function
+async fn async_main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     cli.validate()?;
     if cli.hmac_key.is_none() {

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -248,8 +248,11 @@ impl MetricsRecorder {
                     return Ok(0.0);
                 }
 
-                let transfer =
-                    Transfer::decode_log(&log.inner).map_err(FundsManagerError::parse)?;
+                let transfer = match Transfer::decode_log(&log.inner) {
+                    Ok(transfer) => transfer,
+                    // Failure to decode implies the event is not a transfer
+                    Err(_) => return Ok(0.0),
+                };
 
                 if transfer.to == self.darkpool_address || transfer.from == self.darkpool_address {
                     let value =


### PR DESCRIPTION
This PR implements `ExecutionVenue::get_quote` for the `BebopClient`. In the process, I simplified many of the API types. There were a bunch of issues stemming from using untagged enums & the combination of flattened structs w/ `f64`s that are now avoided.

### Testing
- [x] Run local funds manager, assert that we can successfully get + deserialize quotes from Bebop