### PR TITLE
solver: estimate flashclock error

### DIFF
--- a/renegade-solver/src/flashblocks/clock/constants.rs
+++ b/renegade-solver/src/flashblocks/clock/constants.rs
@@ -1,10 +1,29 @@
 //! Constants for the FlashblockClock.
 
 /// The frequency of flashblocks according to the [docs](https://docs.base.org/base-chain/network-information/block-building).
-pub const DEFAULT_FLASHBLOCK_MS: u64 = 200;
+pub const DEFAULT_FLASHBLOCK_MS: f64 = 200.0;
 /// The frequency of L2 blocks according to the [docs](https://docs.base.org/base-chain/network-information/block-building).
-pub const DEFAULT_L2_MS: u64 = 2_000;
+pub const DEFAULT_L2_MS: f64 = 2_000.0;
+/// The initial seed value for the websocket drift EMA.
+pub const DEFAULT_FORECAST_ERROR_MS: f64 = 200.0;
 /// EMA window lengths for flashblock durations.
-pub const FLASHBLOCK_WINDOW: usize = 10;
+pub const FLASHBLOCK_WINDOW: u32 = 10;
 /// EMA window lengths for L2 block durations.
-pub const L2_WINDOW: usize = 2;
+pub const L2_WINDOW: u32 = 2;
+/// EMA window lengths for websocket drift.
+pub const FORECAST_ERROR_WINDOW: u32 = 4;
+/// This lead time accounts for the fact that we observe the completion of the
+/// building phase of a flashblock, not the start over the Websocket.
+/// To target a specific flashblock, we must ensure our transaction is in the
+/// builder's mempool snapshot for that flashblock, so we lead by approximately
+/// one flashblock duration.
+pub const BLOCK_BUILDER_DEADLINE_LEAD_TIME_MS: u64 = 200;
+/// This lead time accounts for the following facts:
+/// - flashblock #0 is special in that it does not contain user txns, so we can
+///   be in the mempool without being included in that flashblock.
+/// - if a transaction has a miner tip higher than the minimum miner tip already
+///   in the block, it will not be included in the block. Therefore, we can
+///   arrive sometime during the building phase of (N-1)#10 and still be
+///   included in N#1, where N is the target block number and 1 is the
+///   flashblock number.
+pub const FIRST_FLASHBLOCK_LEAD_TIME_MS: u64 = 300;

--- a/renegade-solver/src/flashblocks/clock/mod.rs
+++ b/renegade-solver/src/flashblocks/clock/mod.rs
@@ -5,8 +5,12 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use alloy_primitives::BlockNumber;
 use renegade_util::get_current_time_millis;
 
+use crate::flashblocks::clock::constants::{
+    BLOCK_BUILDER_DEADLINE_LEAD_TIME_MS, FIRST_FLASHBLOCK_LEAD_TIME_MS,
+};
 use crate::flashblocks::{Flashblock, FlashblocksReceiver};
 
 use self::ema::EmaManager;
@@ -28,6 +32,8 @@ pub struct FlashblockClockSnapshot {
     pub last_flashblock_idx: u64,
     /// The last observed flashblock timestamp in milliseconds.
     pub last_flashblock_ts: u64,
+    /// The current EMA estimate of the websocket forecast error.
+    pub forecast_error_ms: f64,
 }
 
 /// A thread-safe clock that can estimate the time at which we will observe a
@@ -68,43 +74,82 @@ impl FlashblockClock {
         Self(Arc::new(FlashblockClockInner::new()))
     }
 
-    /// Returns the estimated target timestamp in milliseconds for the given
-    /// target flashblock and L2 block.
-    pub fn target_timestamp_ms(&self, target_flashblock: u64, target_l2: u64) -> u64 {
+    /// Given a flashblock and block number we use
+    /// - the last observed L2 block
+    /// - the average flash(block) durations
+    ///
+    /// to predict the timestamp at which we will observe the flashblock over
+    /// the Websocket.
+    ///
+    /// Returns the estimated target timestamp in milliseconds since the Unix
+    /// epoch.
+    pub fn predict_flashblock_ts(&self, flashblock: u64, block: BlockNumber) -> Option<u64> {
         let FlashblockClockSnapshot {
             flashblock_duration_ms,
             l2_block_duration_ms,
             last_l2_idx,
             last_l2_ts,
-            last_flashblock_idx,
-            last_flashblock_ts,
+            ..
         } = self.snapshot();
 
-        // If we're in the same L2 block as the last observed flashblock, use the last
-        // flashblock timestamp.
-        if target_l2 == last_l2_idx && last_flashblock_ts != 0 {
-            let delta_flashblock = target_flashblock.saturating_sub(last_flashblock_idx);
-            return last_flashblock_ts + delta_flashblock.saturating_mul(flashblock_duration_ms);
+        // If we don't have any observations, return 0.
+        if last_l2_ts == 0 {
+            return None;
         }
 
-        // If we're in a different L2 block, use the last observed L2 block timestamp.
-        if last_l2_ts != 0 {
-            let delta_l2 = target_l2.saturating_sub(last_l2_idx);
-            return last_l2_ts
-                + delta_l2.saturating_mul(l2_block_duration_ms)
-                + target_flashblock.saturating_mul(flashblock_duration_ms);
-        }
+        // Always use the last observed L2 block as our anchor point
+        let l2_blocks_delta = block.saturating_sub(last_l2_idx);
+        let l2_block_offset = last_l2_ts + l2_blocks_delta.saturating_mul(l2_block_duration_ms);
 
-        // If we don't have any estimates, use the current time.
-        let now = get_current_time_millis();
-        now + target_l2.saturating_mul(l2_block_duration_ms)
-            + target_flashblock.saturating_mul(flashblock_duration_ms)
+        // Add the flashblock offset
+        let flashblock_offset = flashblock.saturating_mul(flashblock_duration_ms);
+
+        Some(l2_block_offset + flashblock_offset)
+    }
+
+    /// Given a flashblock and block number we use
+    /// - the average flash(block) durations
+    /// - the learned forecast error
+    /// - the builder deadline lead time
+    /// - the first flashblock lead time
+    ///
+    /// to predict the timestamp at which a transaction should arrive in the
+    /// block builder's inbox.
+    ///
+    /// Returns this timestamp in milliseconds since the Unix epoch.
+    pub fn predict_adjusted_flashblock_ts(
+        &self,
+        flashblock: u64,
+        block: BlockNumber,
+    ) -> Option<u64> {
+        if let Some(predicted_ts) = self.predict_flashblock_ts(flashblock, block) {
+            let forecast_error_ms = self.forecast_error_ms();
+            let adjusted_ts = predicted_ts
+                .saturating_sub(forecast_error_ms.abs() as u64)
+                .saturating_sub(BLOCK_BUILDER_DEADLINE_LEAD_TIME_MS)
+                .saturating_sub(FIRST_FLASHBLOCK_LEAD_TIME_MS);
+
+            Some(adjusted_ts)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the current EMA estimate of the websocket forecast error.
+    ///
+    /// Websocket forecast error is the difference between the actual timestamp
+    /// and the predicted timestamp.
+    fn forecast_error_ms(&self) -> f64 {
+        self.0.ema.forecast_error_ms()
     }
 
     /// Update the state from the observation of a flashblock and L2 block.
     pub fn update_from_observation(&self, current_fb_idx: u64, current_l2_idx: u64, now: u64) {
+        // Update the last observed flashblock index and timestamp
         self.0.last_flashblock_idx.store(current_fb_idx, Ordering::Relaxed);
         self.0.last_flashblock_ts.store(now, Ordering::Relaxed);
+
+        // Update the last observed L2 block index and timestamp
         let last_l2_idx = self.0.last_l2_idx.load(Ordering::Relaxed);
         if current_l2_idx != last_l2_idx {
             self.0.last_l2_idx.store(current_l2_idx, Ordering::Relaxed);
@@ -123,6 +168,7 @@ impl FlashblockClock {
             last_l2_ts: inner.last_l2_ts.load(Ordering::Relaxed),
             last_flashblock_idx: inner.last_flashblock_idx.load(Ordering::Relaxed),
             last_flashblock_ts: inner.last_flashblock_ts.load(Ordering::Relaxed),
+            forecast_error_ms: ema.forecast_error_ms(),
         }
     }
 }
@@ -159,7 +205,17 @@ impl FlashblocksReceiver for FlashblockClock {
             ema.update_l2_estimate(l2_sample);
         }
 
+        if let Some(predicted_ts) = self.predict_flashblock_ts(current_fb_idx, current_l2_idx) {
+            ema.update_forecast_error_estimate(now_ms as f64, predicted_ts as f64);
+        }
+
         // Update the state of the flashblock clock.
         self.update_from_observation(current_fb_idx, current_l2_idx, now_ms);
+    }
+}
+
+impl Default for FlashblockClock {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
### Purpose
This PR introduces the notion of forecasting error that is present in the system. The timestamp that we wish our transactions to arrive in the block builder's inbox is in the future, so we use average flashblock and block durations to predict when that might be. This is inherently prone to error as past block durations are not exactly representative of future block durations; therefore we "learn" from this error and use it to inform our predictions.

From running this locally, our predictions are usually late by ~180ms, which probably warrants further investigation.