### PR TITLE
funds-manager: wait 2 tx confirmations by default

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/mod.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/mod.rs
@@ -38,7 +38,7 @@ use tracing::{debug, info};
 use crate::{
     custody_client::fireblocks_client::FireblocksClient,
     helpers::{
-        get_erc20_balance, send_tx_with_retry, to_env_agnostic_name, IERC20, ONE_CONFIRMATION,
+        get_erc20_balance, send_tx_with_retry, to_env_agnostic_name, IERC20, TWO_CONFIRMATIONS,
     },
 };
 use crate::{
@@ -355,7 +355,7 @@ impl CustodyClient {
 
         info!("Transferring {amount} ETH to {to:#x}");
         let tx = TransactionRequest::default().with_to(to).with_value(amount_units);
-        send_tx_with_retry(tx, &client, ONE_CONFIRMATION).await
+        send_tx_with_retry(tx, &client, TWO_CONFIRMATIONS).await
     }
 
     /// Get the erc20 balance of an address

--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     helpers::{
         approve_erc20_allowance, build_provider, get_gas_cost, get_received_amount,
-        handle_http_response, send_tx_with_retry, ONE_CONFIRMATION,
+        handle_http_response, send_tx_with_retry, TWO_CONFIRMATIONS,
     },
 };
 
@@ -260,7 +260,7 @@ impl BebopClient {
         &self,
         tx: TransactionRequest,
     ) -> Result<TransactionReceipt, ExecutionClientError> {
-        send_tx_with_retry(tx, &self.rpc_provider, ONE_CONFIRMATION)
+        send_tx_with_retry(tx, &self.rpc_provider, TWO_CONFIRMATIONS)
             .await
             .map_err(ExecutionClientError::onchain)
     }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     },
     helpers::{
         approve_erc20_allowance, build_provider, get_gas_cost, get_received_amount,
-        handle_http_response, send_tx_with_retry, to_chain_id, ONE_CONFIRMATION,
+        handle_http_response, send_tx_with_retry, to_chain_id, TWO_CONFIRMATIONS,
     },
 };
 
@@ -262,7 +262,7 @@ impl LifiClient {
         &self,
         tx: TransactionRequest,
     ) -> Result<TransactionReceipt, ExecutionClientError> {
-        send_tx_with_retry(tx, &self.rpc_provider, ONE_CONFIRMATION)
+        send_tx_with_retry(tx, &self.rpc_provider, TWO_CONFIRMATIONS)
             .await
             .map_err(ExecutionClientError::onchain)
     }

--- a/funds-manager/funds-manager-server/src/helpers.rs
+++ b/funds-manager/funds-manager-server/src/helpers.rs
@@ -31,9 +31,9 @@ use crate::{
     error::FundsManagerError,
 };
 
-/// An annotated constant used to indicate that only one confirmation is
+/// An annotated constant used to indicate that two confirmations are
 /// required for a transaction
-pub(crate) const ONE_CONFIRMATION: u64 = 1;
+pub(crate) const TWO_CONFIRMATIONS: u64 = 2;
 /// The maximum number of retries for a transaction
 const TX_MAX_RETRIES: u32 = 5;
 /// The minimum delay between retries
@@ -185,7 +185,7 @@ pub(crate) async fn approve_erc20_allowance(
     // Otherwise, approve the allowance
     let approval_amount = amount * APPROVAL_AMPLIFIER;
     let tx = erc20.approve(spender, approval_amount).into_transaction_request();
-    let receipt = send_tx_with_retry(tx, &rpc_provider, ONE_CONFIRMATION).await?;
+    let receipt = send_tx_with_retry(tx, &rpc_provider, TWO_CONFIRMATIONS).await?;
 
     info!("Approved erc20 allowance at: {:#x}", receipt.transaction_hash);
     Ok(())


### PR DESCRIPTION
This PR bumps the default # of confirmations to await the settlement of transaction from 1 -> 2. The reason we do this is to avoid operating on preconfirmed state due to the enablement of flashblocks in Base mainnet + Alchemy.

With the enablement of flashblocks, the `eth_getTransactionReceipt` RPC will [by default return transaction receipts included in flashblocks](https://docs.base.org/base-chain/flashblocks/apps#eth-gettransactionreceipt). This is the RPC relied upon by `alloy` downstream of invoking `pending_tx.get_receipt()`, in [`watch_pending_transaction`](https://github.com/alloy-rs/alloy/blob/v1.0.1/crates/provider/src/provider/trait.rs#L1287). In that same method, you can see that if `required_confirmations <= 1`, the receipt is returned as soon as it is found onchain - in the case of Base, this means as soon as it's included in a flashblock.

However, [all flashblocks in a block use the same base block number](https://docs.base.org/base-chain/flashblocks/node-providers#interpreting-the-data), so as long as we set # confirmations to >= 2, this should properly await the mining of the full block.

This should alleviate issues we'd see in the bot server when attempting to withdraw funds immediately after the funds manager completes a swap. Oftentimes, the funds manager would error on the `/withdraw` endpoint invocation with a misleading `Insufficient balance` error.

In the case of Arbitrum, the difference between waiting 1 -> 2 confirmations is minimal. Thus, this is a much simpler change to implement than setting per-chain default confirmations, though I am happy to rework this PR to do that.