### PR TITLE
solver: fill orders with multiple outputs

### DIFF
--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -29,7 +29,7 @@ renegade-common = { workspace = true }
 renegade-config = { workspace = true }
 renegade-constants = { workspace = true }
 renegade-solidity-abi = { workspace = true }
-renegade-sdk = "0.1.15"
+renegade-sdk = { git = "https://github.com/renegade-fi/rust-sdk" }
 renegade-util = { workspace = true, features = [
     "telemetry",
 ] }

--- a/renegade-solver/src/uniswapx/renegade_api.rs
+++ b/renegade-solver/src/uniswapx/renegade_api.rs
@@ -42,15 +42,15 @@ impl UniswapXSolver {
         &self,
         input_token: Address,
         output_token: Address,
-        input_amount: u128,
+        output_amount: u128,
     ) -> SolverResult<ExternalOrder> {
         let is_buy_side = self.is_usdc(input_token);
         if is_buy_side {
             // Base is output token, quote is input token
-            self.build_buy_order(output_token, input_token, input_amount)
+            self.build_buy_order(output_token, input_token, output_amount)
         } else {
             // Base is input token, quote is output token
-            self.build_sell_order(input_token, output_token, input_amount)
+            self.build_sell_order(input_token, output_token, output_amount)
         }
     }
 
@@ -59,12 +59,12 @@ impl UniswapXSolver {
         &self,
         base: Address,
         quote: Address,
-        in_amount: u128,
+        output_amount: u128,
     ) -> SolverResult<ExternalOrder> {
         let order = ExternalOrderBuilder::new()
             .base_mint(&base.to_string())
             .quote_mint(&quote.to_string())
-            .quote_amount(in_amount)
+            .exact_base_output(output_amount)
             .side(OrderSide::Buy)
             .build()?;
         Ok(order)
@@ -75,12 +75,12 @@ impl UniswapXSolver {
         &self,
         base: Address,
         quote: Address,
-        in_amount: u128,
+        output_amount: u128,
     ) -> SolverResult<ExternalOrder> {
         let order = ExternalOrderBuilder::new()
             .base_mint(&base.to_string())
             .quote_mint(&quote.to_string())
-            .base_amount(in_amount)
+            .exact_quote_output(output_amount)
             .side(OrderSide::Sell)
             .build()?;
         Ok(order)

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -109,7 +109,7 @@ impl UniswapXSolver {
     ///
     /// TODO: Loosen and remove this method's checks in follow-ups
     fn temporary_order_filter(&self, order: &PriorityOrder) -> SolverResult<bool> {
-        // For now, we only support orders with 1 output token
+        // For now, we only support orders with the same token for all outputs
         if !order.outputs.is_empty() {
             let first_output_token = order.outputs[0].token;
             for output in order.outputs.iter() {


### PR DESCRIPTION
### Purpose
This PR enables the solver to handle orders with multiple output entries, as long as they are the same token. This is fairly trivial as the `Executor` must simply maintain the invariant that it holds sufficient output tokens by the time `reactorCallback` is finished. The `Reactor` contract is responsible for actually transferring these output tokens from the `Executor` to recipient(s). 