### PR TITLE
funds-manager: execution_client: bebop, lifi: fallback to gas estimation

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/bebop/api_types.rs
@@ -146,11 +146,6 @@ impl BebopQuoteResponse {
         self.best_route().map(|route| route.quote.tx.data.clone())
     }
 
-    /// Get the gas limit for the quote
-    pub fn get_gas_limit(&self) -> Result<U256, ExecutionClientError> {
-        self.best_route().map(|route| route.quote.tx.gas)
-    }
-
     /// Get the approval target for the quote
     pub fn get_approval_target(&self) -> Result<Address, ExecutionClientError> {
         self.best_route().map(|route| route.quote.approval_target)
@@ -206,5 +201,4 @@ pub struct BebopTxData {
     to: Address,
     value: U256,
     data: Bytes,
-    gas: U256,
 }

--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/api_types.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/api_types.rs
@@ -68,8 +68,6 @@ struct LifiTransactionRequest {
     data: String,
     /// Amount of native token to send (in hex)
     value: String,
-    /// Gas limit in hex
-    gas_limit: String,
 }
 
 /// Quote estimate details from LiFi API
@@ -160,12 +158,6 @@ impl LifiQuote {
         hex::decode(self.transaction_request.data.trim_start_matches("0x"))
             .map_err(ExecutionClientError::quote_conversion)
             .map(Bytes::from)
-    }
-
-    /// Get the gas limit for the swap
-    pub fn get_gas_limit(&self) -> Result<U256, ExecutionClientError> {
-        U256::from_str_radix(self.transaction_request.gas_limit.trim_start_matches("0x"), 16)
-            .map_err(ExecutionClientError::quote_conversion)
     }
 
     /// Get the tool (venue) providing the route


### PR DESCRIPTION
This PR bypasses the gas limit estimate returned by the Lifi & Bebop APIs in favor of local gas estimation. This is primarily so that we catch reverts during estimation instead of executing a reverting transaction.

### Testing
- [x] Ran local funds manager, executed swap, settled w/o gas estimation issues