### PR TITLE
funds-manager: custody_client: use FB available balance for HL vault

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/withdraw.rs
@@ -169,11 +169,13 @@ impl CustodyClient {
 
         let usdc_mint = self.get_hyperliquid_usdc_mint()?;
 
-        let hl_bal = self.get_erc20_balance(&usdc_mint, &hyperliquid_address).await?;
-        if hl_bal < amount {
+        let hl_available_bal =
+            self.get_vault_available_balance(hyperliquid_vault_id.clone(), &usdc_mint).await?;
+
+        if hl_available_bal < amount {
             // We round up the amount to transfer to account for
             // potential floating point precision issues.
-            let amount_to_transfer = round_up(rounded_amount - hl_bal, USDC_DECIMALS)?;
+            let amount_to_transfer = round_up(rounded_amount - hl_available_bal, USDC_DECIMALS)?;
             let bal = self.get_erc20_balance(&usdc_mint, &hot_wallet.address).await?;
             if bal < amount_to_transfer {
                 return Err(FundsManagerError::Custom("Insufficient balance".to_string()));


### PR DESCRIPTION
This PR tweaks the Hyperliquid deposit logic to use the Fireblocks "available" balance in the HL vault, rather than reading the ERC20 balance directly. The available balance is what FB uses to determine insufficient funds, and is the total balance less any other pending outgoing transfers.

This should smooth out the errors we've seen rebalancing our hedges

### Testing
- [x] Test HL deposits w/ local funds manager