### PR TITLE
price-reporter-client: `:s/get_nominal_price/get_decimal_adjusted_price`

### DIFF
--- a/auth/auth-server/src/chain_events/tasks.rs
+++ b/auth/auth-server/src/chain_events/tasks.rs
@@ -161,7 +161,7 @@ impl OnChainEventListenerExecutor {
         };
         let nominal_price = self
             .price_reporter_client
-            .get_nominal_price(&refund_asset.get_addr(), self.chain)
+            .get_decimal_adjusted_price(&refund_asset.get_addr(), self.chain)
             .await?;
 
         // We fetch the actual refund amount in the transaction. This is resilient

--- a/auth/auth-server/src/server/gas_sponsorship/refund_calculation.rs
+++ b/auth/auth-server/src/server/gas_sponsorship/refund_calculation.rs
@@ -80,7 +80,7 @@ impl Server {
             .ok_or(AuthServerError::gas_sponsorship(ERR_PRICE_BIGDECIMAL_CONVERSION))?;
 
         let buy_token_price =
-            self.price_reporter_client.get_nominal_price(&buy_mint, self.chain).await?;
+            self.price_reporter_client.get_decimal_adjusted_price(&buy_mint, self.chain).await?;
 
         let conversion_rate = eth_price / buy_token_price;
 

--- a/price-reporter-client/src/lib.rs
+++ b/price-reporter-client/src/lib.rs
@@ -103,9 +103,9 @@ impl PriceReporterClient {
         self.get_price(&mint, weth_token.get_chain()).await
     }
 
-    /// Get the nominal price of a token, i.e. whole units of USDC per nominal
-    /// unit of TOKEN
-    pub async fn get_nominal_price(
+    /// Get the decimal-adjusted price of a token, i.e. whole units of USDC per
+    /// nominal unit of TOKEN
+    pub async fn get_decimal_adjusted_price(
         &self,
         mint: &str,
         chain: Chain,
@@ -119,7 +119,6 @@ impl PriceReporterClient {
         })?;
 
         let adjustment: BigDecimal = BigInt::from(10).pow(decimals as u32).into();
-
         Ok(price / adjustment)
     }
 

--- a/price-reporter-client/src/price_stream.rs
+++ b/price-reporter-client/src/price_stream.rs
@@ -18,7 +18,7 @@ use renegade_api::websocket::WebsocketMessage;
 use serde::Deserialize;
 use tokio::{net::TcpStream, sync::RwLock, task::JoinHandle};
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
-use tracing::{error, info, warn};
+use tracing::{debug, error, warn};
 
 use super::{construct_price_topic, error::PriceReporterClientError, get_base_mint_from_topic};
 
@@ -217,7 +217,7 @@ impl MultiPriceStream {
                         let mint = get_base_mint_from_topic(&price_message.topic)?;
                         state.update_price(mint, price_message.price).await;
                     } else {
-                        warn!("Received invalid price message: {text}");
+                        debug!("Received invalid price message: {text}");
                     }
                 },
                 Message::Close(_) => {
@@ -253,7 +253,7 @@ async fn connect_and_subscribe(
             serde_json::to_string(&message).map_err(PriceReporterClientError::parsing)?,
         );
 
-        info!("Subscribing to price stream for {mint}...");
+        debug!("Subscribing to price stream for {mint}...");
         write.send(message_ser).await.map_err(PriceReporterClientError::websocket)?;
     }
 


### PR DESCRIPTION
### Purpose
This PR renames `get_nominal_price` to `get_decimal_adjusted_price`. The method in no way returns a nominal price and the actual transformation applied is a decimal adjustment.