### PR TITLE
funds-manager: execution_client: bebop, lifi: handle gas estimation errors gracefully

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/lifi/mod.rs
@@ -309,21 +309,31 @@ impl ExecutionVenue for LifiClient {
 
         info!("Executing Lifi quote from {}", lifi_execution_data.tool);
 
-        let receipt = self.send_tx(tx).await?;
-        let gas_cost = get_gas_cost(&receipt);
-        let tx_hash = receipt.transaction_hash;
+        match self.send_tx(tx).await {
+            Ok(receipt) => {
+                let gas_cost = get_gas_cost(&receipt);
+                let tx_hash = receipt.transaction_hash;
 
-        if receipt.status() {
-            let recipient = lifi_execution_data.from;
-            let buy_token_address = quote.buy_token.get_alloy_address();
-            let buy_amount_actual = get_received_amount(&receipt, buy_token_address, recipient);
+                if receipt.status() {
+                    let recipient = lifi_execution_data.from;
+                    let buy_token_address = quote.buy_token.get_alloy_address();
+                    let buy_amount_actual =
+                        get_received_amount(&receipt, buy_token_address, recipient);
 
-            Ok(ExecutionResult { buy_amount_actual, gas_cost, tx_hash: Some(tx_hash) })
-        } else {
-            warn!("tx ({:#x}) failed", tx_hash);
-            // For an unsuccessful swap, we exclude the TX hash and report
-            // an actual buy amount of zero, but we still include the gas cost
-            Ok(ExecutionResult { buy_amount_actual: U256::ZERO, gas_cost, tx_hash: None })
+                    Ok(ExecutionResult { buy_amount_actual, gas_cost, tx_hash: Some(tx_hash) })
+                } else {
+                    warn!("tx ({:#x}) reverted", tx_hash);
+                    Ok(ExecutionResult { buy_amount_actual: U256::ZERO, gas_cost, tx_hash: None })
+                }
+            },
+            Err(e) => {
+                warn!("swap tx failed to send: {e}");
+                Ok(ExecutionResult {
+                    buy_amount_actual: U256::ZERO,
+                    gas_cost: U256::ZERO,
+                    tx_hash: None,
+                })
+            },
         }
     }
 }


### PR DESCRIPTION
This PR tweaks the error handling of the `BebopClient` & `LifiClient` `send_tx` method to treat failures to send the TX in the same way that it treats reverted TXs. This is necessary because we will be catching reverts during gas estimation implicitly in `send_tx`, and we want to signal to the swap loop that this merits a retry, rather than propagating an error all the way to the endpoint handler.