### PR TITLE
auth-server: Remove exclusive bundles

### DIFF
--- a/auth/auth-server/src/bundle_store/mod.rs
+++ b/auth/auth-server/src/bundle_store/mod.rs
@@ -28,8 +28,6 @@ pub struct BundleContext {
     pub is_sponsored: bool,
     /// The nullifier that was nullified as a result of the bundle being settled
     pub nullifier: Nullifier,
-    /// Whether the bundle was shared
-    pub shared: bool,
     /// The timestamp of the price of the match in milliseconds
     pub price_timestamp: u64,
     /// The timestamp of the assembly of the bundle in milliseconds

--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -221,11 +221,7 @@ impl OnChainEventListenerExecutor {
             let bundle_id = external_match.bundle_id(&nullifier)?;
             if let Some(bundle_ctx) = self.bundle_store.read(&bundle_id).await? {
                 // Increase rate limit
-                self.add_bundle_rate_limit_token(
-                    bundle_ctx.key_description.clone(),
-                    bundle_ctx.shared,
-                )
-                .await;
+                self.add_bundle_rate_limit_token(bundle_ctx.key_description.clone()).await;
 
                 let api_match: ApiExternalMatchResult = external_match.match_result().into();
 

--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -131,8 +131,8 @@ impl OnChainEventListenerExecutor {
     }
 
     /// Increment the token balance for a given API user
-    pub async fn add_bundle_rate_limit_token(&self, key_description: String, shared: bool) {
-        self.rate_limiter.add_bundle_token(key_description, shared).await;
+    pub async fn add_bundle_rate_limit_token(&self, key_description: String) {
+        self.rate_limiter.add_bundle_token(key_description).await;
     }
 
     /// Record the gas sponsorship rate limit & metrics for a given settled

--- a/auth/auth-server/src/main.rs
+++ b/auth/auth-server/src/main.rs
@@ -80,13 +80,10 @@ pub struct Cli {
     #[arg(long, env = "CHAIN_ID")]
     pub chain_id: Chain,
     /// The bundle rate limit in bundles per minute
-    #[arg(long, env = "BUNDLE_RATE_LIMIT", default_value = "4")]
+    #[arg(long, env = "BUNDLE_RATE_LIMIT", default_value = "200")]
     pub bundle_rate_limit: u64,
-    /// The shared bundle rate limit in bundles per minute
-    #[arg(long, env = "SHARED_BUNDLE_RATE_LIMIT", default_value = "50")]
-    pub shared_bundle_rate_limit: u64,
     /// The quote rate limit in quotes per minute
-    #[arg(long, env = "QUOTE_RATE_LIMIT", default_value = "100")]
+    #[arg(long, env = "QUOTE_RATE_LIMIT", default_value = "500")]
     pub quote_rate_limit: u64,
     /// The path to the file containing token remaps for the given chain
     ///

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_malleable_quote.rs
@@ -91,9 +91,8 @@ impl Server {
         &self,
         ctx: &mut AssembleQuoteRequestCtx,
     ) -> Result<(), AuthServerError> {
-        let allow_shared = ctx.body.allow_shared;
         let key_desc = ctx.user();
-        self.check_bundle_rate_limit(key_desc, allow_shared).await?;
+        self.check_bundle_rate_limit(key_desc).await?;
         self.route_assembly_req(ctx).await?;
 
         // Apply gas sponsorship to the assembly request

--- a/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/assemble_quote.rs
@@ -119,9 +119,8 @@ impl Server {
         &self,
         ctx: &mut AssembleQuoteRequestCtx,
     ) -> Result<(), AuthServerError> {
-        let allow_shared = ctx.body.allow_shared;
         let key_desc = ctx.user();
-        self.check_bundle_rate_limit(key_desc, allow_shared).await?;
+        self.check_bundle_rate_limit(key_desc).await?;
 
         // Apply gas sponsorship to the assembly request
         let gas_sponsorship_info = self.sponsor_assembly_request(ctx).await?;
@@ -262,10 +261,9 @@ impl Server {
         ctx: &SponsoredAssembleQuoteResponseCtx,
     ) -> Result<(), AuthServerError> {
         // Record the bundle context in the store
-        let shared = ctx.request().allow_shared;
         let price_timestamp = ctx.request().signed_quote.quote.price.timestamp;
         let assembled_timestamp = get_current_time_millis();
-        self.write_bundle_context(shared, price_timestamp, Some(assembled_timestamp), ctx).await?;
+        self.write_bundle_context(price_timestamp, Some(assembled_timestamp), ctx).await?;
 
         let req = ctx.request();
         if req.updated_order.is_some() {
@@ -273,8 +271,7 @@ impl Server {
         }
 
         let order = &req.signed_quote.quote.order;
-        let shared_bundle = req.allow_shared;
-        self.handle_bundle_response(order, ctx, shared_bundle)
+        self.handle_bundle_response(order, ctx)
     }
 }
 

--- a/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
+++ b/auth/auth-server/src/server/api_handlers/external_match/direct_match.rs
@@ -115,8 +115,7 @@ impl Server {
         ctx: &mut DirectMatchRequestCtx,
     ) -> Result<(), AuthServerError> {
         // Check the rate limit
-        // Direct matches are always shared
-        self.check_bundle_rate_limit(ctx.user(), true /* shared */).await?;
+        self.check_bundle_rate_limit(ctx.user()).await?;
         self.route_direct_match_req(ctx).await?;
 
         // Apply gas sponsorship to the match request
@@ -239,7 +238,6 @@ impl Server {
         let price_timestamp = get_current_time_millis();
         // Record the bundle context in the store
         self.write_bundle_context(
-            true, // shared
             price_timestamp,
             None, // assembled_timestamp
             ctx,
@@ -248,6 +246,6 @@ impl Server {
 
         let req = ctx.request();
         let order = &req.external_order;
-        self.handle_bundle_response(order, ctx, true /* shared */)
+        self.handle_bundle_response(order, ctx)
     }
 }

--- a/auth/auth-server/src/server/api_handlers/mod.rs
+++ b/auth/auth-server/src/server/api_handlers/mod.rs
@@ -30,9 +30,7 @@ use super::gas_sponsorship::refund_calculation::{
 };
 use crate::error::AuthServerError;
 use crate::telemetry::helpers::calculate_implied_price;
-use crate::telemetry::labels::{
-    GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG, SHARED_BUNDLE_TAG,
-};
+use crate::telemetry::labels::{GAS_SPONSORED_METRIC_TAG, SDK_VERSION_METRIC_TAG};
 use crate::telemetry::{
     helpers::record_external_match_metrics,
     labels::{KEY_DESCRIPTION_METRIC_TAG, REQUEST_ID_METRIC_TAG, REQUEST_PATH_METRIC_TAG},
@@ -168,7 +166,6 @@ impl Server {
         &self,
         order: &ExternalOrder,
         ctx: &MatchBundleResponseCtx<Req>,
-        shared_bundle: bool,
     ) -> Result<(), AuthServerError>
     where
         Req: Serialize + for<'de> Deserialize<'de>,
@@ -186,7 +183,6 @@ impl Server {
             (GAS_SPONSORED_METRIC_TAG.to_string(), is_sponsored.to_string()),
             (SDK_VERSION_METRIC_TAG.to_string(), ctx.sdk_version.clone()),
             (REQUEST_PATH_METRIC_TAG.to_string(), ctx.path.clone()),
-            (SHARED_BUNDLE_TAG.to_string(), shared_bundle.to_string()),
         ];
 
         // Record quote comparisons before settlement, if enabled

--- a/auth/auth-server/src/server/api_handlers/settlement.rs
+++ b/auth/auth-server/src/server/api_handlers/settlement.rs
@@ -19,7 +19,6 @@ impl Server {
     /// Returns the bundle ID
     pub async fn write_bundle_context<Req>(
         &self,
-        shared_bundle: bool,
         price_timestamp: u64,
         assembled_timestamp: Option<u64>,
         ctx: &MatchBundleResponseCtx<Req>,
@@ -47,7 +46,6 @@ impl Server {
             gas_sponsorship_info: sponsorship_info,
             is_sponsored,
             nullifier,
-            shared: shared_bundle,
             price_timestamp,
             assembled_timestamp,
         };
@@ -74,7 +72,6 @@ impl Server {
         let bundle_id = generate_malleable_bundle_id(&resp.match_bundle.match_result, &nullifier)?;
         let gas_sponsorship_info = ctx.sponsorship_info();
         let is_sponsored = gas_sponsorship_info.is_some();
-        let shared = req.allow_shared;
         let price_timestamp = req.signed_quote.quote.price.timestamp;
 
         let bundle_ctx = BundleContext {
@@ -84,7 +81,6 @@ impl Server {
             gas_sponsorship_info,
             is_sponsored,
             nullifier,
-            shared,
             price_timestamp,
             assembled_timestamp,
         };

--- a/auth/auth-server/src/server/setup.rs
+++ b/auth/auth-server/src/server/setup.rs
@@ -65,7 +65,6 @@ impl Server {
         let rate_limiter = AuthServerRateLimiter::new(
             args.quote_rate_limit,
             args.bundle_rate_limit,
-            args.shared_bundle_rate_limit,
             args.max_gas_sponsorship_value,
             &args.execution_cost_redis_url,
         )

--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -127,6 +127,3 @@ pub const L2_BASE_FEE_TAG: &str = "l2_base_fee";
 /// Metric tag indicating whether or not the bundle was settled as part of a CoW
 /// Protocol auction
 pub const SETTLED_VIA_COWSWAP_TAG: &str = "settled_via_cowswap";
-
-/// Metric tag indicating whether a bundle is shared
-pub const SHARED_BUNDLE_TAG: &str = "shared"; // values: "true" | "false"


### PR DESCRIPTION
### Purpose
This PR removes exclusive bundles from the auth server. This will be deployed via an infra change which sets the `BUNDLE_RATE_LIMIT` to the value that was previously the `SHARED_BUNDLE_RATE_LIMIT` so that the switch between rate limits is without error.

### Testing
- [ ] Test in testnet