### PR TITLE
funds-manager: execution_client: swap_to_target: skip 0-size USDC leg of multi-swap

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/swap/swap_to_target.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/swap/swap_to_target.rs
@@ -307,6 +307,12 @@ impl ExecutionClient {
         let usdc_token = Token::from_ticker_on_chain(USDC_TICKER, self.chain);
 
         let usdc_target_balance = purchase_values.iter().map(|(_, value)| value).sum();
+
+        if usdc_target_balance == 0.0 {
+            info!("No purchases needed, skipping swap into USDC");
+            return Ok(vec![]);
+        }
+
         let exclude_tokens = purchase_values.iter().map(|(token, _)| token.get_addr()).collect();
 
         let swap_request = SwapIntoTargetTokenRequest {


### PR DESCRIPTION
This PR tweaks the USDC-purchasing leg of the `multi_swap_into_target_tokens` method to be skipped if the total USDC purchase value is 0. This is possible when the hot wallet has sufficient balances in the tokens of which the gas sponsor needs a refill. The remaining logic in the method will be skipped due to the per-token purchase loop operating on a zero-length filtered vector.

This is a minor improvement that mostly cleans up our funds manager logs.