### PR TITLE
funds-manager: sum recv amt across multiple transfers

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
@@ -302,8 +302,7 @@ impl ExecutionVenue for BebopClient {
         if receipt.status() {
             let recipient = bebop_execution_data.from;
             let buy_token_address = quote.buy_token.get_alloy_address();
-            let buy_amount_actual = get_received_amount(&receipt, buy_token_address, recipient)
-                .map_err(ExecutionClientError::onchain)?;
+            let buy_amount_actual = get_received_amount(&receipt, buy_token_address, recipient);
 
             Ok(ExecutionResult { buy_amount_actual, gas_cost, tx_hash: Some(tx_hash) })
         } else {

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -323,8 +323,7 @@ impl ExecutionVenue for LifiClient {
         if receipt.status() {
             let recipient = lifi_execution_data.from;
             let buy_token_address = quote.buy_token.get_alloy_address();
-            let buy_amount_actual = get_received_amount(&receipt, buy_token_address, recipient)
-                .map_err(ExecutionClientError::onchain)?;
+            let buy_amount_actual = get_received_amount(&receipt, buy_token_address, recipient);
 
             Ok(ExecutionResult { buy_amount_actual, gas_cost, tx_hash: Some(tx_hash) })
         } else {


### PR DESCRIPTION
This PR fixes the `get_received_amount` helper to sum the amount of ERC20 received by the recipient across _all_ transfer logs in a transaction, as opposed to just the first one.