### PR TITLE
funds-manager: custody_client: gas_sponsor: replace allocation w/ fixed dollar value

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -1,7 +1,5 @@
 //! Handlers for gas sponsor operations
 
-use std::collections::HashMap;
-
 use alloy::{
     eips::BlockId,
     network::TransactionBuilder,
@@ -11,10 +9,13 @@ use alloy::{
 };
 use alloy_primitives::utils::parse_ether;
 use alloy_sol_types::SolCall;
-use renegade_common::types::{chain::Chain, token::Token};
+use renegade_common::types::{
+    chain::Chain,
+    token::{get_all_base_tokens, Token},
+};
 use tracing::{error, info};
 
-use crate::{error::FundsManagerError, helpers::fetch_s3_object};
+use crate::error::FundsManagerError;
 
 use super::{CustodyClient, DepositWithdrawSource};
 
@@ -22,20 +23,8 @@ use super::{CustodyClient, DepositWithdrawSource};
 // | Constants |
 // -------------
 
-/// The suffix used to denote the gas sponsor allocation bucket
-const ALLOCATION_SPONSOR_BUCKET_SUFFIX: &str = "gas-sponsor-allocation";
-
-/// The key used to denote the gas sponsor allocation object
-const ALLOCATION_OBJECT_KEY: &str = "allocation.json";
-
-/// The threshold beneath which we skip refilling gas for the gas sponsor.
-/// If the contract's balance deviates from the desired balance by less than
-/// this proportion, we skip refilling
-const GAS_SPONSOR_REFILL_TOLERANCE: f64 = 0.1; // 10%
-
-/// The ticker used to denote the native ETH allocation
-/// in the gas sponsor allocation
-const NATIVE_ETH_TICKER: &str = "ETH";
+/// The desired USDC value of the gas sponsor's reserves in each token
+pub const DESIRED_GAS_SPONSORSHIP_RESERVE_VALUE: f64 = 50.0;
 
 /// The minimum USDC value of a token transfer to the gas sponsor
 const MIN_TRANSFER_VALUE: f64 = 10.0;
@@ -43,14 +32,6 @@ const MIN_TRANSFER_VALUE: f64 = 10.0;
 /// The factor by which to reduce the amount of a token to send to the gas
 /// sponsor when we are sending the entire hot wallet balance of the token
 pub const MAX_REFILL_REDUCTION_FACTOR: f64 = 0.9999;
-
-// ---------
-// | Types |
-// ---------
-
-/// A type alias describing the format of token allocations, namely a map from
-/// ticker to amount (in units of whole tokens)
-type GasSponsorAllocation = HashMap<String, f64>;
 
 // -------
 // | ABI |
@@ -71,43 +52,31 @@ impl CustodyClient {
     // | Handlers |
     // ------------
 
-    /// Fetch the gas sponsor allocation from S3
-    pub async fn fetch_gas_sponsor_allocation(
-        &self,
-    ) -> Result<GasSponsorAllocation, FundsManagerError> {
-        let bucket = format!("{}-{ALLOCATION_SPONSOR_BUCKET_SUFFIX}", self.chain);
-        let json_str = fetch_s3_object(&bucket, ALLOCATION_OBJECT_KEY, &self.aws_config).await?;
-
-        // Parse the JSON string to GasSponsorAllocation
-        let allocation: GasSponsorAllocation =
-            serde_json::from_str(&json_str).map_err(FundsManagerError::parse)?;
-
-        Ok(allocation)
-    }
-
     /// Gets the tokens which the gas sponsor needs to be refilled for.
     ///
     /// Returns a vector of (token, refill_amount).
-    pub async fn get_tokens_needing_refill(
-        &self,
-        allocation: &GasSponsorAllocation,
-    ) -> Result<Vec<(Token, f64)>, FundsManagerError> {
+    pub async fn get_tokens_needing_refill(&self) -> Result<Vec<(Token, f64)>, FundsManagerError> {
         let gas_sponsor_address = self.gas_sponsor_address();
 
         let mut tokens = Vec::new();
-        for (ticker, desired_amount) in allocation {
-            // Skip the native ETH allocation, that is handled in `refill_gas_sponsor_eth`
-            if ticker == NATIVE_ETH_TICKER {
-                continue;
-            }
 
-            let token = Token::from_ticker_on_chain(ticker, self.chain);
+        let all_tokens_on_chain =
+            get_all_base_tokens().into_iter().filter(|t| t.chain == self.chain);
 
+        for token in all_tokens_on_chain {
             // Get the gas sponsor's balance of the token
+            let price = self.price_reporter.get_price(&token.addr, self.chain).await?;
             let bal = self.get_erc20_balance(&token.addr, &gas_sponsor_address).await?;
+            let bal_value = bal * price;
 
-            if bal < desired_amount * (1.0 - GAS_SPONSOR_REFILL_TOLERANCE) {
-                tokens.push((token, *desired_amount - bal));
+            if bal_value < DESIRED_GAS_SPONSORSHIP_RESERVE_VALUE - MIN_TRANSFER_VALUE {
+                let refill_value = DESIRED_GAS_SPONSORSHIP_RESERVE_VALUE - bal_value;
+                let refill_amount = refill_value / price;
+
+                let ticker = token.get_ticker().unwrap_or(token.get_addr());
+                info!("Gas sponsor needs {refill_amount} (${refill_value}) of {ticker}");
+
+                tokens.push((token, refill_amount));
             }
         }
 
@@ -115,21 +84,18 @@ impl CustodyClient {
     }
 
     /// Refill the gas sponsor with ETH
-    pub async fn refill_gas_sponsor_eth(
-        &self,
-        allocation: &GasSponsorAllocation,
-    ) -> Result<(), FundsManagerError> {
-        let desired_eth_amount = allocation
-            .get(NATIVE_ETH_TICKER)
-            .ok_or(FundsManagerError::custom("Gas sponsor allocation missing ETH entry"))?;
-
+    pub async fn refill_gas_sponsor_eth(&self) -> Result<(), FundsManagerError> {
+        let price = self.price_reporter.get_eth_price().await?;
         let bal = self.get_ether_balance(&self.gas_sponsor_address()).await?;
+        let bal_value = bal * price;
 
-        if bal < desired_eth_amount * (1.0 - GAS_SPONSOR_REFILL_TOLERANCE) {
-            let amount_to_send = desired_eth_amount - bal;
-            match self.send_eth_to_gas_sponsor(amount_to_send).await {
+        if bal_value < DESIRED_GAS_SPONSORSHIP_RESERVE_VALUE - MIN_TRANSFER_VALUE {
+            let refill_value = DESIRED_GAS_SPONSORSHIP_RESERVE_VALUE - bal_value;
+            let refill_amount = refill_value / price;
+
+            match self.send_eth_to_gas_sponsor(refill_amount).await {
                 Ok(TransactionReceipt { transaction_hash: tx, .. }) => {
-                    info!("Sent {amount_to_send} ETH from hot wallet to gas sponsor in tx {tx:#x}");
+                    info!("Sent {refill_amount} ETH from hot wallet to gas sponsor in tx {tx:#x}");
                 },
                 Err(e) => {
                     error!("Failed to send ETH to gas sponsor, skipping: {e}");
@@ -153,14 +119,17 @@ impl CustodyClient {
         let bal =
             self.get_erc20_balance(&token.get_addr(), &quoter_wallet.address().to_string()).await?;
 
-        let send_amount = if bal <= amount { bal * MAX_REFILL_REDUCTION_FACTOR } else { amount };
+        let send_amount = if bal <= amount {
+            let send_amount = bal * MAX_REFILL_REDUCTION_FACTOR;
+            info!("Hot wallet has less than the desired balance of {ticker}, sending {send_amount} {ticker}");
+            send_amount
+        } else {
+            amount
+        };
 
         let price = self.price_reporter.get_price(mint, self.chain).await?;
         let value = send_amount * price;
 
-        // TODO: Rather than doing this check here, we should replace the check in
-        // `get_tokens_needing_refill` with it. This should also let us remove
-        // the gas sponsor allocation in favor of a fixed USDC value.
         if value < MIN_TRANSFER_VALUE {
             return Err(FundsManagerError::custom(format!(
                 "Attempted transfer of ${value} of {ticker} to gas sponsor is below ${MIN_TRANSFER_VALUE} minimum"
@@ -172,7 +141,7 @@ impl CustodyClient {
             .await?;
 
         info!(
-            "Sent {amount} {ticker} from hot wallet to gas sponsor in tx {:#x}",
+            "Sent {send_amount} {ticker} from hot wallet to gas sponsor in tx {:#x}",
             receipt.transaction_hash
         );
 

--- a/funds-manager/funds-manager-server/src/handlers.rs
+++ b/funds-manager/funds-manager-server/src/handlers.rs
@@ -436,14 +436,12 @@ pub(crate) async fn refill_gas_sponsor_handler(
     let quoter_wallet = custody_client.get_quoter_hot_wallet().await?;
     let signer = custody_client.get_hot_wallet_private_key(&quoter_wallet.address).await?;
 
-    let allocation = custody_client.fetch_gas_sponsor_allocation().await?;
-
     // Refill the gas sponsor with native ETH
-    custody_client.refill_gas_sponsor_eth(&allocation).await?;
+    custody_client.refill_gas_sponsor_eth().await?;
 
     // Refill the gas sponsor with ERC20s
 
-    let tokens_needing_refill = custody_client.get_tokens_needing_refill(&allocation).await?;
+    let tokens_needing_refill = custody_client.get_tokens_needing_refill().await?;
 
     // Swap into the target tokens such that we can cover the refill amounts
     let swap_outcomes =


### PR DESCRIPTION
This PR replaces the gas sponsor allocation in S3 w/ a fixed dollar value of reserves expected in the gas sponsor for each token.

### Testing
- [x] Test gas sponsor refills where existing USDC balance covers all target balances
- [x] Test gas sponsor refills where addnl USDC purchases are required, asserting that target tokens are excluded from swaps
- [x] Test gas sponsor refills where existing token balances cover targets
- [x] Test gas sponsor refills where addnl token purchases are required