### PR TITLE
docker: use trixie debian distro in dockerfiles

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,5 +1,5 @@
 # === Chef === #
-FROM --platform=arm64 rust:latest AS chef
+FROM --platform=arm64 rust:1.89-trixie AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -50,7 +50,7 @@ WORKDIR /build
 RUN cargo build --release -p auth-server --features "$CARGO_FEATURES"
 
 # === Release stage === #
-FROM --platform=arm64 debian:bookworm-slim
+FROM --platform=arm64 debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y libssl-dev ca-certificates libpq-dev
 

--- a/compliance/compliance-server/Dockerfile
+++ b/compliance/compliance-server/Dockerfile
@@ -1,5 +1,5 @@
 # === Chef === #
-FROM --platform=arm64 rust:latest AS chef
+FROM --platform=arm64 rust:1.89-trixie AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -44,7 +44,7 @@ WORKDIR /build
 RUN cargo build --release -p compliance-server
 
 # === Release stage === #
-FROM --platform=arm64 debian:bookworm-slim
+FROM --platform=arm64 debian:trixie-slim
 
 RUN apt-get update && \
     apt-get install -y libssl-dev && \

--- a/funds-manager/Dockerfile
+++ b/funds-manager/Dockerfile
@@ -1,5 +1,5 @@
 # === Chef === #
-FROM --platform=arm64 rust:latest AS chef
+FROM --platform=arm64 rust:1.89-trixie AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -47,7 +47,7 @@ WORKDIR /build
 RUN cargo build --release -p funds-manager
 
 # === Release stage === #
-FROM --platform=arm64 debian:bookworm-slim
+FROM --platform=arm64 debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y libssl-dev ca-certificates libpq-dev
 

--- a/price-reporter/Dockerfile
+++ b/price-reporter/Dockerfile
@@ -1,5 +1,5 @@
 # === Chef === #
-FROM --platform=arm64 rust:latest AS chef
+FROM --platform=arm64 rust:1.89-trixie AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -45,7 +45,7 @@ WORKDIR /build
 RUN cargo build --release -p renegade-price-reporter
 
 # === Release === #
-FROM --platform=arm64 debian:bookworm-slim
+FROM --platform=arm64 debian:trixie-slim
 
 RUN apt-get update && \
     apt-get install -y libssl-dev ca-certificates

--- a/prover-service/Dockerfile
+++ b/prover-service/Dockerfile
@@ -1,5 +1,5 @@
 # === Chef === #
-FROM --platform=arm64 rust:latest AS chef
+FROM --platform=arm64 rust:1.89-trixie AS chef
 
 # Create a build dir and add local dependencies
 WORKDIR /build
@@ -48,7 +48,7 @@ WORKDIR /build
 RUN cargo build --release -p prover-service --features "$CARGO_FEATURES"
 
 # === Release stage === #
-FROM --platform=arm64 debian:bookworm-slim
+FROM --platform=arm64 debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y libssl-dev ca-certificates libpq-dev
 


### PR DESCRIPTION
This PR updates the dockerfiles in this repo to use `rust:1.89-trixie` and `debian:trixie-slim`. Otherwise, containers fail to run due to `rust:latest` using `trixie` and the release stage not having the expected versions of `GLIBC`.