### PR TITLE
price-reporter: exchanges: coinbase: Refresh order book from snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7410,6 +7410,7 @@ dependencies = [
  "lazy_static",
  "matchit 0.7.3",
  "ordered-float",
+ "rand 0.8.5",
  "reqwest 0.12.22",
  "serde",
  "serde_json",

--- a/price-reporter/Cargo.toml
+++ b/price-reporter/Cargo.toml
@@ -38,6 +38,7 @@ derivative = "2.2.0"
 itertools = "0.10"
 lazy_static = "1.4"
 ordered-float = "4.0"
+rand = "0.8"
 
 # === Renegade === #
 renegade-api = { package = "external-api", workspace = true }

--- a/price-reporter/src/exchanges/coinbase/order_book.rs
+++ b/price-reporter/src/exchanges/coinbase/order_book.rs
@@ -1,0 +1,132 @@
+//! A local copy of the Coinbase order book
+
+use std::sync::{Arc, RwLock};
+
+use crossbeam_skiplist::SkipSet;
+use ordered_float::NotNan;
+
+use crate::exchanges::{
+    coinbase::types::CoinbaseOrderBookSnapshotResponse, error::ExchangeConnectionError,
+};
+
+// ------------------
+// | Orderbook Data |
+// ------------------
+
+/// A non-nan f64
+type NonNanF64 = NotNan<f64>;
+/// A shared skip set of price levels
+pub type OrderBookLevels = Arc<SkipSet<NonNanF64>>;
+
+/// The order book data stored locally by the connection
+#[derive(Clone, Default)]
+pub struct CoinbaseOrderBookData {
+    /// The bid price levels, sorted in ascending order
+    bids: OrderBookLevels,
+    /// The offer price levels, sorted in ascending order  
+    offers: OrderBookLevels,
+    /// A rehydration lock; used to ensure that no writes occur while the order
+    /// book is being rehydrated
+    ///
+    /// Individual writes need only hold a read lock and concurrent access is
+    /// managed by the concurrent-safe `OrderBookLevels` type. The re-hydrate
+    /// operation alone needs a write lock.
+    rehydration_lock: Arc<RwLock<()>>,
+}
+
+impl CoinbaseOrderBookData {
+    /// Construct a new order book data
+    pub fn new() -> Self {
+        let bids = Arc::new(SkipSet::new());
+        let offers = Arc::new(SkipSet::new());
+        let rehydration_lock = Arc::new(RwLock::new(()));
+        Self { bids, offers, rehydration_lock }
+    }
+
+    // ------------------------
+    // | Midpoint Calculation |
+    // ------------------------
+
+    /// Get the best bid price from the current order book
+    pub fn best_bid(&self) -> Option<f64> {
+        self.bids.back().map(|e| e.value().into_inner())
+    }
+
+    /// Get the best offer price from the current order book
+    pub fn best_offer(&self) -> Option<f64> {
+        self.offers.front().map(|e| e.value().into_inner())
+    }
+
+    /// Get the midpoint price from the current order book
+    pub fn midpoint(&self) -> Option<f64> {
+        let best_bid = self.best_bid()?;
+        let best_offer = self.best_offer()?;
+        Some((best_bid + best_offer) / 2.)
+    }
+
+    // ----------------------
+    // | Order Book Updates |
+    // ----------------------
+
+    /// Remove a bid at the given price level
+    pub fn remove_bid(&self, price_level: f64) {
+        let _guard = self.rehydration_lock.read().unwrap();
+        if let Ok(price_notnan) = NotNan::new(price_level) {
+            self.bids.remove(&price_notnan);
+        }
+    }
+
+    /// Remove an offer at the given price level
+    pub fn remove_offer(&self, price_level: f64) {
+        let _guard = self.rehydration_lock.read().unwrap();
+        if let Ok(price_notnan) = NotNan::new(price_level) {
+            self.offers.remove(&price_notnan);
+        }
+    }
+
+    /// Add a bid at the given price level
+    pub fn add_bid(&self, price_level: f64) {
+        let _guard = self.rehydration_lock.read().unwrap();
+        if let Ok(price_notnan) = NotNan::new(price_level) {
+            self.bids.insert(price_notnan);
+        }
+    }
+
+    /// Add an offer at the given price level
+    pub fn add_offer(&self, price_level: f64) {
+        let _guard = self.rehydration_lock.read().unwrap();
+        if let Ok(price_notnan) = NotNan::new(price_level) {
+            self.offers.insert(price_notnan);
+        }
+    }
+
+    /// Rehydrate the order book from a snapshot
+    ///
+    /// Deletes all existing price level data
+    pub fn rehydrate(
+        &self,
+        snapshot: CoinbaseOrderBookSnapshotResponse,
+    ) -> Result<(), ExchangeConnectionError> {
+        let _guard = self.rehydration_lock.write().unwrap();
+        // Clear existing price level data
+        self.bids.clear();
+        self.offers.clear();
+
+        // Add in the snapshot data
+        for bid in snapshot.bids {
+            let price_level: f64 = bid.0.parse().map_err(ExchangeConnectionError::custom)?;
+            if let Ok(price_notnan) = NotNan::new(price_level) {
+                self.bids.insert(price_notnan);
+            }
+        }
+
+        for offer in snapshot.asks {
+            let price_level: f64 = offer.0.parse().map_err(ExchangeConnectionError::custom)?;
+            if let Ok(price_notnan) = NotNan::new(price_level) {
+                self.offers.insert(price_notnan);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/price-reporter/src/exchanges/coinbase/types.rs
+++ b/price-reporter/src/exchanges/coinbase/types.rs
@@ -1,0 +1,15 @@
+//! API types for the Coinbase connection
+
+use serde::{Deserialize, Serialize};
+
+/// The Coinbase order book snapshot response
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CoinbaseOrderBookSnapshotResponse {
+    /// The bid price levels, sorted in ascending order
+    pub bids: Vec<CoinbaseOrderBookLevel>,
+    /// The offer price levels, sorted in ascending order
+    pub asks: Vec<CoinbaseOrderBookLevel>,
+}
+
+/// A tuple of (price, quantity, num_orders)
+pub type CoinbaseOrderBookLevel = (String, String, u64);

--- a/price-reporter/src/exchanges/error.rs
+++ b/price-reporter/src/exchanges/error.rs
@@ -17,6 +17,9 @@ pub enum ExchangeConnectionError {
     /// A cryptographic error occurred
     #[error("cryptographic error: {0}")]
     Crypto(String),
+    /// A custom error occurred
+    #[error("custom error: {0}")]
+    Custom(String),
     /// An initial websocket subscription to a remote server failed.
     #[error("initial websocket subscription failed: {0}")]
     HandshakeFailure(String),
@@ -47,5 +50,11 @@ impl ExchangeConnectionError {
     /// Create an error indicating that the given exchange is not supported
     pub fn unsupported_exchange(exchange: Exchange) -> Self {
         Self::UnsupportedExchange(exchange)
+    }
+
+    /// Create a custom error
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn custom<T: ToString>(message: T) -> Self {
+        Self::Custom(message.to_string())
     }
 }


### PR DESCRIPTION
### Purpose
This PR refreshes the order book for each Coinbase connection periodically from a snapshot. We randomize the interval at which we refresh to avoid rate limits on the market data API.

### Testing
- [x] Tested locally
- [ ] Testing in testnet