### PR TITLE
solver: wire up submission latency, forecast error, builder lead time

### DIFF
--- a/renegade-solver/src/flashblocks/clock/ema.rs
+++ b/renegade-solver/src/flashblocks/clock/ema.rs
@@ -62,7 +62,8 @@ impl EmaManager {
 
     /// Updates the EMA estimate of the websocket forecast error.
     ///
-    /// The websocket forecast error is the difference between the actual timestamp and the predicted timestamp.
+    /// The websocket forecast error is the difference between the actual
+    /// timestamp and the predicted timestamp.
     pub fn update_forecast_error_estimate(&self, actual_ts: f64, predicted_ts: f64) {
         let sample_ts = actual_ts - predicted_ts;
         self.forecast_error.update(sample_ts);

--- a/renegade-solver/src/flashblocks/listener.rs
+++ b/renegade-solver/src/flashblocks/listener.rs
@@ -5,13 +5,13 @@
 //! This is copied from https://github.com/base/node-reth/blob/main/crates/flashblocks-rpc/src/subscription.rs
 //! to avoid the dependency on `node-reth`.
 
-use std::time::Instant;
 use std::{io::Read, sync::Arc};
 
 use alloy_primitives::map::foldhash::HashMap;
 use alloy_primitives::{Address, U256};
 use alloy_rpc_types_engine::PayloadId;
 use futures_util::StreamExt;
+use renegade_util::get_current_time_millis;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
@@ -45,7 +45,7 @@ pub struct Flashblock {
     pub base: Option<ExecutionPayloadBaseV1>,
     pub diff: ExecutionPayloadFlashblockDeltaV1,
     pub metadata: Metadata,
-    pub received_at: Instant,
+    pub received_at: u64,
 }
 
 /// Simplify actor messages to just handle shutdown.
@@ -173,7 +173,7 @@ fn try_decode_message(bytes: &[u8]) -> eyre::Result<Flashblock> {
         base: payload.base,
         diff: payload.diff,
         metadata,
-        received_at: Instant::now(),
+        received_at: get_current_time_millis(),
     })
 }
 

--- a/renegade-solver/src/main.rs
+++ b/renegade-solver/src/main.rs
@@ -57,14 +57,14 @@ async fn main() {
     chain_state_cache_worker.start();
 
     // Create the TxStore
-    let tx_store = TxStore::new();
+    let tx_store = TxStore::default();
 
     // Create the arrival controller
     let controller = ArrivalController::default();
 
     // Create flashblocks listener and start the subscription
     let flashblock_clock = FlashblockClock::new();
-    let chain_listener = ChainEventsListener::new(tx_store.clone(), controller.clone());
+    let chain_listener = ChainEventsListener::new(tx_store.clone());
 
     let flashblocks_listener = FlashblocksListener::new(
         vec![Box::new(chain_listener), Box::new(flashblock_clock.clone())],
@@ -72,7 +72,7 @@ async fn main() {
     );
     flashblocks_listener.start();
 
-    let tx_driver = TxDriver::new(&executor_client);
+    let tx_driver = TxDriver::new(&controller, &executor_client, &tx_store);
     // Create the UniswapX solver and begin its polling loop
     let uniswapx = UniswapXSolver::new(
         cli.clone(),


### PR DESCRIPTION
### Purpose
This PR wires up the new arrival controller and forecast error estimator so that our `send timestamp` is calculated as the `predicted target timestamp - (forecast error + block builder lead time + first flashblock lead time)`, all the while updating on the correct RTT that is the difference between submission and acknowledgement from the node of a successful submission.