### PR TITLE
price-reporter-client: optionally stream prices, set ws/wss accordingly

### DIFF
--- a/auth/auth-server/src/server/setup.rs
+++ b/auth/auth-server/src/server/setup.rs
@@ -18,7 +18,7 @@ use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::Address;
 use base64::{Engine, engine::general_purpose};
-use price_reporter_client::PriceReporterClient;
+use price_reporter_client::{PriceReporterClient, PriceReporterClientConfig};
 use renegade_common::types::chain::Chain;
 use renegade_common::types::{
     hmac::HmacKey,
@@ -67,10 +67,10 @@ impl Server {
         )
         .await?;
 
-        let price_reporter_client = PriceReporterClient::new(
-            args.price_reporter_url.clone(),
-            true, // exit_on_stale
-        )?;
+        let price_reporter_client = PriceReporterClient::new(PriceReporterClientConfig {
+            base_url: args.price_reporter_url.clone(),
+            ..Default::default()
+        })?;
 
         let gas_sponsor_address = parse_gas_sponsor_address(&args)?;
         let gas_cost_sampler = Arc::new(

--- a/funds-manager/funds-manager-server/src/server.rs
+++ b/funds-manager/funds-manager-server/src/server.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashMap, error::Error, sync::Arc};
 
 use aws_config::{BehaviorVersion, Region};
-use price_reporter_client::PriceReporterClient;
+use price_reporter_client::{PriceReporterClient, PriceReporterClientConfig};
 use renegade_common::types::{chain::Chain, hmac::HmacKey};
 use renegade_config::setup_token_remaps;
 
@@ -58,10 +58,10 @@ impl Server {
             .unwrap()?;
         }
 
-        let price_reporter = PriceReporterClient::new(
-            args.price_reporter_url.clone(),
-            true, // exit_on_stale
-        )?;
+        let price_reporter = PriceReporterClient::new(PriceReporterClientConfig {
+            base_url: args.price_reporter_url.clone(),
+            ..Default::default()
+        })?;
 
         let hmac_key = args.get_hmac_key();
 

--- a/renegade-solver/src/main.rs
+++ b/renegade-solver/src/main.rs
@@ -10,7 +10,7 @@
 use std::net::SocketAddr;
 
 use clap::Parser;
-use price_reporter_client::PriceReporterClient;
+use price_reporter_client::{PriceReporterClient, PriceReporterClientConfig};
 use renegade_config::setup_token_remaps;
 use serde_json::json;
 use tracing::{info, info_span};
@@ -37,10 +37,10 @@ async fn main() {
     let executor_client = ExecutorClient::new(&cli).expect("Failed to create executor client");
 
     // Create the price reporter client
-    let price_reporter_client = PriceReporterClient::new(
-        cli.price_reporter_url.clone(),
-        true, // exit_on_stale
-    )
+    let price_reporter_client = PriceReporterClient::new(PriceReporterClientConfig {
+        base_url: cli.price_reporter_url.clone(),
+        ..Default::default()
+    })
     .expect("Failed to create price reporter client");
 
     // Create the UniswapX solver and begin its polling loop


### PR DESCRIPTION
In this PR, we add a `stream_prices` flag to the `PriceReporterClient` constructor, allowing the client to be constructed w/o initializing the `MultiPriceStream`. Additionally, we set the websocket URL scheme to be `wss` or `ws` depending on if the base URL uses `https` or `http`.

### Testing
- [x] Test streaming-disabled price reporter locally
- [x] Test streaming-enabled, non-`wss` price reporter locally