### PR TITLE
funds-manager: Include gas wallet info in api response

### DIFF
--- a/funds-manager/funds-manager-api/src/types/gas.rs
+++ b/funds-manager/funds-manager-api/src/types/gas.rs
@@ -77,4 +77,17 @@ pub struct ReportActivePeersRequest {
 pub struct GasWalletsResponse {
     /// The list of gas wallet addresses
     pub addresses: Vec<String>,
+    /// The list of gas wallet entries
+    pub entries: Vec<GasWalletEntry>,
+}
+
+/// A gas wallet's entry
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GasWalletEntry {
+    /// The address of the gas wallet
+    pub address: String,
+    /// The status of the gas wallet
+    pub status: String,
+    /// The peer ID of the gas wallet
+    pub peer_id: Option<String>,
 }

--- a/funds-manager/funds-manager-server/src/db/models.rs
+++ b/funds-manager/funds-manager-server/src/db/models.rs
@@ -5,6 +5,7 @@ use std::{fmt::Display, str::FromStr, time::SystemTime};
 
 use bigdecimal::BigDecimal;
 use diesel::prelude::*;
+use funds_manager_api::gas::GasWalletEntry;
 use num_bigint::BigInt;
 use renegade_circuit_types::note::Note;
 use renegade_common::types::chain::Chain;
@@ -184,5 +185,11 @@ impl GasWallet {
         let status = GasWalletStatus::Inactive.to_string();
         let chain = to_env_agnostic_name(chain);
         GasWallet { id, address, peer_id: None, status, created_at: SystemTime::now(), chain }
+    }
+}
+
+impl From<GasWallet> for GasWalletEntry {
+    fn from(wallet: GasWallet) -> Self {
+        GasWalletEntry { address: wallet.address, status: wallet.status, peer_id: wallet.peer_id }
     }
 }

--- a/funds-manager/funds-manager-server/src/handlers/gas.rs
+++ b/funds-manager/funds-manager-server/src/handlers/gas.rs
@@ -172,8 +172,9 @@ pub(crate) async fn get_gas_wallets_handler(
     let custody_client = server.get_custody_client(&chain)?;
     let gas_wallets = custody_client.get_all_gas_wallets().await?;
 
-    let addresses = gas_wallets.into_iter().map(|wallet| wallet.address).collect();
-    let resp = GasWalletsResponse { addresses };
+    let addresses = gas_wallets.iter().map(|wallet| wallet.address.clone()).collect();
+    let entries = gas_wallets.into_iter().map(|wallet| wallet.into()).collect();
+    let resp = GasWalletsResponse { addresses, entries };
 
     Ok(warp::reply::json(&resp))
 }


### PR DESCRIPTION
### Purpose

This PR adds extra information about gas wallets in the `GET /custody/:chain/gas-wallets` endpoint, specifically:

- The current status (`active`, `inactive`, `pending`) of the wallet
- The peer to which the wallet is currently allocated

This will help us view gas wallets in the toolbox.

### Testing

- [x] Test in testnet