### PR TITLE
funds_manager: fee_indexer: Base fee indexing + redemption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 name = "funds-manager"
 version = "0.1.0"
 dependencies = [
+ "abi",
  "alloy",
  "alloy-dyn-abi",
  "alloy-json-rpc",

--- a/funds-manager/funds-manager-server/Cargo.toml
+++ b/funds-manager/funds-manager-server/Cargo.toml
@@ -52,6 +52,7 @@ renegade-circuits = { package = "circuits", workspace = true }
 renegade-circuit-types = { package = "circuit-types", workspace = true }
 renegade-crypto = { workspace = true }
 renegade-util = { package = "util", workspace = true }
+renegade-solidity-abi = { workspace = true }
 
 # === Misc Dependencies === #
 async-trait = "0.1"


### PR DESCRIPTION
This PR fixes fee indexing & redemption on Base. We previously were only parsing notes according to the Arbitrum fee settlement ABI, despite listening for the appropriate `NotePosted` event on both chains. We also ensure the inclusion of redemption TXs in full Base blocks.

### Testing
- [x] Fee indexing on local Base funds manager
- [x] Fee redemption on local Base funds manager