### PR TITLE
solver: add flashblocks listener

### DIFF
--- a/renegade-solver/src/flashblocks/listener.rs
+++ b/renegade-solver/src/flashblocks/listener.rs
@@ -1,0 +1,186 @@
+#![allow(missing_docs, clippy::missing_docs_in_private_items, unused)]
+//! Subscribes to flashblocks events and forwards them to the
+//! `FlashblocksReceiver` trait.
+//!
+//! This is copied from https://github.com/base/node-reth/blob/main/crates/flashblocks-rpc/src/subscription.rs
+//! to avoid the dependency on `node-reth`.
+
+use std::time::Instant;
+use std::{io::Read, sync::Arc};
+
+use alloy_primitives::map::foldhash::HashMap;
+use alloy_primitives::{Address, U256};
+use alloy_rpc_types_engine::PayloadId;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use tracing::{error, info};
+use url::Url;
+
+use crate::flashblocks::types::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
+};
+
+pub trait FlashblocksReceiver {
+    fn on_flashblock_received(&self, flashblock: Flashblock);
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Metadata {
+    // If this field is needed in the future, add the `reth_optimism_primitives` dependency
+    // and use the `OpReceipt` type.
+    // There were rustc combatibility issues with `ark_mpc` so it was omitted for now.
+    // pub receipts: HashMap<B256, OpReceipt>,
+    pub new_account_balances: HashMap<Address, U256>,
+    pub block_number: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Flashblock {
+    pub payload_id: PayloadId,
+    pub index: u64,
+    pub base: Option<ExecutionPayloadBaseV1>,
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    pub metadata: Metadata,
+    pub received_at: Instant,
+}
+
+// Simplify actor messages to just handle shutdown
+#[derive(Debug)]
+enum ActorMessage {
+    BestPayload { payload: Flashblock },
+}
+
+pub struct FlashblocksSubscriber<Receiver> {
+    flashblocks_state: Arc<Receiver>,
+    ws_url: Url,
+}
+
+impl<Receiver> FlashblocksSubscriber<Receiver>
+where
+    Receiver: FlashblocksReceiver + Send + Sync + 'static,
+{
+    pub fn new(flashblocks_state: Arc<Receiver>, ws_url: Url) -> Self {
+        Self { ws_url, flashblocks_state }
+    }
+
+    pub fn start(self) {
+        info!(
+            message = "Starting Flashblocks subscription",
+            url = %self.ws_url,
+        );
+
+        let ws_url = self.ws_url.clone();
+
+        let (sender, mut mailbox) = mpsc::channel(100);
+
+        tokio::spawn(async move {
+            let mut backoff = std::time::Duration::from_secs(1);
+            const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(10);
+
+            loop {
+                match connect_async(ws_url.as_str()).await {
+                    Ok((ws_stream, _)) => {
+                        info!(message = "WebSocket connection established");
+
+                        let (_, mut read) = ws_stream.split();
+
+                        while let Some(msg) = read.next().await {
+                            match msg {
+                                Ok(Message::Binary(bytes)) => match try_decode_message(&bytes) {
+                                    Ok(payload) => {
+                                        let _ = sender.send(ActorMessage::BestPayload { payload: payload.clone() }).await.map_err(|e| {
+                                            error!(message = "Failed to publish message to channel", error = %e);
+                                        });
+                                    },
+                                    Err(e) => {
+                                        error!(
+                                            message = "error decoding flashblock message",
+                                            error = %e
+                                        );
+                                    },
+                                },
+                                Ok(Message::Close(_)) => {
+                                    info!(message = "WebSocket connection closed by upstream");
+                                    break;
+                                },
+                                Err(e) => {
+                                    error!(
+                                        message = "error receiving message",
+                                        error = %e
+                                    );
+                                    break;
+                                },
+                                _ => {},
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        error!(
+                            message = "WebSocket connection error, retrying",
+                            backoff_duration = ?backoff,
+                            error = %e
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
+                        continue;
+                    },
+                }
+            }
+        });
+
+        let flashblocks_state = self.flashblocks_state.clone();
+        tokio::spawn(async move {
+            while let Some(message) = mailbox.recv().await {
+                match message {
+                    ActorMessage::BestPayload { payload } => {
+                        flashblocks_state.on_flashblock_received(payload);
+                    },
+                }
+            }
+        });
+    }
+}
+
+fn try_decode_message(bytes: &[u8]) -> eyre::Result<Flashblock> {
+    let text = try_parse_message(bytes)?;
+
+    let payload: FlashblocksPayloadV1 = match serde_json::from_str(&text) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(eyre::eyre!("failed to parse message: {}", e));
+        },
+    };
+
+    let metadata: Metadata = match serde_json::from_value(payload.metadata.clone()) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(eyre::eyre!("failed to parse message metadata: {}", e));
+        },
+    };
+
+    Ok(Flashblock {
+        payload_id: payload.payload_id,
+        index: payload.index,
+        base: payload.base,
+        diff: payload.diff,
+        metadata,
+        received_at: Instant::now(),
+    })
+}
+
+fn try_parse_message(bytes: &[u8]) -> eyre::Result<String> {
+    if let Ok(text) = String::from_utf8(bytes.to_vec()) {
+        if text.trim_start().starts_with("{") {
+            return Ok(text);
+        }
+    }
+
+    let mut decompressor = brotli::Decompressor::new(bytes, 4096);
+    let mut decompressed = Vec::new();
+    decompressor.read_to_end(&mut decompressed)?;
+
+    let text = String::from_utf8(decompressed)?;
+    Ok(text)
+}

--- a/renegade-solver/src/flashblocks/mod.rs
+++ b/renegade-solver/src/flashblocks/mod.rs
@@ -1,0 +1,5 @@
+//! Defines a listener for flashblocks events.
+
+pub mod listener;
+pub mod multi_listener;
+pub mod types;

--- a/renegade-solver/src/flashblocks/multi_listener.rs
+++ b/renegade-solver/src/flashblocks/multi_listener.rs
@@ -1,0 +1,27 @@
+//! Defines a composite listener that fans out to multiple listeners.
+
+use std::sync::Arc;
+
+use crate::flashblocks::listener::{Flashblock, FlashblocksReceiver};
+
+/// The composite listener
+pub struct MultiListener {
+    /// The listeners to forward the flashblocks to.
+    listeners: Vec<Arc<dyn FlashblocksReceiver + Send + Sync>>,
+}
+
+impl MultiListener {
+    /// Creates a new `MultiListener` with the given listeners.
+    pub fn new(listeners: Vec<Arc<dyn FlashblocksReceiver + Send + Sync>>) -> Self {
+        Self { listeners }
+    }
+}
+
+impl FlashblocksReceiver for MultiListener {
+    fn on_flashblock_received(&self, flashblock: Flashblock) {
+        for listener in &self.listeners {
+            // Clone so each listener gets its own owned copy
+            listener.on_flashblock_received(flashblock.clone());
+        }
+    }
+}

--- a/renegade-solver/src/flashblocks/types.rs
+++ b/renegade-solver/src/flashblocks/types.rs
@@ -1,0 +1,80 @@
+//! Defines the types for flashblocks.
+//!
+//! This is copied from https://github.com/flashbots/rollup-boost/blob/main/crates/rollup-boost/src/flashblocks/primitives.rs
+//! to avoid the dependency on `rollup-boost`.
+
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use alloy_rpc_types_eth::Withdrawal;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Represents the modified portions of an execution payload within a
+/// flashblock. This structure contains only the fields that can be updated
+/// during block construction, such as state root, receipts, logs, and new
+/// transactions. Other immutable block fields like parent hash and block number
+/// are excluded since they remain constant throughout the block's construction.
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct ExecutionPayloadFlashblockDeltaV1 {
+    /// The state root of the block.
+    pub state_root: B256,
+    /// The receipts root of the block.
+    pub receipts_root: B256,
+    /// The logs bloom of the block.
+    pub logs_bloom: Bloom,
+    /// The gas used of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_used: u64,
+    /// The block hash of the block.
+    pub block_hash: B256,
+    /// The transactions of the block.
+    pub transactions: Vec<Bytes>,
+    /// Array of [`Withdrawal`] enabled with V2
+    pub withdrawals: Vec<Withdrawal>,
+    /// The withdrawals root of the block.
+    pub withdrawals_root: B256,
+}
+
+/// Represents the base configuration of an execution payload that remains
+/// constant throughout block construction. This includes fundamental block
+/// properties like parent hash, block number, and other header fields that are
+/// determined at block creation and cannot be modified.
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct ExecutionPayloadBaseV1 {
+    /// Ecotone parent beacon block root
+    pub parent_beacon_block_root: B256,
+    /// The parent hash of the block.
+    pub parent_hash: B256,
+    /// The fee recipient of the block.
+    pub fee_recipient: Address,
+    /// The previous randao of the block.
+    pub prev_randao: B256,
+    /// The block number.
+    #[serde(with = "alloy_serde::quantity")]
+    pub block_number: u64,
+    /// The gas limit of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_limit: u64,
+    /// The timestamp of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub timestamp: u64,
+    /// The extra data of the block.
+    pub extra_data: Bytes,
+    /// The base fee per gas of the block.
+    pub base_fee_per_gas: U256,
+}
+
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct FlashblocksPayloadV1 {
+    /// The payload id of the flashblock
+    pub payload_id: PayloadId,
+    /// The index of the flashblock in the block
+    pub index: u64,
+    /// The base execution payload configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<ExecutionPayloadBaseV1>,
+    /// The delta/diff containing modified portions of the execution payload
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    /// Additional metadata associated with the flashblock
+    pub metadata: Value,
+}


### PR DESCRIPTION
### Purpose
This PR adds a `FlashblocksListener` that will enable the solver to subscribe to and receive events from the configured Flashblocks block builder.

Much of the code is taken directly from https://github.com/base/node-reth, we could have added the crate as a dependency but I chose to copy specific files over instead since it 3x'd the overall number of dependencies.