### PR TITLE
auth-server: chain_events: remove reintroduced sponsorship rate limit tags

### DIFF
--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -212,9 +212,6 @@ impl OnChainEventListenerExecutor {
         // - Refund amount (whole units)
         // - Gas prices (L1 & L2)
 
-        let (remaining_value, remaining_time) =
-            self.rate_limiter.remaining_gas_sponsorship_value_and_time(key.clone()).await;
-
         let refund_asset_ticker = if refund_native_eth {
             ETH_TICKER.to_string()
         } else {


### PR DESCRIPTION
This PR removes the computation of the remaining value & time on the gas sponsorship rate limit bucket, accidentally reintroduced when merging the previous PR.