### PR TITLE
funds-manager: execution_client: venues: exclude failing quote sources from retries

### DIFF
--- a/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/cowswap/mod.rs
@@ -423,7 +423,12 @@ impl ExecutionVenue for CowswapClient {
     async fn get_quotes(
         &self,
         params: QuoteParams,
+        excluded_quote_sources: &[CrossVenueQuoteSource],
     ) -> Result<Vec<ExecutableQuote>, ExecutionClientError> {
+        if excluded_quote_sources.contains(&CrossVenueQuoteSource::Cowswap) {
+            return Ok(vec![]);
+        }
+
         let slippage_tolerance = params.slippage_tolerance;
         let quote_request = self.construct_quote_params(params);
         let quote_response: OrderQuoteResponse =

--- a/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
+++ b/funds-manager/funds-manager-server/src/execution_client/venues/mod.rs
@@ -7,7 +7,10 @@ use funds_manager_api::quoters::{QuoteParams, SupportedExecutionVenue};
 use crate::execution_client::{
     error::ExecutionClientError,
     venues::{
-        bebop::BebopClient, cowswap::CowswapClient, lifi::LifiClient, quote::ExecutableQuote,
+        bebop::BebopClient,
+        cowswap::CowswapClient,
+        lifi::LifiClient,
+        quote::{CrossVenueQuoteSource, ExecutableQuote},
     },
 };
 
@@ -63,12 +66,14 @@ pub trait ExecutionVenue: Sync {
     /// Get the name of the venue
     fn venue_specifier(&self) -> SupportedExecutionVenue;
 
-    /// Get quotes from the venue.
+    /// Get quotes from the venue, excluding those from the given list of
+    /// sources.
     ///
     /// Each quote should represent a unique variant of `CrossVenueQuoteSource`.
     async fn get_quotes(
         &self,
         params: QuoteParams,
+        excluded_quote_sources: &[CrossVenueQuoteSource],
     ) -> Result<Vec<ExecutableQuote>, ExecutionClientError>;
 
     /// Execute a quote from the venue


### PR DESCRIPTION
This PR adds an `excluded_quote_sources` parameter to the `ExecutionVenue::get_quotes` method, and tracks the sources of failing quotes in the `swap_immediate` loop. Now, whenever we fail to execute a quote from a given source, we then skip fetching new quotes from that source on subsequent retries, unless the swap size is decreased.

### Testing
- [x] Ran local funds manager, invoked Lifi swap, asserted that failing TXs led to exchange exclusion and that subsequent Lifi quotes indeed excluded those exchanges