### PR TITLE
solver: add base fee cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,6 +3132,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "postcard",
+ "rand 0.8.5",
  "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "ruint",
  "serde",
@@ -7425,25 +7426,37 @@ dependencies = [
 
 [[package]]
 name = "renegade-sdk"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77656fb817f157896c0859241d70b5c665ed5a5fb019e4edd1f9f04f2e759449"
+version = "0.1.17"
+source = "git+https://github.com/renegade-fi/rust-sdk#c631ee9bcb1463c98afa1c140b899b053e778ee5"
 dependencies = [
  "alloy",
  "alloy-rpc-types-eth",
  "base64 0.22.1",
  "bigdecimal 0.4.8",
+ "circuit-types",
+ "common",
+ "constants 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
+ "darkpool-client",
+ "external-api",
  "eyre",
+ "futures-util",
  "hmac",
+ "k256",
  "num-bigint",
  "num-integer",
  "num-traits",
+ "renegade-crypto 0.1.0 (git+https://github.com/renegade-fi/renegade.git)",
  "reqwest 0.12.22",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.20.1",
+ "tracing",
  "url",
+ "util",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -9172,8 +9185,10 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls 0.21.12",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
  "webpki-roots 0.25.4",
@@ -9526,6 +9541,7 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "rustls 0.21.12",
  "sha1",

--- a/renegade-solver/src/fee_cache/fees.rs
+++ b/renegade-solver/src/fee_cache/fees.rs
@@ -2,9 +2,6 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-/// The default value for the base fee per gas.
-const NONE: u64 = 0;
-
 /// The inner cache backing storage. Kept private to hide concurrency details.
 struct FeeCacheInner {
     /// The base fee per gas.
@@ -12,19 +9,12 @@ struct FeeCacheInner {
 }
 
 /// A value-type handle to the fee cache. Clones are cheap and share state.
-#[derive(Clone)]
 pub struct FeeCache(Arc<FeeCacheInner>);
-
-impl Default for FeeCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 impl FeeCache {
     /// Create a new cache
     pub fn new() -> Self {
-        Self(Arc::new(FeeCacheInner { base_fee_per_gas: AtomicU64::new(NONE) }))
+        Self(Arc::new(FeeCacheInner { base_fee_per_gas: AtomicU64::default() }))
     }
 
     /// Sets the base fee per gas.
@@ -35,7 +25,7 @@ impl FeeCache {
     /// Gets the base fee per gas.
     pub fn base_fee_per_gas(&self) -> Option<u64> {
         match self.0.base_fee_per_gas.load(Ordering::Relaxed) {
-            NONE => None,
+            0 => None,
             v => Some(v),
         }
     }

--- a/renegade-solver/src/fee_cache/fees.rs
+++ b/renegade-solver/src/fee_cache/fees.rs
@@ -1,0 +1,42 @@
+//! Defines a cache for the base fee per gas.
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// The default value for the base fee per gas.
+const NONE: u64 = 0;
+
+/// The inner cache backing storage. Kept private to hide concurrency details.
+struct FeeCacheInner {
+    /// The base fee per gas.
+    base_fee_per_gas: AtomicU64,
+}
+
+/// A value-type handle to the fee cache. Clones are cheap and share state.
+#[derive(Clone)]
+pub struct FeeCache(Arc<FeeCacheInner>);
+
+impl Default for FeeCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FeeCache {
+    /// Create a new cache
+    pub fn new() -> Self {
+        Self(Arc::new(FeeCacheInner { base_fee_per_gas: AtomicU64::new(NONE) }))
+    }
+
+    /// Sets the base fee per gas.
+    pub fn set_base_fee_per_gas(&self, base: u64) {
+        self.0.base_fee_per_gas.store(base, Ordering::Relaxed);
+    }
+
+    /// Gets the base fee per gas.
+    pub fn base_fee_per_gas(&self) -> Option<u64> {
+        match self.0.base_fee_per_gas.load(Ordering::Relaxed) {
+            NONE => None,
+            v => Some(v),
+        }
+    }
+}

--- a/renegade-solver/src/fee_cache/mod.rs
+++ b/renegade-solver/src/fee_cache/mod.rs
@@ -1,0 +1,5 @@
+//! Defines a cache for the base fee per gas.
+pub mod fees;
+pub mod worker;
+
+pub use fees::FeeCache;

--- a/renegade-solver/src/fee_cache/worker.rs
+++ b/renegade-solver/src/fee_cache/worker.rs
@@ -1,0 +1,43 @@
+//! Defines a worker that listens for blocks and updates the fee cache.
+
+use alloy::providers::{DynProvider, Provider};
+use futures_util::StreamExt;
+use tracing::{error, info, warn};
+
+use crate::fee_cache::fees::FeeCache;
+
+/// The worker that listens for blocks and updates the fee cache.
+pub struct FeeCacheWorker {
+    /// The provider to use to subscribe to blocks.
+    provider: DynProvider,
+    /// The fee cache to update.
+    fee_cache: FeeCache,
+}
+
+impl FeeCacheWorker {
+    /// Creates a new `FeeCacheWorker` with the given provider and fee cache.
+    pub fn new(provider: DynProvider, fee_cache: FeeCache) -> Self {
+        Self { provider, fee_cache }
+    }
+
+    /// Starts the worker.
+    pub fn start(&self) {
+        let provider = self.provider.clone();
+        let fee_cache = self.fee_cache.clone();
+        tokio::spawn(async move {
+            match provider.subscribe_blocks().await {
+                Ok(subscription) => {
+                    info!("listening for blocks via websocket");
+                    let mut stream = subscription.into_stream();
+                    while let Some(header) = stream.next().await {
+                        if let Some(base) = header.base_fee_per_gas {
+                            fee_cache.set_base_fee_per_gas(base);
+                        }
+                    }
+                    warn!("block stream ended");
+                },
+                Err(e) => error!("subscription error: {e}"),
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Purpose
This PR adds a base fee cache that is updated on every L2 block. We do this to remove retrieval of the latest base fee from the hot path of building a tx.