### PR TITLE
funds-manager: api, execution_client: allow increasing price deviation

### DIFF
--- a/funds-manager/funds-manager-api/src/types/quoters.rs
+++ b/funds-manager/funds-manager-api/src/types/quoters.rs
@@ -100,6 +100,10 @@ pub struct QuoteParams {
     ///
     /// If not provided, the default slippage tolerance will be used.
     pub slippage_tolerance: Option<f64>,
+    /// Whether to increase the price deviation tolerance when it is exceeded
+    /// in fetched quotes
+    #[serde(default)]
+    pub increase_price_deviation: bool,
     /// The venue to use for the quote. If not provided, the best quote across
     /// all venues will be selected.
     pub venue: Option<SupportedExecutionVenue>,

--- a/funds-manager/funds-manager-server/src/execution_client/swap.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap.rs
@@ -33,6 +33,11 @@ const SWAP_DECAY_FACTOR: U256 = U256::from_limbs([2, 0, 0, 0]);
 const MIN_SWAP_QUOTE_AMOUNT: f64 = 10.0; // 10 USDC
 /// The default maximum allowable deviation from the Renegade price in a quote
 const DEFAULT_MAX_PRICE_DEVIATION: f64 = 0.0100; // 100bps, or 1%
+/// The relative amount by which the price deviation tolerance will be increased
+const PRICE_DEVIATION_INCREASE: f64 = 0.2; // 20%
+/// The maximum multiple of the default price deviation tolerance that will be
+/// allowed
+const MAX_PRICE_DEVIATION_INCREASE: f64 = 4.0; // 4x
 /// The buffer to scale the target amount by when executing swaps to cover it,
 /// to account for price drift
 const SWAP_TO_COVER_BUFFER: f64 = 1.1;
@@ -95,6 +100,7 @@ impl ExecutionClient {
         mut params: QuoteParams,
     ) -> Result<Option<DecayingSwapOutcome>, ExecutionClientError> {
         let mut cumulative_gas_cost = U256::ZERO;
+        let mut max_price_deviation_multiplier = 1.0;
         loop {
             if !self.can_execute_swap(&params).await? {
                 return Ok(None);
@@ -109,10 +115,15 @@ impl ExecutionClient {
             let executable_quote = maybe_executable_quote.unwrap();
 
             if self
-                .exceeds_price_deviation(&executable_quote.quote, params.slippage_tolerance)
+                .exceeds_price_deviation(&executable_quote.quote, max_price_deviation_multiplier)
                 .await?
             {
-                params.from_amount /= SWAP_DECAY_FACTOR;
+                adjust_for_price_deviation(&mut params, &mut max_price_deviation_multiplier);
+                if max_price_deviation_multiplier > MAX_PRICE_DEVIATION_INCREASE {
+                    warn!("Price deviation tolerance exceeds maximum increase ({MAX_PRICE_DEVIATION_INCREASE}x)");
+                    return Ok(None);
+                }
+
                 continue;
             }
 
@@ -136,44 +147,6 @@ impl ExecutionClient {
             warn!("swap failed, retrying w/ reduced-size quote");
             params.from_amount /= SWAP_DECAY_FACTOR;
         }
-    }
-
-    /// Check whether a swap represented by the quote params meets the criteria
-    /// for execution
-    async fn can_execute_swap(&self, params: &QuoteParams) -> Result<bool, ExecutionClientError> {
-        if !self.has_sufficient_balance(params).await? {
-            warn!("Hot wallet does not have sufficient balance to cover swap");
-            return Ok(false);
-        }
-
-        let expected_quote_amount = self.get_expected_quote_amount(params).await?;
-        if expected_quote_amount < MIN_SWAP_QUOTE_AMOUNT {
-            warn!("Expected swap amount of {expected_quote_amount} USDC is less than minimum swap amount ({MIN_SWAP_QUOTE_AMOUNT})");
-            return Ok(false);
-        }
-
-        Ok(true)
-    }
-
-    /// Compute the expected quote amount for a swap, using the Renegade price
-    /// for the sell token
-    async fn get_expected_quote_amount(
-        &self,
-        params: &QuoteParams,
-    ) -> Result<f64, ExecutionClientError> {
-        let from_token = Token::from_addr_on_chain(&params.from_token, self.chain);
-        let from_amount_u128 =
-            u256_try_into_u128(params.from_amount).map_err(ExecutionClientError::parse)?;
-
-        let from_amount_f64 = from_token.convert_to_decimal(from_amount_u128);
-        if from_token.is_stablecoin() {
-            return Ok(from_amount_f64);
-        }
-
-        let price = self.price_reporter.get_price(&from_token.addr, self.chain).await?;
-        let approx_quote_amount = from_amount_f64 * price;
-
-        Ok(approx_quote_amount)
     }
 
     /// Try to execute swaps to cover a target amount of a token,
@@ -361,6 +334,44 @@ impl ExecutionClient {
     // | General Swapping Helpers |
     // ----------------------------
 
+    /// Check whether a swap represented by the quote params meets the criteria
+    /// for execution
+    async fn can_execute_swap(&self, params: &QuoteParams) -> Result<bool, ExecutionClientError> {
+        if !self.has_sufficient_balance(params).await? {
+            warn!("Hot wallet does not have sufficient balance to cover swap");
+            return Ok(false);
+        }
+
+        let expected_quote_amount = self.get_expected_quote_amount(params).await?;
+        if expected_quote_amount < MIN_SWAP_QUOTE_AMOUNT {
+            warn!("Expected swap amount of {expected_quote_amount} USDC is less than minimum swap amount ({MIN_SWAP_QUOTE_AMOUNT})");
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    /// Compute the expected quote amount for a swap, using the Renegade price
+    /// for the sell token
+    async fn get_expected_quote_amount(
+        &self,
+        params: &QuoteParams,
+    ) -> Result<f64, ExecutionClientError> {
+        let from_token = Token::from_addr_on_chain(&params.from_token, self.chain);
+        let from_amount_u128 =
+            u256_try_into_u128(params.from_amount).map_err(ExecutionClientError::parse)?;
+
+        let from_amount_f64 = from_token.convert_to_decimal(from_amount_u128);
+        if from_token.is_stablecoin() {
+            return Ok(from_amount_f64);
+        }
+
+        let price = self.price_reporter.get_price(&from_token.addr, self.chain).await?;
+        let approx_quote_amount = from_amount_f64 * price;
+
+        Ok(approx_quote_amount)
+    }
+
     /// Get the best quote for a swap, across all execution venues
     #[instrument(
         skip_all,
@@ -438,7 +449,7 @@ impl ExecutionClient {
     async fn exceeds_price_deviation(
         &self,
         quote: &ExecutionQuote,
-        slippage_tolerance: Option<f64>,
+        max_deviation_multiplier: f64,
     ) -> Result<bool, ExecutionClientError> {
         // Get the renegade price for the pair
         let base_addr = &quote.base_token().addr;
@@ -463,14 +474,7 @@ impl ExecutionClient {
             .and_then(|ticker| self.max_price_deviations.get(&ticker).copied())
             .unwrap_or(DEFAULT_MAX_PRICE_DEVIATION);
 
-        // If the client specified a slippage tolerance greater than the configured
-        // max deviation, we respect the client's preference to "force through" the
-        // quote.
-        let deviation_threshold = if let Some(slippage_tolerance) = slippage_tolerance {
-            slippage_tolerance.max(max_deviation)
-        } else {
-            max_deviation
-        };
+        let deviation_threshold = max_deviation * max_deviation_multiplier;
 
         let exceeds_max_deviation = deviation > deviation_threshold;
         if exceeds_max_deviation {
@@ -514,4 +518,19 @@ fn record_price_deviation(quote: &ExecutionQuote, deviation: f64) {
         VENUE_TAG => quote.venue.to_string(),
     )
     .set(deviation);
+}
+
+/// Adjust the given quote params in the case that the resulting quote exceeds
+/// the price deviation tolerance.
+///
+/// Concretely, this means increasing the max price deviation multiplier if the
+/// params allow for it, or reducing the swap size otherwise.
+fn adjust_for_price_deviation(params: &mut QuoteParams, max_price_deviation_multiplier: &mut f64) {
+    if params.increase_price_deviation {
+        *max_price_deviation_multiplier += PRICE_DEVIATION_INCREASE;
+        info!("Price deviation exceeded, increasing price deviation tolerance by {max_price_deviation_multiplier}x");
+    } else {
+        info!("Price deviation exceeded, reducing swap size by {SWAP_DECAY_FACTOR}x");
+        params.from_amount /= SWAP_DECAY_FACTOR;
+    }
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
@@ -230,7 +230,7 @@ impl BebopClient {
             .with_input(execution_data.data.clone())
             .with_max_fee_per_gas(latest_basefee * 2)
             .with_max_priority_fee_per_gas(latest_basefee * 2)
-            .with_gas_limit(gas_limit);
+            .with_gas_limit(gas_limit * 2);
 
         Ok(tx)
     }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -32,7 +32,7 @@ impl AllExecutionVenues {
     pub fn get_all_venues(&self) -> Vec<&dyn ExecutionVenue> {
         // TEMP: We are disabling Cowswap by default until we have a mechanism
         // for self-trade prevention
-        vec![&self.lifi, &self.cowswap]
+        vec![&self.lifi, &self.bebop]
     }
 
     /// Get a venue by its specifier

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -13,7 +13,7 @@ use alloy::{
     sol,
 };
 use alloy_json_rpc::{ErrorPayload, RpcError};
-use alloy_primitives::{utils::format_units, Address, Log, U256};
+use alloy_primitives::{utils::format_units, Address, U256};
 use alloy_sol_types::SolEvent;
 use aws_config::SdkConfig;
 use aws_sdk_s3::Client as S3Client;
@@ -202,7 +202,7 @@ pub fn get_received_amount(
     token_address: Address,
     recipient: Address,
 ) -> Result<U256, FundsManagerError> {
-    let logs: Vec<Log<IERC20::Transfer>> = receipt
+    receipt
         .logs()
         .iter()
         .filter_map(|log| {
@@ -212,9 +212,6 @@ pub fn get_received_amount(
                 IERC20::Transfer::decode_log(&log.inner).ok()
             }
         })
-        .collect();
-
-    logs.iter()
         .find_map(|transfer| if transfer.to == recipient { Some(transfer.value) } else { None })
         .ok_or(FundsManagerError::on_chain("no matching transfer event found"))
 }

--- a/funds-manager/funds-manager-server/src/main.rs
+++ b/funds-manager/funds-manager-server/src/main.rs
@@ -74,8 +74,23 @@ use crate::handlers::{
 // | Cli |
 // -------
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+/// The runtime stack size to use for the server
+const RUNTIME_STACK_SIZE: usize = 50 * 1024 * 1024; // 50MB
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Create a custom tokio runtime with 50MB stack size.
+    // We sometimes see stack overflows in debug mode; so we manually setup the
+    // stack
+    tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(RUNTIME_STACK_SIZE)
+        .enable_all()
+        .build()
+        .expect("Failed to create tokio runtime")
+        .block_on(async_main())
+}
+
+/// Async main function
+async fn async_main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
     cli.validate()?;
     if cli.hmac_key.is_none() {

--- a/funds-manager/funds-manager-server/src/metrics/cost.rs
+++ b/funds-manager/funds-manager-server/src/metrics/cost.rs
@@ -248,8 +248,11 @@ impl MetricsRecorder {
                     return Ok(0.0);
                 }
 
-                let transfer =
-                    Transfer::decode_log(&log.inner).map_err(FundsManagerError::parse)?;
+                let transfer = match Transfer::decode_log(&log.inner) {
+                    Ok(transfer) => transfer,
+                    // Failure to decode implies the event is not a transfer
+                    Err(_) => return Ok(0.0),
+                };
 
                 if transfer.to == self.darkpool_address || transfer.from == self.darkpool_address {
                     let value =


### PR DESCRIPTION
This PR adds a `increase_price_deviation` field to the `QuoteParams` allowing clients to specify whether the funds manager should increase its price deviation tolerance in the case that a quote exceeds it.

### Testing
- [x] Run local funds manager w/ small deviation tolerance, invoke swaps and assert that deviation tolerance is increased until a quote is executed (or the max increase is hit)