### PR TITLE
funds-manager: custody-client: refill gas wallets even if insufficient funds

### DIFF
--- a/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
+++ b/funds-manager/funds-manager-server/src/custody_client/gas_wallets.rs
@@ -142,15 +142,13 @@ impl CustodyClient {
             total_amount += needs;
         }
 
-        if my_balance < total_amount {
-            return Err(FundsManagerError::custom(
-                "gas wallet does not have enough ETH to cover the refill",
-            ));
-        }
+        // If the gas wallet has insufficient funds, top up each wallet as much as
+        // possible
+        let target =
+            if my_balance < total_amount { my_balance / wallets.len() as f64 } else { fill_to };
 
-        // Refill the balances
         for wallet in wallets.iter() {
-            self.top_up_gas(&wallet.address, fill_to).await?;
+            self.top_up_gas(&wallet.address, target).await?;
         }
         Ok(())
     }


### PR DESCRIPTION
### Purpose
This PR adjusts the behavior when refilling relayer gas wallets. Previously, if the funds manager gas wallet did not have enough funds to fully fund all relayer gas wallets, it would exit early. Now, we take the available amount and divide it amongst all relayer wallets.