### PR TITLE
funds-manager: execution_client: bebop: convert into ExecutableQuote

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -100,6 +100,10 @@ pub struct QuoteParams {
     ///
     /// If not provided, the default slippage tolerance will be used.
     pub slippage_tolerance: Option<f64>,
+    /// Whether to increase the price deviation tolerance when it is exceeded
+    /// in fetched quotes
+    #[serde(default)]
+    pub increase_price_deviation: bool,
     /// The venue to use for the quote. If not provided, the best quote across
     /// all venues will be selected.
     pub venue: Option<SupportedExecutionVenue>,

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -4,7 +4,7 @@ pub mod swap;
 pub mod venues;
 
 use alloy::{providers::DynProvider, signers::local::PrivateKeySigner};
-use alloy_primitives::Address;
+use alloy_primitives::{Address, U256};
 use price_reporter_client::PriceReporterClient;
 use renegade_common::types::chain::Chain;
 
@@ -13,7 +13,7 @@ use crate::{
     execution_client::venues::{
         bebop::BebopClient, cowswap::CowswapClient, lifi::LifiClient, AllExecutionVenues,
     },
-    helpers::{build_provider, get_erc20_balance},
+    helpers::{build_provider, get_erc20_balance, get_erc20_balance_raw},
 };
 
 use self::error::ExecutionClientError;
@@ -62,6 +62,20 @@ impl ExecutionClient {
             venues,
             max_price_deviations,
         }
+    }
+
+    /// Get the erc20 balance of an address, as a U256
+    pub(crate) async fn get_erc20_balance_raw(
+        &self,
+        token_address: &str,
+    ) -> Result<U256, ExecutionClientError> {
+        get_erc20_balance_raw(
+            token_address,
+            &self.hot_wallet_address.to_string(),
+            self.rpc_provider.clone(),
+        )
+        .await
+        .map_err(ExecutionClientError::onchain)
     }
 
     /// Get the erc20 balance of an address

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -471,6 +471,7 @@ impl ExecutionClient {
             QuoteExecutionData::Cowswap(_) => {
                 self.venues.cowswap.execute_quote(executable_quote).await
             },
+            QuoteExecutionData::Bebop(_) => self.venues.bebop.execute_quote(executable_quote).await,
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -33,6 +33,11 @@ const SWAP_DECAY_FACTOR: U256 = U256::from_limbs([2, 0, 0, 0]);
 const MIN_SWAP_QUOTE_AMOUNT: f64 = 10.0; // 10 USDC
 /// The default maximum allowable deviation from the Renegade price in a quote
 const DEFAULT_MAX_PRICE_DEVIATION: f64 = 0.0100; // 100bps, or 1%
+/// The relative amount by which the price deviation tolerance will be increased
+const PRICE_DEVIATION_INCREASE: f64 = 0.2; // 20%
+/// The maximum multiple of the default price deviation tolerance that will be
+/// allowed
+const MAX_PRICE_DEVIATION_INCREASE: f64 = 4.0; // 4x
 /// The buffer to scale the target amount by when executing swaps to cover it,
 /// to account for price drift
 const SWAP_TO_COVER_BUFFER: f64 = 1.1;
@@ -95,10 +100,9 @@ impl ExecutionClient {
         mut params: QuoteParams,
     ) -> Result<Option<DecayingSwapOutcome>, ExecutionClientError> {
         let mut cumulative_gas_cost = U256::ZERO;
+        let mut max_price_deviation_multiplier = 1.0;
         loop {
-            let expected_quote_amount = self.get_expected_quote_amount(&params).await?;
-            if expected_quote_amount < MIN_SWAP_QUOTE_AMOUNT {
-                warn!("Expected swap amount of {expected_quote_amount} USDC is less than minimum swap amount ({MIN_SWAP_QUOTE_AMOUNT})");
+            if !self.can_execute_swap(&params).await? {
                 return Ok(None);
             }
 
@@ -111,10 +115,15 @@ impl ExecutionClient {
             let executable_quote = maybe_executable_quote.unwrap();
 
             if self
-                .exceeds_price_deviation(&executable_quote.quote, params.slippage_tolerance)
+                .exceeds_price_deviation(&executable_quote.quote, max_price_deviation_multiplier)
                 .await?
             {
-                params.from_amount /= SWAP_DECAY_FACTOR;
+                adjust_for_price_deviation(&mut params, &mut max_price_deviation_multiplier);
+                if max_price_deviation_multiplier > MAX_PRICE_DEVIATION_INCREASE {
+                    warn!("Price deviation tolerance exceeds maximum increase ({MAX_PRICE_DEVIATION_INCREASE}x)");
+                    return Ok(None);
+                }
+
                 continue;
             }
 
@@ -138,27 +147,6 @@ impl ExecutionClient {
             warn!("swap failed, retrying w/ reduced-size quote");
             params.from_amount /= SWAP_DECAY_FACTOR;
         }
-    }
-
-    /// Compute the expected quote amount for a swap, using the Renegade price
-    /// for the sell token
-    async fn get_expected_quote_amount(
-        &self,
-        params: &QuoteParams,
-    ) -> Result<f64, ExecutionClientError> {
-        let from_token = Token::from_addr_on_chain(&params.from_token, self.chain);
-        let from_amount_u128 =
-            u256_try_into_u128(params.from_amount).map_err(ExecutionClientError::parse)?;
-
-        let from_amount_f64 = from_token.convert_to_decimal(from_amount_u128);
-        if from_token.is_stablecoin() {
-            return Ok(from_amount_f64);
-        }
-
-        let price = self.price_reporter.get_price(&from_token.addr, self.chain).await?;
-        let approx_quote_amount = from_amount_f64 * price;
-
-        Ok(approx_quote_amount)
     }
 
     /// Try to execute swaps to cover a target amount of a token,
@@ -346,6 +334,44 @@ impl ExecutionClient {
     // | General Swapping Helpers |
     // ----------------------------
 
+    /// Check whether a swap represented by the quote params meets the criteria
+    /// for execution
+    async fn can_execute_swap(&self, params: &QuoteParams) -> Result<bool, ExecutionClientError> {
+        if !self.has_sufficient_balance(params).await? {
+            warn!("Hot wallet does not have sufficient balance to cover swap");
+            return Ok(false);
+        }
+
+        let expected_quote_amount = self.get_expected_quote_amount(params).await?;
+        if expected_quote_amount < MIN_SWAP_QUOTE_AMOUNT {
+            warn!("Expected swap amount of {expected_quote_amount} USDC is less than minimum swap amount ({MIN_SWAP_QUOTE_AMOUNT})");
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    /// Compute the expected quote amount for a swap, using the Renegade price
+    /// for the sell token
+    async fn get_expected_quote_amount(
+        &self,
+        params: &QuoteParams,
+    ) -> Result<f64, ExecutionClientError> {
+        let from_token = Token::from_addr_on_chain(&params.from_token, self.chain);
+        let from_amount_u128 =
+            u256_try_into_u128(params.from_amount).map_err(ExecutionClientError::parse)?;
+
+        let from_amount_f64 = from_token.convert_to_decimal(from_amount_u128);
+        if from_token.is_stablecoin() {
+            return Ok(from_amount_f64);
+        }
+
+        let price = self.price_reporter.get_price(&from_token.addr, self.chain).await?;
+        let approx_quote_amount = from_amount_f64 * price;
+
+        Ok(approx_quote_amount)
+    }
+
     /// Get the best quote for a swap, across all execution venues
     #[instrument(
         skip_all,
@@ -409,11 +435,21 @@ impl ExecutionClient {
         Ok(maybe_best_quote)
     }
 
+    /// Check whether the hot wallet has a sufficient balance to cover a swap
+    /// represened by the quote params
+    async fn has_sufficient_balance(
+        &self,
+        params: &QuoteParams,
+    ) -> Result<bool, ExecutionClientError> {
+        let balance = self.get_erc20_balance_raw(&params.from_token).await?;
+        Ok(balance >= params.from_amount)
+    }
+
     /// Check if a quote deviates too far from the Renegade price
     async fn exceeds_price_deviation(
         &self,
         quote: &ExecutionQuote,
-        slippage_tolerance: Option<f64>,
+        max_deviation_multiplier: f64,
     ) -> Result<bool, ExecutionClientError> {
         // Get the renegade price for the pair
         let base_addr = &quote.base_token().addr;
@@ -438,14 +474,7 @@ impl ExecutionClient {
             .and_then(|ticker| self.max_price_deviations.get(&ticker).copied())
             .unwrap_or(DEFAULT_MAX_PRICE_DEVIATION);
 
-        // If the client specified a slippage tolerance greater than the configured
-        // max deviation, we respect the client's preference to "force through" the
-        // quote.
-        let deviation_threshold = if let Some(slippage_tolerance) = slippage_tolerance {
-            slippage_tolerance.max(max_deviation)
-        } else {
-            max_deviation
-        };
+        let deviation_threshold = max_deviation * max_deviation_multiplier;
 
         let exceeds_max_deviation = deviation > deviation_threshold;
         if exceeds_max_deviation {
@@ -489,4 +518,19 @@ fn record_price_deviation(quote: &ExecutionQuote, deviation: f64) {
         VENUE_TAG => quote.venue.to_string(),
     )
     .set(deviation);
+}
+
+/// Adjust the given quote params in the case that the resulting quote exceeds
+/// the price deviation tolerance.
+///
+/// Concretely, this means increasing the max price deviation multiplier if the
+/// params allow for it, or reducing the swap size otherwise.
+fn adjust_for_price_deviation(params: &mut QuoteParams, max_price_deviation_multiplier: &mut f64) {
+    if params.increase_price_deviation {
+        *max_price_deviation_multiplier += PRICE_DEVIATION_INCREASE;
+        info!("Price deviation exceeded, increasing price deviation tolerance by {max_price_deviation_multiplier}x");
+    } else {
+        info!("Price deviation exceeded, reducing swap size by {SWAP_DECAY_FACTOR}x");
+        params.from_amount /= SWAP_DECAY_FACTOR;
+    }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
@@ -3,7 +3,7 @@
 #![allow(missing_docs)]
 #![allow(clippy::missing_docs_in_private_items)]
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
 
 use alloy_primitives::{Address, Bytes, U256};
 use renegade_common::types::{chain::Chain, token::Token};
@@ -164,6 +164,15 @@ impl BebopQuoteResponse {
 pub enum BebopRouteSource {
     JAMv2,
     PMMv3,
+}
+
+impl Display for BebopRouteSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BebopRouteSource::JAMv2 => write!(f, "JAMv2"),
+            BebopRouteSource::PMMv3 => write!(f, "PMMv3"),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
@@ -5,7 +5,11 @@
 
 use std::collections::HashMap;
 
+use alloy_primitives::{Address, Bytes, U256};
+use renegade_common::types::{chain::Chain, token::Token};
 use serde::{Deserialize, Serialize};
+
+use crate::execution_client::error::ExecutionClientError;
 
 /// The subset of Bebop quote request query parameters that we support.
 ///
@@ -52,82 +56,144 @@ pub enum ApprovalType {
     Standard,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BebopQuoteResponse {
     routes: Vec<BebopRoute>,
     best_price: BebopRouteSource,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+impl BebopQuoteResponse {
+    /// Get the winning route (JAMv2 vs PMMv3) for the quote
+    pub fn best_route(&self) -> Result<&BebopRoute, ExecutionClientError> {
+        self.routes
+            .iter()
+            .find(|route| route.route_source == self.best_price)
+            .ok_or(ExecutionClientError::custom("Winning Bebop route not found"))
+    }
+
+    /// Get the sell token for the quote
+    pub fn sell_token(&self, chain: Chain) -> Result<Token, ExecutionClientError> {
+        let sell_token_address = self
+            .best_route()?
+            .quote
+            .sell_tokens
+            .keys()
+            .next()
+            .ok_or(ExecutionClientError::custom("No sell token found"))?;
+
+        Ok(Token::from_addr_on_chain(sell_token_address, chain))
+    }
+
+    /// Get the buy token for the quote
+    pub fn buy_token(&self, chain: Chain) -> Result<Token, ExecutionClientError> {
+        let buy_token_address = self
+            .best_route()?
+            .quote
+            .buy_tokens
+            .keys()
+            .next()
+            .ok_or(ExecutionClientError::custom("No buy token found"))?;
+
+        Ok(Token::from_addr_on_chain(buy_token_address, chain))
+    }
+
+    /// Get the sell amount for the quote
+    pub fn sell_amount(&self) -> Result<U256, ExecutionClientError> {
+        let bebop_sell_token = self
+            .best_route()?
+            .quote
+            .sell_tokens
+            .values()
+            .next()
+            .ok_or(ExecutionClientError::custom("No sell token found"))?;
+
+        Ok(bebop_sell_token.amount)
+    }
+
+    /// Get the buy amount for the quote
+    pub fn buy_amount(&self) -> Result<U256, ExecutionClientError> {
+        let bebop_buy_token = self
+            .best_route()?
+            .quote
+            .buy_tokens
+            .values()
+            .next()
+            .ok_or(ExecutionClientError::custom("No buy token found"))?;
+
+        Ok(bebop_buy_token.amount)
+    }
+
+    /// Get the `to` address for the quote
+    pub fn get_to_address(&self) -> Result<Address, ExecutionClientError> {
+        self.best_route().map(|route| route.quote.tx.to)
+    }
+
+    /// Get the `from` address for the quote
+    pub fn get_from_address(&self) -> Result<Address, ExecutionClientError> {
+        self.best_route().map(|route| route.quote.tx.from)
+    }
+
+    /// Get the `value` for the quote
+    pub fn get_value(&self) -> Result<U256, ExecutionClientError> {
+        self.best_route().map(|route| route.quote.tx.value)
+    }
+
+    /// Get the calldata for the quote
+    pub fn get_data(&self) -> Result<Bytes, ExecutionClientError> {
+        self.best_route().map(|route| route.quote.tx.data.clone())
+    }
+
+    /// Get the gas limit for the quote
+    pub fn get_gas_limit(&self) -> Result<U256, ExecutionClientError> {
+        self.best_route().map(|route| route.quote.tx.gas)
+    }
+
+    /// Get the approval target for the quote
+    pub fn get_approval_target(&self) -> Result<Address, ExecutionClientError> {
+        self.best_route().map(|route| route.quote.approval_target)
+    }
+
+    /// Get the route source (JAMv2 vs PMMv3) for the quote
+    pub fn get_route_source(&self) -> Result<BebopRouteSource, ExecutionClientError> {
+        self.best_route().map(|route| route.route_source)
+    }
+}
+
+#[derive(Deserialize, PartialEq, Eq, Hash, Debug, Clone, Copy)]
 pub enum BebopRouteSource {
     JAMv2,
     PMMv3,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(tag = "type", content = "quote")]
-pub enum BebopRoute {
-    JAMv2(BebopJamQuote),
-    PMMv3(BebopPmmQuote),
+#[derive(Deserialize, Debug)]
+#[serde(tag = "type")]
+pub struct BebopRoute {
+    #[serde(rename = "type")]
+    route_source: BebopRouteSource,
+    quote: BebopQuote,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct BebopJamQuote {
-    slippage: f64,
-    buy_tokens: HashMap<String, BebopBuyToken>,
-    sell_tokens: HashMap<String, BebopSellToken>,
-    settlement_address: String,
-    approval_target: String,
-    price_impact: f64,
+pub struct BebopQuote {
+    buy_tokens: HashMap<String, BebopToken>,
+    sell_tokens: HashMap<String, BebopToken>,
+    approval_target: Address,
     tx: BebopTxData,
-    solver: String,
 }
-
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct BebopPmmQuote {
-    slippage: f64,
-    buy_tokens: HashMap<String, BebopBuyToken>,
-    sell_tokens: HashMap<String, BebopSellToken>,
-    settlement_address: String,
-    approval_target: String,
-    price_impact: f64,
-    tx: BebopTxData,
-    makers: Vec<String>,
+pub struct BebopToken {
+    amount: U256,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopBuyToken {
-    amount: String,
-    decimals: u8,
-    price_usd: f64,
-    symbol: String,
-    price: f64,
-    price_before_fee: f64,
-    minimum_amount: String,
-    amount_before_fee: String,
-    delta_from_expected: f64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct BebopSellToken {
-    amount: String,
-    decimals: u8,
-    price_usd: f64,
-    symbol: String,
-    price: f64,
-    price_before_fee: f64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BebopTxData {
-    from: String,
-    to: String,
-    value: String,
-    data: String,
+    from: Address,
+    to: Address,
+    value: U256,
+    data: Bytes,
+    gas: U256,
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -32,7 +32,7 @@ impl AllExecutionVenues {
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
         // TEMP: We are disabling Cowswap by default until we have a mechanism
         // for self-trade prevention
-        vec![&self.lifi, &self.cowswap]
+        vec![&self.lifi, &self.bebop]
     }
 
     /// Get a venue by its specifier

--- a/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/quote.rs
@@ -11,8 +11,8 @@ use crate::{
     execution_client::{
         error::ExecutionClientError,
         venues::{
-            cowswap::CowswapQuoteExecutionData, lifi::LifiQuoteExecutionData,
-            SupportedExecutionVenue,
+            bebop::BebopQuoteExecutionData, cowswap::CowswapQuoteExecutionData,
+            lifi::LifiQuoteExecutionData, SupportedExecutionVenue,
         },
     },
     helpers::to_chain_id,
@@ -151,6 +151,8 @@ pub enum QuoteExecutionData {
     Lifi(LifiQuoteExecutionData),
     /// Cowswap-specific quote execution data
     Cowswap(CowswapQuoteExecutionData),
+    /// Bebop-specific quote execution data
+    Bebop(BebopQuoteExecutionData),
 }
 
 impl QuoteExecutionData {
@@ -169,6 +171,15 @@ impl QuoteExecutionData {
         match self {
             QuoteExecutionData::Cowswap(data) => Ok(data.clone()),
             _ => Err(ExecutionClientError::quote_conversion("Non-Cowswap quote execution data")),
+        }
+    }
+
+    /// "Unwraps" Bebop quote execution data, returning an error if it is not
+    /// the Bebop variant
+    pub fn bebop(&self) -> Result<BebopQuoteExecutionData, ExecutionClientError> {
+        match self {
+            QuoteExecutionData::Bebop(data) => Ok(data.clone()),
+            _ => Err(ExecutionClientError::quote_conversion("Non-Bebop quote execution data")),
         }
     }
 }

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -74,8 +74,23 @@ use crate::handlers::{
 // | Cli |
 // -------
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+/// The runtime stack size to use for the server
+const RUNTIME_STACK_SIZE: usize = 50 * 1024 * 1024; // 50MB
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Create a custom tokio runtime with 50MB stack size.
+    // We sometimes see stack overflows in debug mode; so we manually setup the
+    // stack
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(RUNTIME_STACK_SIZE)
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime")
+        .block_on(async_main())
+}
+
+/// Async main function
+async fn async_main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     cli.validate()?;
     if cli.hmac_key.is_none() {

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -248,8 +248,11 @@ impl MetricsRecorder {
                     return Ok(0.0);
                 }
 
-                let transfer =
-                    Transfer::decode_log(&log.inner).map_err(FundsManagerError::parse)?;
+                let transfer = match Transfer::decode_log(&log.inner) {
+                    Ok(transfer) => transfer,
+                    // Failure to decode implies the event is not a transfer
+                    Err(_) => return Ok(0.0),
+                };
 
                 if transfer.to == self.darkpool_address || transfer.from == self.darkpool_address {
                     let value =


### PR DESCRIPTION
This PR implements the logic of converting a `BebopQuote` into an `ExecutableQuote`. I continued in stripping down the API type definitions along the way.

### Testing
- [x] Run local funds manager, get & convert Bebop quote successfully