### PR TITLE
solver: add base fee cache

### DIFF
--- a/renegade-solver/src/fee_cache/fees.rs
+++ b/renegade-solver/src/fee_cache/fees.rs
@@ -1,0 +1,32 @@
+//! Defines a cache for the base fee per gas.
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// The default value for the base fee per gas.
+const NONE: u64 = 0;
+
+/// The cache for the base fee per gas.
+pub struct FeeCache {
+    /// The base fee per gas.
+    base_fee_per_gas: AtomicU64,
+}
+
+impl Default for FeeCache {
+    fn default() -> Self {
+        Self { base_fee_per_gas: AtomicU64::new(NONE) }
+    }
+}
+
+impl FeeCache {
+    /// Sets the base fee per gas.
+    pub fn set_base_fee_per_gas(&self, base: u64) {
+        self.base_fee_per_gas.store(base, Ordering::Relaxed);
+    }
+
+    /// Gets the base fee per gas.
+    pub fn base_fee_per_gas(&self) -> Option<u64> {
+        match self.base_fee_per_gas.load(Ordering::Relaxed) {
+            NONE => None,
+            v => Some(v),
+        }
+    }
+}

--- a/renegade-solver/src/fee_cache/mod.rs
+++ b/renegade-solver/src/fee_cache/mod.rs
@@ -1,0 +1,5 @@
+//! Defines a cache for the base fee per gas.
+pub mod fees;
+pub mod worker;
+
+pub use fees::FeeCache;

--- a/renegade-solver/src/fee_cache/worker.rs
+++ b/renegade-solver/src/fee_cache/worker.rs
@@ -1,0 +1,45 @@
+//! Defines a worker that listens for blocks and updates the fee cache.
+
+use std::sync::Arc;
+
+use alloy::providers::{DynProvider, Provider};
+use futures_util::StreamExt;
+use tracing::{error, info, warn};
+
+use crate::fee_cache::fees::FeeCache;
+
+/// The worker that listens for blocks and updates the fee cache.
+pub struct FeeCacheWorker {
+    /// The provider to use to subscribe to blocks.
+    provider: DynProvider,
+    /// The fee cache to update.
+    fee_cache: Arc<FeeCache>,
+}
+
+impl FeeCacheWorker {
+    /// Creates a new `FeeCacheWorker` with the given provider and fee cache.
+    pub fn new(provider: DynProvider, fee_cache: Arc<FeeCache>) -> Self {
+        Self { provider, fee_cache }
+    }
+
+    /// Starts the worker.
+    pub fn start(&self) {
+        let provider = self.provider.clone();
+        let fee_cache = self.fee_cache.clone();
+        tokio::spawn(async move {
+            match provider.subscribe_blocks().await {
+                Ok(subscription) => {
+                    info!("listening for blocks via websocket");
+                    let mut stream = subscription.into_stream();
+                    while let Some(header) = stream.next().await {
+                        if let Some(base) = header.base_fee_per_gas {
+                            fee_cache.set_base_fee_per_gas(base);
+                        }
+                    }
+                    warn!("block stream ended");
+                },
+                Err(e) => error!("subscription error: {e}"),
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds a base fee cache that is updated on every L2 block. This is to remove the step fetching the base fee from the hot path of building a tx while guaranteeing the latest base fee.