### PR TITLE
auth-server: gas_estimation: base: use latest block basefee

### DIFF
--- a/auth/auth-server/src/chain_events/listener.rs
+++ b/auth/auth-server/src/chain_events/listener.rs
@@ -254,7 +254,7 @@ impl OnChainEventListenerExecutor {
                 self.record_external_match_spread_cost(&bundle_ctx, &api_match).await?;
 
                 // Record settlement metrics
-                self.record_settlement_metrics(&receipt, &bundle_ctx, &api_match).await?;
+                self.record_settlement_metrics(&receipt, &bundle_ctx, &api_match)?;
 
                 // Record sponsorship metrics
                 if let Some(gas_sponsorship_info) = &bundle_ctx.gas_sponsorship_info {

--- a/auth/auth-server/src/server/gas_estimation/gas_oracles/base.rs
+++ b/auth/auth-server/src/server/gas_estimation/gas_oracles/base.rs
@@ -2,6 +2,7 @@
 
 use GasOracle::GasOracleInstance;
 use alloy::primitives::{Address, U256};
+use alloy::providers::Provider;
 use alloy::{hex, sol};
 use alloy_primitives::FixedBytes;
 use renegade_darkpool_client::client::RenegadeProvider;
@@ -11,6 +12,9 @@ use super::GasPriceEstimation;
 /// The address of the gas oracle contract on Base
 pub const GAS_ORACLE_ADDRESS: Address =
     Address(FixedBytes(hex!("0x420000000000000000000000000000000000000F")));
+
+/// The error message returned when no basefee is found for the latest block
+const ERR_NO_BASEFEE: &str = "no basefee found for latest block";
 
 sol! {
     #[sol(rpc)]
@@ -27,17 +31,23 @@ pub async fn estimate_l1_gas_component(
     _to: Address,
     data: Vec<u8>,
 ) -> Result<GasPriceEstimation, String> {
-    let gas_oracle = GasOracleInstance::new(GAS_ORACLE_ADDRESS, provider);
+    // Get the gas price directly from the RPC. This isn't exactly the basefee,
+    // but is a sufficient approximation that keeps our RPC costs low.
+    // We do this instead of calling `gasPrice` on the oracle, as that method
+    // has proven unreliable (i.e., returns 0).
+    let gas_price = provider.get_gas_price().await.map_err(|e| e.to_string())?;
+    let l2_base_fee = U256::from(gas_price);
 
     // Sample values from the gas oracle contract
+    let gas_oracle = GasOracleInstance::new(GAS_ORACLE_ADDRESS, provider);
+
     let l1_base_fee = gas_oracle.l1BaseFee().call().await.map_err(|e| e.to_string())?;
-    let gas_price = gas_oracle.gasPrice().call().await.map_err(|e| e.to_string())?;
     let l1_gas_used =
         gas_oracle.getL1GasUsed(data.into()).call().await.map_err(|e| e.to_string())?;
 
     Ok(GasPriceEstimation {
         gas_estimate_for_l1: l1_gas_used,
-        l2_base_fee: gas_price,
+        l2_base_fee,
         // Ethereum L1 charges 16 gas per non-zero byte of calldata
         l1_data_fee: l1_base_fee * U256::from(16),
     })


### PR DESCRIPTION
This PR patches the Base gas estimator to use the basefee from the latest block as opposed to calling `gasPrice` on the `GasPriceOracle` contract, as this method has been consistently returning 0.

### Testing
- [x] Run local auth server targeting Base Sepolia, assert that fetched base fee matches what is shown in the block explorer