### PR TITLE
solver: build tx before awaiting send

### DIFF
--- a/renegade-solver/src/cli.rs
+++ b/renegade-solver/src/cli.rs
@@ -1,6 +1,8 @@
 //! The CLI for the renegade solver
 
+use alloy_primitives::ChainId;
 use clap::Parser;
+
 use renegade_common::types::chain::Chain;
 use renegade_util::telemetry::{configure_telemetry_with_metrics_config, metrics::MetricsConfig};
 
@@ -80,5 +82,14 @@ impl Cli {
             Some(metrics_config),
         )
         .expect("Failed to configure telemetry");
+    }
+}
+
+/// Map a Chain enum to its numeric chain ID
+pub fn chain_to_chain_id(c: &Chain) -> ChainId {
+    match c {
+        Chain::ArbitrumOne => 42161u64, // Arbitrum One Mainnet
+        Chain::BaseMainnet => 8453u64,  // Base Mainnet
+        _ => panic!("Unsupported chain: only ArbitrumOne and BaseMainnet are allowed"),
     }
 }

--- a/renegade-solver/src/error.rs
+++ b/renegade-solver/src/error.rs
@@ -49,6 +49,9 @@ pub enum SolverError {
     /// TxStore error
     #[error("TxStore error: {0}")]
     TxStore(#[from] TxStoreError),
+    /// Custom error
+    #[error("Custom error: {0}")]
+    Custom(String),
 }
 
 impl SolverError {

--- a/renegade-solver/src/fee_cache/fees.rs
+++ b/renegade-solver/src/fee_cache/fees.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 struct FeeCacheInner {
     /// The base fee per gas.
     base_fee_per_gas: AtomicU64,
+    /// The pending nonce for the signer address.
+    pending_nonce: AtomicU64,
 }
 
 #[derive(Clone)]
@@ -15,7 +17,10 @@ pub struct FeeCache(Arc<FeeCacheInner>);
 impl FeeCache {
     /// Create a new cache
     pub fn new() -> Self {
-        Self(Arc::new(FeeCacheInner { base_fee_per_gas: AtomicU64::default() }))
+        Self(Arc::new(FeeCacheInner {
+            base_fee_per_gas: AtomicU64::default(),
+            pending_nonce: AtomicU64::default(),
+        }))
     }
 
     /// Sets the base fee per gas.
@@ -26,6 +31,19 @@ impl FeeCache {
     /// Gets the base fee per gas.
     pub fn base_fee_per_gas(&self) -> Option<u64> {
         match self.0.base_fee_per_gas.load(Ordering::Relaxed) {
+            0 => None,
+            v => Some(v),
+        }
+    }
+
+    /// Sets the pending nonce for the signer address.
+    pub fn set_pending_nonce(&self, nonce: u64) {
+        self.0.pending_nonce.store(nonce, Ordering::Relaxed);
+    }
+
+    /// Gets the pending nonce for the signer address.
+    pub fn pending_nonce(&self) -> Option<u64> {
+        match self.0.pending_nonce.load(Ordering::Relaxed) {
             0 => None,
             v => Some(v),
         }

--- a/renegade-solver/src/fee_cache/worker.rs
+++ b/renegade-solver/src/fee_cache/worker.rs
@@ -1,10 +1,15 @@
 //! Defines a worker that listens for blocks and updates the fee cache.
 
-use alloy::providers::{DynProvider, Provider};
+use alloy::{
+    providers::{DynProvider, Provider},
+    signers::local::PrivateKeySigner,
+};
+use alloy_primitives::Address;
 use futures_util::StreamExt;
+use std::str::FromStr;
 use tracing::{error, info, warn};
 
-use crate::fee_cache::fees::FeeCache;
+use crate::{cli::Cli, fee_cache::fees::FeeCache};
 
 /// The worker that listens for blocks and updates the fee cache.
 pub struct FeeCacheWorker {
@@ -12,23 +17,29 @@ pub struct FeeCacheWorker {
     provider: DynProvider,
     /// The fee cache to update.
     fee_cache: FeeCache,
+    /// Signer address whose pending nonce is tracked
+    signer_address: Address,
 }
 
 impl FeeCacheWorker {
     /// Creates a new `FeeCacheWorker` with the given provider and fee cache.
-    pub fn new(provider: DynProvider, fee_cache: FeeCache) -> Self {
-        Self { provider, fee_cache }
+    pub fn new(provider: DynProvider, fee_cache: FeeCache, cli: &Cli) -> Self {
+        let private_key =
+            PrivateKeySigner::from_str(&cli.private_key).expect("Failed to parse private key");
+        let signer_address = private_key.address();
+        Self { provider, fee_cache, signer_address }
     }
 
     /// Starts the worker.
     pub fn start(&self) {
         let provider = self.provider.clone();
         let fee_cache = self.fee_cache.clone();
-        tokio::spawn(Self::watch_blocks(provider, fee_cache));
+        let signer = self.signer_address;
+        tokio::spawn(Self::watch_blocks(provider, fee_cache, signer));
     }
 
     /// Watch for blocks and update the fee cache via a websocket stream.
-    async fn watch_blocks(provider: DynProvider, fee_cache: FeeCache) {
+    async fn watch_blocks(provider: DynProvider, fee_cache: FeeCache, signer: Address) {
         match provider.subscribe_blocks().await {
             Ok(subscription) => {
                 info!("listening for blocks via websocket");
@@ -36,6 +47,11 @@ impl FeeCacheWorker {
                 while let Some(header) = stream.next().await {
                     if let Some(base) = header.base_fee_per_gas {
                         fee_cache.set_base_fee_per_gas(base);
+                    }
+                    // Update pending nonce on each block tick
+                    match provider.get_transaction_count(signer).await {
+                        Ok(nonce) => fee_cache.set_pending_nonce(nonce),
+                        Err(e) => warn!("failed to refresh pending nonce: {}", e),
                     }
                 }
                 warn!("block stream ended");

--- a/renegade-solver/src/tx_driver/driver.rs
+++ b/renegade-solver/src/tx_driver/driver.rs
@@ -1,8 +1,9 @@
 //! Defines the transaction driver which is responsible for scheduling
 //! transactions to be submitted on-chain.
 
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
-use tokio::time::{sleep_until, Instant};
+use alloy_primitives::{Bytes, TxHash};
+use eyre::Result;
+use tokio::time::{sleep_until, Duration, Instant};
 
 use crate::flashblocks::{Flashblock, FlashblocksReceiver};
 use crate::tx_store::store::{L2Position, TxStore};
@@ -11,80 +12,61 @@ use crate::uniswapx::executor_client::ExecutorClient;
 /// The driver for the transaction scheduler.
 #[derive(Clone)]
 pub struct TxDriver {
-    /// The sender for the transaction scheduler.
-    scheduler: UnboundedSender<(String, Instant)>,
     /// The transaction store
     tx_store: TxStore,
+    /// Executor client used for sending transactions
+    executor_client: ExecutorClient,
 }
 
 impl TxDriver {
     /// Creates a new `TxDriver` with the given transaction store and executor
     /// client.
     pub fn new(tx_store: TxStore, executor: &ExecutorClient) -> Self {
-        let (tx, rx) = unbounded_channel();
-        let tx_store_clone = tx_store.clone();
-        let executor_client_clone = executor.clone();
-
-        tokio::spawn(Self::run_scheduler(rx, tx_store_clone, executor_client_clone));
-
-        Self { tx_store, scheduler: tx }
+        Self { tx_store, executor_client: executor.clone() }
     }
 
-    /// Background task: drains scheduled items and submits transactions at
-    /// their target times.
-    async fn run_scheduler(
-        mut rx: UnboundedReceiver<(String, Instant)>,
-        tx_store: TxStore,
+    /// Send a pre-computed transaction at the specified time
+    async fn send_tx(
+        id: String,
+        send_at: Instant,
+        raw_tx_bytes: Bytes,
+        tx_hash: TxHash,
         executor_client: ExecutorClient,
-    ) {
-        while let Some((tx_id, at)) = rx.recv().await {
-            let tx_store_clone = tx_store.clone();
-            let executor_client_clone = executor_client.clone();
-            tokio::spawn(Self::handle_scheduled_tx(
-                tx_id,
-                at,
-                tx_store_clone,
-                executor_client_clone,
-            ));
-        }
-    }
+    ) -> Result<()> {
+        // Wait until the send time
+        sleep_until(send_at).await;
 
-    /// Handles a single scheduled transaction: waits until the target time and
-    /// submits it.
-    async fn handle_scheduled_tx(
-        tx_id: String,
-        at: Instant,
-        tx_store: TxStore,
-        executor_client: ExecutorClient,
-    ) {
-        sleep_until(at).await;
+        // Send the pre-signed transaction
+        executor_client.send_raw(raw_tx_bytes).await?;
 
-        match tx_store.resolve_fee_caps(&tx_id) {
-            Ok(tx) => {
-                tracing::info!(id = %tx_id, "taking the shot");
-                match executor_client.send_tx(tx).await {
-                    Ok(tx_hash) => {
-                        tx_store.record_tx_hash(&tx_id, tx_hash);
-                        tracing::info!(id = %tx_id, tx_hash = %tx_hash, "shot out");
-                    },
-                    Err(err) => {
-                        tracing::warn!(id = %tx_id, err = %err, "error sending tx");
-                    },
-                }
-            },
-            Err(err) => {
-                tracing::warn!(id = %tx_id, err = %err, "failed to hydrate and send tx");
-            },
-        }
+        tracing::info!(message = "shot out", id = %id, tx_hash = %tx_hash);
+        Ok(())
     }
 }
 
 impl FlashblocksReceiver for TxDriver {
     fn on_flashblock_received(&self, fb: Flashblock) {
         let position = L2Position { l2_block: fb.metadata.block_number, flashblock: fb.index };
-        let ready_txns = self.tx_store.due_at(&position, fb.received_at);
-        for (id, send_at) in ready_txns {
-            let _ = self.scheduler.send((id, send_at.into()));
+        let ready_txns = self.tx_store.due_at(&position);
+
+        for (id, buffer_ms, raw_tx_bytes, tx_hash) in ready_txns {
+            let executor_client = self.executor_client.clone();
+            let buffer_duration = Duration::from_millis(buffer_ms);
+            let send_at = fb.received_at.checked_add(buffer_duration).unwrap();
+
+            tokio::spawn(async move {
+                if let Err(err) = Self::send_tx(
+                    id.clone(),
+                    send_at.into(),
+                    raw_tx_bytes,
+                    tx_hash,
+                    executor_client,
+                )
+                .await
+                {
+                    tracing::warn!(message = "send_tx failed", id = %id, err = %err);
+                }
+            });
         }
     }
 }

--- a/renegade-solver/src/tx_store/store.rs
+++ b/renegade-solver/src/tx_store/store.rs
@@ -1,18 +1,15 @@
 //! Triggered transaction store for L2 transactions.
 //!
-//! Tracks queued transactions keyed by ID, the L2 trigger at which they should
-//! be sent, and their inclusion status. Resolves fee caps on demand using a
-//! `FeeCache`. Hash-based queries are performed by linear scan (no index).
+//! Tracks queued pre-computed transactions keyed by ID, the L2 trigger at which
+//! they should be sent, and their inclusion status. All expensive operations
+//! (hydration, signing) are performed at insertion time.
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
 
-use alloy::rpc::types::TransactionRequest;
-use alloy_primitives::{TxHash, B256};
+use alloy_primitives::{Bytes, TxHash};
 
-use crate::fee_cache::FeeCache;
-use crate::tx_store::error::{TxStoreError, TxStoreResult};
+use crate::tx_store::error::TxStoreResult;
 use dashmap::DashMap;
 
 /// Alias for the order hash type.
@@ -28,14 +25,17 @@ pub struct L2Position {
 }
 
 impl L2Position {
-    /// Given an estimated flashblocks per block, return the L2 position after
-    /// subtracting the given number of flashblocks, respecting the block
-    /// boundaries.
-    pub fn sub_flashblocks(&self, flashblocks: u64, flashblocks_per_block: u64) -> Self {
-        let idx = self.l2_block * flashblocks_per_block + self.flashblock;
-        let idx = idx.saturating_sub(flashblocks);
-        let l2_block = idx / flashblocks_per_block;
-        let flashblock = idx % flashblocks_per_block;
+    /// Returns the linearized flashblock index for this position given the
+    /// flashblocks-per-block value.
+    pub fn linear_index(&self, flashblocks_per_block: u64) -> u128 {
+        (self.l2_block as u128) * (flashblocks_per_block as u128) + (self.flashblock as u128)
+    }
+
+    /// Constructs an `L2Position` from a linearized flashblock index.
+    pub fn from_linear_index(idx: u128, flashblocks_per_block: u64) -> Self {
+        let fpb = flashblocks_per_block.max(1) as u128;
+        let l2_block = (idx / fpb) as u64;
+        let flashblock = (idx % fpb) as u64;
         Self { l2_block, flashblock }
     }
 }
@@ -61,72 +61,78 @@ impl TxTiming {
 #[derive(Clone, Debug, Default)]
 pub struct TxStatus {
     /// The hash of the broadcast transaction (if known).
-    pub tx_hash: Option<B256>,
+    pub tx_hash: TxHash,
     /// The observed inclusion position (if seen).
     pub observed_position: Option<L2Position>,
 }
 
-/// A queued transaction with trigger timing and mutable status.
+/// A pre-computed transaction ready for immediate sending.
 #[derive(Clone, Debug)]
 pub struct TxContext {
     /// The ID of the transaction. In practice, this is the order hash of the
     /// UniswapX order.
     pub id: OrderHash,
-    /// The template request for the transaction (no nonce/max_fee_per_gas set).
-    pub request: TransactionRequest,
+    /// The pre-signed raw transaction bytes.
+    pub raw_tx_bytes: Bytes,
+    /// The target position for which we aim the inclusion.
+    pub target: L2Position,
     /// The timing information for when to send.
     pub timing: TxTiming,
     /// The evolving status of this transaction.
     pub status: TxStatus,
 }
 
-/// A thread-safe store for transactions that are sent on specific L2 triggers.
+/// A thread-safe store for pre-computed transactions.
 #[derive(Clone)]
 pub struct TxStore {
-    /// The inner store.
+    /// The inner store of pre-computed transactions.
     by_id: Arc<DashMap<OrderHash, TxContext>>,
-    /// Fee source to compute max_fee_per_gas at send time.
-    fee_cache: FeeCache,
 }
 
 impl TxStore {
-    /// Creates a new `TxStore` with the given fee cache.
-    pub fn new(fee_cache: FeeCache) -> Self {
-        Self { by_id: Arc::new(DashMap::new()), fee_cache }
+    /// Creates a new `TxStore`.
+    pub fn new() -> Self {
+        Self { by_id: Arc::new(DashMap::new()) }
     }
 
     // --------------
     // | Public API |
     // --------------
 
-    /// Enqueues a transaction with the given timing.
-    pub fn enqueue_with_timing(
+    /// Enqueues a pre-computed transaction.
+    pub fn enqueue(
         &self,
         id: &OrderHash,
-        request: TransactionRequest,
+        raw_tx_bytes: Bytes,
+        tx_hash: TxHash,
+        target: L2Position,
         timing: TxTiming,
-    ) -> TxStoreResult<()> {
-        let tx = TxContext { id: id.to_string(), request, timing, status: TxStatus::default() };
+    ) {
+        let tx = TxContext {
+            id: id.to_string(),
+            raw_tx_bytes,
+            target,
+            timing,
+            status: TxStatus { tx_hash, observed_position: None },
+        };
         self.by_id.insert(tx.id.clone(), tx);
-        Ok(())
     }
 
     /// Returns the transactions that are due to send at the specified trigger
-    /// position, along with the time each should be sent (after buffering).
-    ///
-    /// `received_at` is the timestamp when the trigger position was observed
-    /// locally; it is used as the base to apply the per-transaction buffer.
-    pub fn due_at(&self, at: &L2Position, received_at: Instant) -> Vec<(String, Instant)> {
+    /// position, including payloads needed for sending.
+    pub fn due_at(&self, at: &L2Position) -> Vec<(OrderHash, u64, Bytes, TxHash)> {
         self.by_id
             .iter()
             .filter_map(|entry| {
                 let id = entry.key();
                 let tx = entry.value();
                 if tx.timing.triggers_at(at) {
-                    let at = received_at
-                        .checked_add(std::time::Duration::from_millis(tx.timing.buffer_ms))
-                        .unwrap_or(received_at);
-                    Some((id.clone(), at))
+                    Some((
+                        id.clone(),
+                        tx.timing.buffer_ms,
+                        tx.raw_tx_bytes.clone(),
+                        tx.status.tx_hash,
+                    ))
                 } else {
                     None
                 }
@@ -134,54 +140,22 @@ impl TxStore {
             .collect()
     }
 
-    /// Resolves the transaction template into a concrete request with fee caps.
-    pub fn resolve_fee_caps(&self, id: &OrderHash) -> TxStoreResult<TransactionRequest> {
-        let tx_ref =
-            self.by_id.get(id).ok_or_else(|| TxStoreError::TxNotFound { id: id.to_string() })?;
-
-        // Read latest base fee from cache.
-        let base = self.fee_cache.base_fee_per_gas().ok_or_else(|| {
-            TxStoreError::TxRequestInvalid("base_fee_per_gas unavailable".to_string())
-        })? as u128;
-
-        let tip = tx_ref.request.max_priority_fee_per_gas.ok_or_else(|| {
-            TxStoreError::TxRequestInvalid("max_priority_fee_per_gas must be set".to_string())
-        })?;
-
-        // Add 20% buffer to the base fee.
-        let buffed_base_fee = base.saturating_mul(12) / 10;
-        let max_fee = buffed_base_fee.saturating_add(tip);
-
-        let mut out = tx_ref.request.clone();
-        out.max_fee_per_gas = Some(max_fee);
-
-        Ok(out)
-    }
-
-    /// Attaches or updates the transaction hash for a queued transaction.
-    pub fn record_tx_hash(&self, id: &OrderHash, tx_hash: B256) {
-        if let Some(mut tx) = self.by_id.get_mut(id) {
-            tx.status.tx_hash = Some(tx_hash);
-        }
-    }
-
-    /// Marks transactions as observed included at the given position if their
-    /// hashes match the provided set.
+    /// Records observed inclusions and returns context tuples for valid
+    /// entries.
     ///
-    /// Returns the `(id, hash)` pairs that matched.
-    pub fn record_inclusions(
+    /// For each transaction whose hash is present in `tx_hashes`, sets
+    /// `observed_position` and returns the (id, target, observed) tuple.
+    pub fn observe_inclusions(
         &self,
-        position: &L2Position,
-        tx_hashes: &HashSet<B256>,
-    ) -> Vec<(String, TxHash)> {
-        let mut out: Vec<(String, B256)> = Vec::new();
+        observed: &L2Position,
+        hashes: &HashSet<TxHash>,
+    ) -> Vec<(String, L2Position, L2Position)> {
+        let mut out: Vec<(String, L2Position, L2Position)> = Vec::new();
         for mut entry in self.by_id.iter_mut() {
             let id = entry.key().clone();
-            if let Some(h) = entry.status.tx_hash {
-                if tx_hashes.contains(&h) {
-                    entry.status.observed_position = Some(*position);
-                    out.push((id, h));
-                }
+            if hashes.contains(&entry.status.tx_hash) {
+                entry.status.observed_position = Some(*observed);
+                out.push((id, entry.target, *observed));
             }
         }
         out

--- a/renegade-solver/src/uniswapx/executor_client/errors.rs
+++ b/renegade-solver/src/uniswapx/executor_client/errors.rs
@@ -1,6 +1,7 @@
 //! Possible errors thrown by the executor client
 
 use alloy::providers::PendingTransactionError;
+use alloy::signers::Error as SignerError;
 use alloy_contract::Error as ContractError;
 use alloy_primitives::U256;
 use alloy_sol_types::Error as SolTypeError;
@@ -37,6 +38,9 @@ pub enum ExecutorError {
     #[error("RPC error: {0}")]
     /// An error interacting with the lower level rpc client
     Rpc(String),
+    #[error("Signer error: {0}")]
+    /// An error interacting with the signer
+    Signer(SignerError),
 }
 
 impl ExecutorError {
@@ -73,5 +77,11 @@ impl From<SolTypeError> for ExecutorError {
 impl From<U256> for ExecutorError {
     fn from(u: U256) -> Self {
         ExecutorError::InvalidU256(u)
+    }
+}
+
+impl From<SignerError> for ExecutorError {
+    fn from(e: SignerError) -> Self {
+        Self::Signer(e)
     }
 }

--- a/renegade-solver/src/uniswapx/mod.rs
+++ b/renegade-solver/src/uniswapx/mod.rs
@@ -3,8 +3,8 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use crate::{
-    cli::Cli, error::SolverResult, tx_store::store::TxStore,
-    uniswapx::uniswap_api::types::OrderEntity,
+    cli::Cli, error::SolverResult, fee_cache::fees::FeeCache, planner::TxPlanner,
+    tx_store::store::TxStore, uniswapx::uniswap_api::types::OrderEntity,
 };
 use alloy::primitives::Address;
 use bimap::BiMap;
@@ -85,6 +85,10 @@ pub struct UniswapXSolver {
     order_cache: OrderCache,
     /// The TxStore for storing solutions
     tx_store: TxStore,
+    /// The TxPlanner for planning transactions
+    planner: TxPlanner,
+    /// The fee cache for getting current base fee and nonce
+    fee_cache: FeeCache,
 }
 
 impl UniswapXSolver {
@@ -97,6 +101,8 @@ impl UniswapXSolver {
         cli: Cli,
         executor_client: ExecutorClient,
         tx_store: TxStore,
+        planner: TxPlanner,
+        fee_cache: FeeCache,
     ) -> SolverResult<Self> {
         let Cli { uniswapx_url: base_url, renegade_api_key, renegade_api_secret, .. } = cli;
 
@@ -113,6 +119,8 @@ impl UniswapXSolver {
             supported_tokens,
             order_cache: new_order_cache(),
             tx_store,
+            planner,
+            fee_cache,
         })
     }
 

--- a/renegade-solver/src/uniswapx/solve.rs
+++ b/renegade-solver/src/uniswapx/solve.rs
@@ -71,8 +71,8 @@ impl UniswapXSolver {
 
         // Add baseline priority fee
         let priority_fee_wei = priority_fee_wei.saturating_add(order.baselinePriorityFeeWei);
-        // Hydrate the transaction request with the latest base fee and nonce
-        self.hydrate_tx_request(&mut tx, priority_fee_wei)?;
+        // Set the transaction's latest base fee and nonce
+        self.set_tx_fee(&mut tx, priority_fee_wei)?;
 
         // Sign the transaction and get hash
         let (raw_tx_bytes, tx_hash) = self.executor_client.sign_transaction(tx)?;
@@ -99,13 +99,9 @@ impl UniswapXSolver {
         Ok(())
     }
 
-    /// Hydrate a transaction request with the latest base fee and nonce from
+    /// Set the transaction's latest base fee and nonce from the cache
     /// the cache
-    fn hydrate_tx_request(
-        &self,
-        tx: &mut TransactionRequest,
-        priority_fee_wei: U256,
-    ) -> SolverResult<()> {
+    fn set_tx_fee(&self, tx: &mut TransactionRequest, priority_fee_wei: U256) -> SolverResult<()> {
         let base_fee = self
             .fee_cache
             .base_fee_per_gas()


### PR DESCRIPTION
### Purpose
This PR modifies the solver to store a ready-to-send tx in the TxStore, such that when the time to submit a tx arrives there is no work to be done except submission. The benefits of this are two-fold:
- hot path of tx submission is optimized
- we know the tx hash before submission ensuring we record confirmation. Previously, there was a race between the sequencer and the flashblocks listener as sometimes the sequencer would be slow to respond with the tx hash, resulting in inclusion in a flashblock being missed.