### PR TITLE
funds-manager: venues: bebop: add API key

### DIFF
--- a/funds-manager/funds-manager-server/src/cli.rs
+++ b/funds-manager/funds-manager-server/src/cli.rs
@@ -207,6 +207,8 @@ pub struct ChainConfig {
     // --- Execution Params --- //
     /// The Lifi API key
     pub lifi_api_key: Option<String>,
+    /// The Bebop API key
+    pub bebop_api_key: Option<String>,
     /// A map from token ticker to the maximum price deviation allowed in a
     /// quote for that token
     #[serde(default)]
@@ -268,6 +270,7 @@ impl ChainConfig {
         let execution_client = ExecutionClient::new(
             chain,
             self.lifi_api_key.clone(),
+            self.bebop_api_key.clone(),
             &self.rpc_url,
             price_reporter.clone(),
             quoter_hot_wallet_private_key,

--- a/funds-manager/funds-manager-server/src/execution_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/mod.rs
@@ -40,6 +40,7 @@ impl ExecutionClient {
     pub fn new(
         chain: Chain,
         lifi_api_key: Option<String>,
+        bebop_api_key: Option<String>,
         rpc_url: &str,
         price_reporter: PriceReporterClient,
         quoter_hot_wallet: PrivateKeySigner,
@@ -50,7 +51,7 @@ impl ExecutionClient {
 
         let lifi = LifiClient::new(lifi_api_key, rpc_url, quoter_hot_wallet.clone(), chain);
         let cowswap = CowswapClient::new(rpc_url, quoter_hot_wallet.clone(), chain);
-        let bebop = BebopClient::new(rpc_url, quoter_hot_wallet, chain);
+        let bebop = BebopClient::new(bebop_api_key, rpc_url, quoter_hot_wallet, chain);
 
         let venues = AllExecutionVenues { lifi, cowswap, bebop };
 

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
@@ -46,6 +46,8 @@ pub struct BebopQuoteParams {
     /// The difference between this and `skip_validation` is undocumented
     /// in the Bebop docs.
     pub skip_taker_checks: bool,
+    /// Referral partner that will be associated with the quote (us).
+    pub source: String,
 }
 
 /// The type of approval to use for the quoted order.


### PR DESCRIPTION
This PR configures the funds manager to use an API key for Bebop.

### Testing
- [x] Ran local funds manager & executed Bebop quote, asserted that API key was used