### PR TITLE
solver: add flashblocks listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +133,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "alloy-transport-ws",
 ]
 
@@ -134,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda689f7287f15bd3582daba6be8d1545bad3740fd1fb778f629a1fe866bb43b"
+checksum = "35f021a55afd68ff2364ccfddaa364fc9a38a72200cdc74fcfb8dc3231d38f2c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 1.3.0",
@@ -256,15 +272,16 @@ checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives 1.3.0",
  "alloy-rlp",
+ "k256",
  "serde",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35887da30b5fc50267109a3c61cd63e6ca1f45967983641053a40ee83468c1"
+checksum = "7473a19f02b25f8e1e8c69d35f02c07245694d11bd91bfe00e9190ac106b3838"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -419,13 +436,16 @@ dependencies = [
  "alloy-primitives 1.3.0",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types 1.3.0",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -502,6 +522,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
@@ -523,9 +544,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41492dac39365b86a954de86c47ec23dcc7452cdb2fde591caadc194b3e34c6"
 dependencies = [
  "alloy-primitives 1.3.0",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
+ "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10493fa300a2757d8134f584800fef545c15905c95122bed1f6dde0b0d9dae27"
+dependencies = [
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
 ]
@@ -550,6 +586,23 @@ dependencies = [
  "alloy-primitives 1.3.0",
  "derive_more 2.0.1",
  "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1a77a23d609bca2e4a60f992dde5f987475cb064da355fa4dbd7cda2e1bb48"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives 1.3.0",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more 2.0.1",
+ "rand 0.8.5",
+ "serde",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -588,10 +641,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-serde"
+name = "alloy-rpc-types-txpool"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8d2c52adebf3e6494976c8542fbdf12f10123b26e11ad56f77274c16a2a039"
+checksum = "3cc803e9b8d16154c856a738c376e002abe4b388e5fef91c8aebc8373e99fd45"
+dependencies = [
+ "alloy-primitives 1.3.0",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30be84f45d4f687b00efaba1e6290cbf53ccc8f6b8fbb54e4c2f9d2a0474ce95"
 dependencies = [
  "alloy-primitives 1.3.0",
  "serde",
@@ -801,6 +866,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport-ipc"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79064b5a08259581cb5614580010007c2df6deab1e8f3e8c7af8d7e9227008f"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-pubsub",
+ "alloy-transport",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-transport-ws"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acb36318dfa50817154064fea7932adf2eec3f51c86680e2b37d7e8906c66bb"
+checksum = "72e29436068f836727d4e7c819ae6bf6f9c9e19a32e96fc23e814709a277f23a"
 dependencies = [
  "alloy-primitives 1.3.0",
  "darling 0.20.11",
@@ -2225,6 +2310,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3469,6 +3575,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "doctest-file"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "downcast-rs"
@@ -5145,6 +5257,21 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7193,6 +7320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
+
+[[package]]
 name = "redis"
 version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7467,20 +7600,26 @@ dependencies = [
  "alloy",
  "alloy-contract",
  "alloy-primitives 1.3.0",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-sol-types 1.3.0",
  "bimap",
+ "brotli",
  "clap",
  "common",
  "config",
  "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "eyre",
+ "futures-util",
  "lru 0.12.5",
- "price-reporter-client",
  "renegade-sdk",
  "reqwest 0.12.22",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "url",
  "util",
@@ -10088,6 +10227,12 @@ dependencies = [
  "wasite",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"

--- a/renegade-solver/Cargo.toml
+++ b/renegade-solver/Cargo.toml
@@ -15,14 +15,18 @@ keywords = ["solver", "renegade", "protocol", "intents", "darkpool"]
 clap = { version = "4.0", features = ["derive", "env"] }
 reqwest = "0.12"
 tokio = { version = "1.0", features = ["full"] }
+tokio-tungstenite = { version = "0.26.2", features = ["native-tls"] }
 tracing = "0.1"
 warp = "0.3"
 
 # === Ethereum Libraries === #
-alloy = { workspace = true, features = ["essentials"] }
+alloy = { workspace = true , features = ["full"] }
 alloy-primitives = { workspace = true, features = ["serde", "k256", "rand"] }
 alloy-sol-types = { workspace = true }
 alloy-contract = { workspace = true }
+alloy-rpc-types-eth = { version = "1.0.23" }
+alloy-rpc-types-engine = { version = "1.0.23", default-features = false, features = ["serde"]}
+alloy-serde = { version = "1.0.23" }
 
 # === Renegade Dependencies === #
 renegade-common = { workspace = true }
@@ -33,10 +37,12 @@ renegade-sdk = { git = "https://github.com/renegade-fi/rust-sdk" }
 renegade-util = { workspace = true, features = [
     "telemetry",
 ] }
-price-reporter-client = { path = "../price-reporter-client" }
 
 # === Misc Dependencies === #
 bimap = "0.6"
+brotli = "8.0.1"
+eyre = "0.6"
+futures-util = "0.3.31"
 lru = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/renegade-solver/src/cli.rs
+++ b/renegade-solver/src/cli.rs
@@ -21,9 +21,6 @@ pub struct Cli {
     /// The URL of the UniswapX API
     #[arg(long, env = "UNISWAPX_URL")]
     pub uniswapx_url: String,
-    /// The URL of the price reporter service
-    #[arg(long, env = "PRICE_REPORTER_URL")]
-    pub price_reporter_url: String,
     /// The API key for the Renegade external match API
     #[arg(long, env = "RENEGADE_API_KEY")]
     pub renegade_api_key: String,
@@ -38,9 +35,12 @@ pub struct Cli {
     /// The address of the executor contract
     #[arg(long, env = "EXECUTOR_ADDRESS")]
     pub contract_address: String,
-    /// The RPC URL for blockchain interaction
-    #[arg(long, env = "RPC_URL")]
-    pub rpc_url: String,
+    /// The Flashblocks WebSocket URL
+    #[arg(long, env = "FB_WEBSOCKET_URL")]
+    pub fb_websocket_url: String,
+    /// The WebSocket URL for real-time block monitoring
+    #[arg(long, env = "RPC_WEBSOCKET_URL")]
+    pub rpc_websocket_url: String,
     /// The private key for signing transactions
     #[arg(long, env = "PRIVATE_KEY")]
     pub private_key: String,

--- a/renegade-solver/src/flashblocks/listener.rs
+++ b/renegade-solver/src/flashblocks/listener.rs
@@ -22,6 +22,7 @@ use crate::flashblocks::types::{
     ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
 };
 
+/// A trait for receiving flashblocks.
 pub trait FlashblocksReceiver {
     fn on_flashblock_received(&self, flashblock: Flashblock);
 }
@@ -37,6 +38,7 @@ pub struct Metadata {
 }
 
 #[derive(Debug, Clone)]
+/// A flashblock received from the flashblocks websocket.
 pub struct Flashblock {
     pub payload_id: PayloadId,
     pub index: u64,
@@ -46,12 +48,13 @@ pub struct Flashblock {
     pub received_at: Instant,
 }
 
-// Simplify actor messages to just handle shutdown
+/// Simplify actor messages to just handle shutdown.
 #[derive(Debug)]
 enum ActorMessage {
     BestPayload { payload: Flashblock },
 }
 
+/// A subscriber that listens for flashblocks and forwards them to a receiver.
 pub struct FlashblocksSubscriber<Receiver> {
     flashblocks_state: Arc<Receiver>,
     ws_url: Url,
@@ -61,10 +64,13 @@ impl<Receiver> FlashblocksSubscriber<Receiver>
 where
     Receiver: FlashblocksReceiver + Send + Sync + 'static,
 {
+    /// Creates a new `FlashblocksSubscriber` with the given receiver and
+    /// websocket URL.
     pub fn new(flashblocks_state: Arc<Receiver>, ws_url: Url) -> Self {
         Self { ws_url, flashblocks_state }
     }
 
+    /// Starts the subscriber.
     pub fn start(self) {
         info!(
             message = "Starting Flashblocks subscription",
@@ -143,6 +149,7 @@ where
     }
 }
 
+/// Decodes a flashblock message and returns a `Flashblock` struct.
 fn try_decode_message(bytes: &[u8]) -> eyre::Result<Flashblock> {
     let text = try_parse_message(bytes)?;
 
@@ -170,6 +177,7 @@ fn try_decode_message(bytes: &[u8]) -> eyre::Result<Flashblock> {
     })
 }
 
+/// Parses a brotli-compressed message.
 fn try_parse_message(bytes: &[u8]) -> eyre::Result<String> {
     if let Ok(text) = String::from_utf8(bytes.to_vec()) {
         if text.trim_start().starts_with("{") {

--- a/renegade-solver/src/flashblocks/listener.rs
+++ b/renegade-solver/src/flashblocks/listener.rs
@@ -1,0 +1,186 @@
+#![allow(missing_docs, clippy::missing_docs_in_private_items, unused)]
+//! Subscribes to flashblocks events and forwards them to the
+//! `FlashblocksReceiver` trait.
+//!
+//! This is copied from https://github.com/base/node-reth/blob/main/crates/flashblocks-rpc/src/subscription.rs
+//! to avoid the dependency on `node-reth`.
+
+use std::time::Instant;
+use std::{io::Read, sync::Arc};
+
+use alloy_primitives::map::foldhash::HashMap;
+use alloy_primitives::{Address, U256};
+use alloy_rpc_types_engine::PayloadId;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+use tracing::{error, info};
+use url::Url;
+
+use crate::flashblocks::types::{
+    ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, FlashblocksPayloadV1,
+};
+
+pub trait FlashblocksReceiver {
+    fn on_flashblock_received(&self, flashblock: Flashblock);
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Metadata {
+    // If this field is needed in the future, add the `reth_optimism_primitives` dependency
+    // and use the `OpReceipt` type.
+    // There were rustc combatibility issues with `ark_mpc` so it was omitted for now.
+    // pub receipts: HashMap<B256, OpReceipt>,
+    pub new_account_balances: HashMap<Address, U256>,
+    pub block_number: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Flashblock {
+    pub payload_id: PayloadId,
+    pub index: u64,
+    pub base: Option<ExecutionPayloadBaseV1>,
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    pub metadata: Metadata,
+    pub received_at: Instant,
+}
+
+// Simplify actor messages to just handle shutdown
+#[derive(Debug)]
+enum ActorMessage {
+    BestPayload { payload: Flashblock },
+}
+
+pub struct FlashblocksSubscriber<Receiver> {
+    flashblocks_state: Arc<Receiver>,
+    ws_url: Url,
+}
+
+impl<Receiver> FlashblocksSubscriber<Receiver>
+where
+    Receiver: FlashblocksReceiver + Send + Sync + 'static,
+{
+    pub fn new(flashblocks_state: Arc<Receiver>, ws_url: Url) -> Self {
+        Self { ws_url, flashblocks_state }
+    }
+
+    pub fn start(self) {
+        info!(
+            message = "Starting Flashblocks subscription",
+            url = %self.ws_url,
+        );
+
+        let ws_url = self.ws_url.clone();
+
+        let (sender, mut mailbox) = mpsc::channel(100);
+
+        tokio::spawn(async move {
+            let mut backoff = std::time::Duration::from_secs(1);
+            const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(10);
+
+            loop {
+                match connect_async(ws_url.as_str()).await {
+                    Ok((ws_stream, _)) => {
+                        info!(message = "WebSocket connection established");
+
+                        let (_, mut read) = ws_stream.split();
+
+                        while let Some(msg) = read.next().await {
+                            match msg {
+                                Ok(Message::Binary(bytes)) => match try_decode_message(&bytes) {
+                                    Ok(payload) => {
+                                        let _ = sender.send(ActorMessage::BestPayload { payload: payload.clone() }).await.map_err(|e| {
+                                            error!(message = "Failed to publish message to channel", error = %e);
+                                        });
+                                    },
+                                    Err(e) => {
+                                        error!(
+                                            message = "error decoding flashblock message",
+                                            error = %e
+                                        );
+                                    },
+                                },
+                                Ok(Message::Close(_)) => {
+                                    info!(message = "WebSocket connection closed by upstream");
+                                    break;
+                                },
+                                Err(e) => {
+                                    error!(
+                                        message = "error receiving message",
+                                        error = %e
+                                    );
+                                    break;
+                                },
+                                _ => {},
+                            }
+                        }
+                    },
+                    Err(e) => {
+                        error!(
+                            message = "WebSocket connection error, retrying",
+                            backoff_duration = ?backoff,
+                            error = %e
+                        );
+                        tokio::time::sleep(backoff).await;
+                        backoff = std::cmp::min(backoff * 2, MAX_BACKOFF);
+                        continue;
+                    },
+                }
+            }
+        });
+
+        let flashblocks_state = self.flashblocks_state.clone();
+        tokio::spawn(async move {
+            while let Some(message) = mailbox.recv().await {
+                match message {
+                    ActorMessage::BestPayload { payload } => {
+                        flashblocks_state.on_flashblock_received(payload);
+                    },
+                }
+            }
+        });
+    }
+}
+
+fn try_decode_message(bytes: &[u8]) -> eyre::Result<Flashblock> {
+    let text = try_parse_message(bytes)?;
+
+    let payload: FlashblocksPayloadV1 = match serde_json::from_str(&text) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(eyre::eyre!("failed to parse message: {}", e));
+        },
+    };
+
+    let metadata: Metadata = match serde_json::from_value(payload.metadata.clone()) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(eyre::eyre!("failed to parse message metadata: {}", e));
+        },
+    };
+
+    Ok(Flashblock {
+        payload_id: payload.payload_id,
+        index: payload.index,
+        base: payload.base,
+        diff: payload.diff,
+        metadata,
+        received_at: Instant::now(),
+    })
+}
+
+fn try_parse_message(bytes: &[u8]) -> eyre::Result<String> {
+    if let Ok(text) = String::from_utf8(bytes.to_vec()) {
+        if text.trim_start().starts_with("{") {
+            return Ok(text);
+        }
+    }
+
+    let mut decompressor = brotli::Decompressor::new(bytes, 4096);
+    let mut decompressed = Vec::new();
+    decompressor.read_to_end(&mut decompressed)?;
+
+    let text = String::from_utf8(decompressed)?;
+    Ok(text)
+}

--- a/renegade-solver/src/flashblocks/mod.rs
+++ b/renegade-solver/src/flashblocks/mod.rs
@@ -1,0 +1,7 @@
+//! Defines a listener for flashblocks events.
+
+mod listener;
+pub mod multi_listener;
+pub use listener::{Flashblock, FlashblocksReceiver};
+pub use multi_listener::FlashblocksListener;
+pub mod types;

--- a/renegade-solver/src/flashblocks/multi_listener.rs
+++ b/renegade-solver/src/flashblocks/multi_listener.rs
@@ -1,0 +1,42 @@
+//! Defines a composite listener that fans out to multiple listeners and owns
+//! the WebSocket subscription lifecycle.
+
+use std::sync::Arc;
+
+use url::Url;
+
+use crate::cli::Cli;
+use crate::flashblocks::listener::{Flashblock, FlashblocksReceiver, FlashblocksSubscriber};
+
+/// The public listener that routes Flashblocks events to multiple receivers
+pub struct FlashblocksListener {
+    /// The listeners to forward the flashblocks to.
+    listeners: Vec<Box<dyn FlashblocksReceiver + Send + Sync>>,
+    /// The websocket URL for flashblocks
+    ws_url: Url,
+}
+
+impl FlashblocksListener {
+    /// Creates a new `MultiListener` with the given listeners and CLI config.
+    pub fn new(listeners: Vec<Box<dyn FlashblocksReceiver + Send + Sync>>, cli: &Cli) -> Self {
+        let ws_url =
+            Url::parse(&cli.fb_websocket_url).expect("Failed to parse flashblocks websocket url");
+        Self { listeners, ws_url }
+    }
+
+    /// Start the flashblocks subscription
+    pub fn start(self) {
+        let ws_url = self.ws_url.clone();
+        let subscriber = FlashblocksSubscriber::new(Arc::new(self), ws_url);
+        subscriber.start();
+    }
+}
+
+impl FlashblocksReceiver for FlashblocksListener {
+    fn on_flashblock_received(&self, flashblock: Flashblock) {
+        for listener in &self.listeners {
+            // Clone so each listener gets its own owned copy
+            listener.on_flashblock_received(flashblock.clone());
+        }
+    }
+}

--- a/renegade-solver/src/flashblocks/types.rs
+++ b/renegade-solver/src/flashblocks/types.rs
@@ -1,0 +1,80 @@
+//! Defines the types for flashblocks.
+//!
+//! This is copied from https://github.com/flashbots/rollup-boost/blob/main/crates/rollup-boost/src/flashblocks/primitives.rs
+//! to avoid the dependency on `rollup-boost`.
+
+use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
+use alloy_rpc_types_engine::PayloadId;
+use alloy_rpc_types_eth::Withdrawal;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Represents the modified portions of an execution payload within a
+/// flashblock. This structure contains only the fields that can be updated
+/// during block construction, such as state root, receipts, logs, and new
+/// transactions. Other immutable block fields like parent hash and block number
+/// are excluded since they remain constant throughout the block's construction.
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct ExecutionPayloadFlashblockDeltaV1 {
+    /// The state root of the block.
+    pub state_root: B256,
+    /// The receipts root of the block.
+    pub receipts_root: B256,
+    /// The logs bloom of the block.
+    pub logs_bloom: Bloom,
+    /// The gas used of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_used: u64,
+    /// The block hash of the block.
+    pub block_hash: B256,
+    /// The transactions of the block.
+    pub transactions: Vec<Bytes>,
+    /// Array of [`Withdrawal`] enabled with V2
+    pub withdrawals: Vec<Withdrawal>,
+    /// The withdrawals root of the block.
+    pub withdrawals_root: B256,
+}
+
+/// Represents the base configuration of an execution payload that remains
+/// constant throughout block construction. This includes fundamental block
+/// properties like parent hash, block number, and other header fields that are
+/// determined at block creation and cannot be modified.
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct ExecutionPayloadBaseV1 {
+    /// Ecotone parent beacon block root
+    pub parent_beacon_block_root: B256,
+    /// The parent hash of the block.
+    pub parent_hash: B256,
+    /// The fee recipient of the block.
+    pub fee_recipient: Address,
+    /// The previous randao of the block.
+    pub prev_randao: B256,
+    /// The block number.
+    #[serde(with = "alloy_serde::quantity")]
+    pub block_number: u64,
+    /// The gas limit of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub gas_limit: u64,
+    /// The timestamp of the block.
+    #[serde(with = "alloy_serde::quantity")]
+    pub timestamp: u64,
+    /// The extra data of the block.
+    pub extra_data: Bytes,
+    /// The base fee per gas of the block.
+    pub base_fee_per_gas: U256,
+}
+
+#[derive(Clone, Debug, PartialEq, Default, Deserialize, Serialize)]
+pub struct FlashblocksPayloadV1 {
+    /// The payload id of the flashblock
+    pub payload_id: PayloadId,
+    /// The index of the flashblock in the block
+    pub index: u64,
+    /// The base execution payload configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<ExecutionPayloadBaseV1>,
+    /// The delta/diff containing modified portions of the execution payload
+    pub diff: ExecutionPayloadFlashblockDeltaV1,
+    /// Additional metadata associated with the flashblock
+    pub metadata: Value,
+}


### PR DESCRIPTION
### Purpose
This PR adds a `FlashblocksListener` that will enable the solver to subscribe to and receive events from the configured Flashblocks block builder.

Much of the code is taken directly from https://github.com/base/node-reth, we could have added the crate as a dependency but I chose to copy specific files over instead since it 3x'd the overall number of dependencies.