### PR TITLE
auth-server: bundle_store: include match direction in bundle ID

### DIFF
--- a/auth/auth-server/src/bundle_store/helpers.rs
+++ b/auth/auth-server/src/bundle_store/helpers.rs
@@ -6,8 +6,8 @@ use renegade_constants::Scalar;
 
 use crate::error::AuthServerError;
 
-/// Generates a deterministic bundle ID by hashing together the nullifier
-/// and the match amounts.
+/// Generates a deterministic bundle ID by hashing together the nullifier,
+/// match amounts, and order direction.
 ///
 /// This approach is prone to collisions because there is no single unique
 /// customer identifier shared by both the on‑chain listener and the HTTP
@@ -29,10 +29,12 @@ pub fn generate_bundle_id(
 ) -> Result<String, AuthServerError> {
     let quote_amt = match_result.quote_amount;
     let base_amt = match_result.base_amount;
+    let direction = match_result.direction as u8;
 
     let mut bytes = nullifier.to_bytes_be();
     bytes.extend(Scalar::from(quote_amt).to_bytes_be());
     bytes.extend(Scalar::from(base_amt).to_bytes_be());
+    bytes.push(direction);
     Ok(hex::encode(keccak256::<&[u8]>(&bytes)))
 }
 


### PR DESCRIPTION
This PR ensures that we include the match direction in the preimage of the hash used as the bundle's ID. We have seen a bug in prod wherein a buy-side match result witnessed onchain was associated with a sell-side bundle stored in the auth server, because the match amounts lined up.

This led to us assuming that the _quote-denominated_ `refund_amount` on the fetched bundle was the amount of _base token_ used to sponsor the settled match. Due to the difference in fixed-point precision (and price) of the base and quote tokens, this led to an immensely inflated refund value being recorded.

### Testing
- [x] Ran local auth server, asserted that external match quote+assembly worked without issue (IDs generated w/o issue)