### PR TITLE
Removed unused IS_MALLEABLE_TAG

### DIFF
--- a/auth/auth-server/src/telemetry/labels.rs
+++ b/auth/auth-server/src/telemetry/labels.rs
@@ -90,5 +90,3 @@ pub const L2_BASE_FEE_TAG: &str = "l2_base_fee";
 /// Metric tag indicating whether or not the bundle was settled as part of a CoW
 /// Protocol auction
 pub const SETTLED_VIA_COWSWAP_TAG: &str = "settled_via_cowswap";
-/// Metric tag indicating whether or not the bundle was malleable
-pub const IS_MALLEABLE_TAG: &str = "is_malleable";


### PR DESCRIPTION
This fixes the clippy check errors from the Github workflow.