### PR TITLE
solver: add arrival control module

### DIFF
--- a/renegade-solver/src/arrival_control/controller.rs
+++ b/renegade-solver/src/arrival_control/controller.rs
@@ -45,19 +45,19 @@ impl ArrivalController {
     }
 
     /// Update the delay estimate with a new observation.
-    pub fn on_feedback(&self, _target_ms: u64, send_ms: u64, ack_ms: u64) {
+    pub fn on_feedback(&self, _target_ms: u64, send_ms: u64, actual_ms: u64) {
         // Update the delay EMA with the observed delay
-        self.update_delay_estimate(send_ms, ack_ms);
+        self.update_delay_estimate(send_ms, actual_ms);
     }
 
     /// Updates the delay estimate with a new observation.
     /// We approximate the one-way delay as the time between sending and
     /// observing the packet arrival.
-    fn update_delay_estimate(&self, send_ms: u64, ack_ms: u64) {
+    fn update_delay_estimate(&self, send_ms: u64, actual_ms: u64) {
         let ema = self.delay_ema.lock().expect("EMA lock poisoned");
         info!("old delay estimate: {}ms", ema.last());
 
-        let observed_one_way_delay_ms = ack_ms.saturating_sub(send_ms) as f64;
+        let observed_one_way_delay_ms = actual_ms.saturating_sub(send_ms) as f64;
         info!("observed delay: {}ms", observed_one_way_delay_ms);
 
         let new_delay_estimate_ms = ema.update(observed_one_way_delay_ms).max(0.0);

--- a/renegade-solver/src/arrival_control/ema.rs
+++ b/renegade-solver/src/arrival_control/ema.rs
@@ -15,7 +15,6 @@ pub struct Ema {
 
 impl Ema {
     /// Construct an EMA with a given smoothing factor α and initial seed value.
-    #[inline]
     pub fn with_alpha(alpha: f64, seed: f64) -> Self {
         assert!(alpha > 0.0 && alpha <= 1.0, "alpha must be in (0,1]");
         Self { alpha, last: AtomicF64::new(seed) }
@@ -26,7 +25,6 @@ impl Ema {
     ///
     /// This makes the EMA roughly comparable to an N-period SMA,
     /// but smoother and more responsive.
-    #[inline]
     pub fn from_window_length(window_length: u32, seed: f64) -> Self {
         assert!(window_length >= 1, "window_length must be >= 1");
         let alpha = 2.0 / (window_length as f64 + 1.0);
@@ -35,7 +33,6 @@ impl Ema {
 
     /// Update the EMA with a new observation, returning the new EMA value.
     /// Applies EMA_t = α·x + (1−α)·EMA_{t−1}.
-    #[inline]
     pub fn update(&self, x: f64) -> f64 {
         let prev = self.last.load(Ordering::Relaxed);
         let a = self.alpha;
@@ -45,7 +42,6 @@ impl Ema {
     }
 
     /// Returns the current EMA estimate.
-    #[inline]
     pub fn last(&self) -> f64 {
         self.last.load(Ordering::Relaxed)
     }


### PR DESCRIPTION
### Purpose
This PR adds an arrival controller that estimates one-way delay via EMA and computes send time as `target_ts - delay_ms`.