### PR TITLE
funds-manager: custody-client: include usdc in refill check

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_sponsor.rs
@@ -11,7 +11,7 @@ use alloy_primitives::utils::parse_ether;
 use alloy_sol_types::SolCall;
 use renegade_common::types::{
     chain::Chain,
-    token::{get_all_base_tokens, Token},
+    token::{get_all_tokens, Token},
 };
 use tracing::{error, info};
 
@@ -60,8 +60,7 @@ impl CustodyClient {
 
         let mut tokens = Vec::new();
 
-        let all_tokens_on_chain =
-            get_all_base_tokens().into_iter().filter(|t| t.chain == self.chain);
+        let all_tokens_on_chain = get_all_tokens().into_iter().filter(|t| t.chain == self.chain);
 
         for token in all_tokens_on_chain {
             // Get the gas sponsor's balance of the token


### PR DESCRIPTION
### Purpose
This PR ensures the refill endpoint includes USDC when checking for refill status by swapping `get_all_base_tokens` for `get_all_tokens`.

### Testing
- [x] Test in testnet that it builds / deploys, mainnet deploy will tell us if USDC balance is refilled